### PR TITLE
chore: guard repository privacy fixtures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # T1 is already required by branch protection. Keep this scan here as
+      # well as in the standalone workflow that covers website-only changes.
+      - name: Scan tracked repository content for private fixtures
+        run: python dev/scripts/repository_privacy_guard.py
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -1,0 +1,35 @@
+name: privacy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: privacy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  repository-privacy:
+    name: Repository privacy guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Test privacy guard
+        run: python -m unittest tests.test_repository_privacy_guard
+
+      - name: Scan tracked repository content
+        run: python dev/scripts/repository_privacy_guard.py

--- a/app/renderer/src/components/speakerReviewOrdering.test.ts
+++ b/app/renderer/src/components/speakerReviewOrdering.test.ts
@@ -47,7 +47,7 @@ describe('orderProfilesForRow identity', () => {
 
 describe('filterProfilesByQuery', () => {
   it('matches anywhere in the name, not just the start', () => {
-    const found = filterProfilesByQuery([p('Zora Quinn'), p('Marie Kutza')], 'quinn');
+    const found = filterProfilesByQuery([p('Zora Quinn'), p('Rowan Example')], 'quinn');
     expect(found.map((x) => x.display_name)).toEqual(['Zora Quinn']);
   });
 

--- a/app/renderer/src/lib/notesCopy.test.ts
+++ b/app/renderer/src/lib/notesCopy.test.ts
@@ -17,8 +17,8 @@ const sections: NotesCopySections = {
     { title: 'Hiring' },
   ],
   keyPoints: ['Ship v2 in July'],
-  actionItems: ['Ben: draft the announcement'],
-  participants: ['Ben', 'Ruzin'],
+  actionItems: ['Casey Example: draft the announcement'],
+  participants: ['Casey Example', 'Morgan Example'],
 };
 
 describe('buildNotesCopyText', () => {
@@ -40,10 +40,10 @@ describe('buildNotesCopyText', () => {
         '- Ship v2 in July',
         '',
         'ACTION ITEMS',
-        '- Ben: draft the announcement',
+        '- Casey Example: draft the announcement',
         '',
         'PARTICIPANTS',
-        'Ben, Ruzin',
+        'Casey Example, Morgan Example',
       ].join('\n'),
     );
   });

--- a/app/renderer/src/lib/notesPdf.test.ts
+++ b/app/renderer/src/lib/notesPdf.test.ts
@@ -17,8 +17,8 @@ const full: NotesPdfInput = {
     { title: 'Hiring' },
   ],
   keyPoints: ['Ship v2 in July'],
-  actionItems: ['Ben: draft the announcement'],
-  participants: ['Ben', 'Ruzin'],
+  actionItems: ['Casey Example: draft the announcement'],
+  participants: ['Casey Example', 'Morgan Example'],
 };
 
 describe('buildNotesHtml', () => {
@@ -37,9 +37,9 @@ describe('buildNotesHtml', () => {
     expect(html).toContain('>Key Points</h2>');
     expect(html).toContain('<li>Ship v2 in July</li>');
     expect(html).toContain('>Action Items</h2>');
-    expect(html).toContain('<li>Ben: draft the announcement</li>');
+    expect(html).toContain('<li>Casey Example: draft the announcement</li>');
     expect(html).toContain('>Participants</h2>');
-    expect(html).toContain('Ben, Ruzin');
+    expect(html).toContain('Casey Example, Morgan Example');
     // Brand chrome: embedded font + logo, footer tagline + site.
     expect(html).toContain('@font-face');
     expect(html).toContain('data:image/svg+xml;base64,');
@@ -148,7 +148,7 @@ describe('buildNotesHtml with an open template report', () => {
     // …and the Standard note's sections are NOT along for the ride.
     expect(html).not.toContain('>Key Topics</h2>');
     expect(html).not.toContain('Ship v2 in July');
-    expect(html).not.toContain('Ben: draft the announcement');
+    expect(html).not.toContain('Casey Example: draft the announcement');
   });
 
   test('keeps the brand chrome, title and meta line', () => {

--- a/app/renderer/src/routes/settings/GeneralTab.test.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.test.tsx
@@ -308,8 +308,8 @@ describe('GeneralTab name-field seed race (#307)', () => {
     const { rerender } = render(<GeneralTab />);
 
     const input = screen.getByTestId('user-name-input') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: 'Ruzin' } });
-    expect(input.value).toBe('Ruzin');
+    fireEvent.change(input, { target: { value: 'Casey Example' } });
+    expect(input.value).toBe('Casey Example');
 
     // The canonical value now arrives from disk.
     h.userName = { data: 'Old Name', isPending: false, isPlaceholderData: false };
@@ -318,7 +318,7 @@ describe('GeneralTab name-field seed race (#307)', () => {
     });
 
     // The user's in-progress edit must survive the late seed.
-    expect((screen.getByTestId('user-name-input') as HTMLInputElement).value).toBe('Ruzin');
+    expect((screen.getByTestId('user-name-input') as HTMLInputElement).value).toBe('Casey Example');
   });
 
   test('the field re-syncs from userName.data after the edit is committed on blur', async () => {
@@ -336,12 +336,12 @@ describe('GeneralTab name-field seed race (#307)', () => {
 
     // The canonical value now arrives from disk. Since the edit was committed
     // (and saved nothing), the field must re-sync to it rather than stay blank.
-    h.userName = { data: 'Ruzin', isPending: false, isPlaceholderData: false };
+    h.userName = { data: 'Casey Example', isPending: false, isPlaceholderData: false };
     await act(async () => {
       rerender(<GeneralTab />);
     });
 
-    expect((screen.getByTestId('user-name-input') as HTMLInputElement).value).toBe('Ruzin');
+    expect((screen.getByTestId('user-name-input') as HTMLInputElement).value).toBe('Casey Example');
   });
 });
 

--- a/app/settings-ipc.test.js
+++ b/app/settings-ipc.test.js
@@ -142,9 +142,9 @@ test('set-microphone inserts the `--` argv delimiter and coalesces null id/label
 
 test('set-user-name coerces nullish names to an empty string and trims the echoed fallback', async () => {
   const named = harness({ pyResult: 'noise' });
-  const r1 = await named.handlers['set-user-name']({}, '  Ben  ');
-  assert.deepStrictEqual(named.calls.py[0].args, ['set-user-name', '  Ben  ']);
-  assert.deepStrictEqual(r1, { success: true, user_name: 'Ben' });
+  const r1 = await named.handlers['set-user-name']({}, '  Casey Example  ');
+  assert.deepStrictEqual(named.calls.py[0].args, ['set-user-name', '  Casey Example  ']);
+  assert.deepStrictEqual(r1, { success: true, user_name: 'Casey Example' });
 
   const nullish = harness({ pyResult: 'noise' });
   const r2 = await nullish.handlers['set-user-name']({}, null);

--- a/dev/scripts/repository_privacy_guard.py
+++ b/dev/scripts/repository_privacy_guard.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Reject known private fixtures and user-data artifacts before they ship."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Iterable, NamedTuple
+import unicodedata
+
+
+class Violation(NamedTuple):
+    path: Path
+    line: int
+    rule: str
+
+
+# SHA-256 fingerprints avoid storing the private values in plaintext. They are
+# identifiers for known values, not encryption or protection against guessing.
+# Candidates are normalized with normalize_candidate() before hashing.
+KNOWN_PRIVATE_FINGERPRINTS = frozenset(
+    {
+        "f581c2b4a491aee6c5c33c25269ef97d2c95e966d009d1ebd0b9642fddaaddd6",
+        "a2f8195ccb3f9ac75ca87e31f1cf4beb7e262e11104ff1172b1310cc40492e85",
+        "f0a846cf3d6368a62379133cc59ee226b3bb67f4267e36cf095d755afee3c09b",
+        "1865a50263d12cb136d9a7232d7d0eb51ec68f91fd9e4c711d3eaf948f772f22",
+        "a3bc853dc02e537734bc949513db6b5d778b4a8b12a41755adaae38e01eb79e8",
+        "4e853a5a42976d41debcb88c5fac405f90f5e9a952c21398bf0466e31b685b21",
+        "a5bd4dc3c27e9db6adabfa8ae120a8ebc404c9e1b8e24a6c14725c8a8fe77565",
+        "2dae4daafe11454b1914913740e7d8300d1e1efa5b496f7cc0f1d9c564f864a3",
+        "62a5894934fec87caf6731e8bacb92b87b9fa179575cc88e63c3a5d231150848",
+    }
+)
+
+# Single names may be legitimate public maintainer attribution. They are only
+# forbidden in tests, fixtures, and internal implementation-plan artifacts.
+KNOWN_PRIVATE_FIXTURE_FINGERPRINTS = frozenset(
+    {
+        "6700869c8ff7480e34a70a708b028700dbaa3a033b5652b903afe89f49a31456",
+        "806c70034ebdfa7840d483758862e01ddcb16fa4507d427bea1964c6c5afe29a",
+        "bfb301b26ca5590c4cd741bea37c36d5b4e5fb92dc4880e8c89448bf82b2b94c",
+        "c6d17a3613b9914e68707fcfac8410f097643bc5840681bb533030d73cbb18f8",
+        "ff38d2567b8123d1144a15ea77d969f1e742a8bdcd7f31c48a7cfdf4c4037663",
+        "006bc948c3e7b00fdcc6eb4b29f4933ab83d239fcf101756f71056258583cd95",
+        "85f5e10431f69bc2a14046a13aabaefc660103b6de7a84f75c4b96181d03f0b5",
+        "443721509b79d08a341b7591ad6d7543807f4a581594895f9e2ff9089cdf72c9",
+        "bf1b4854e41c18b05927d994e4cecabf7b60bd8bd7e9571f8e0662fb7cba6e7b",
+        "946c9356890e2774b75416f4f2c70673cdd9c8d0f05374459bd60e9696fcd146",
+    }
+)
+
+KNOWN_PRIVATE_PATH_FINGERPRINTS = frozenset(
+    {"6700869c8ff7480e34a70a708b028700dbaa3a033b5652b903afe89f49a31456"}
+)
+
+_WORD_RE = re.compile(r"[^\W\d_]+(?:[-'’][^\W\d_]+)*", re.UNICODE)
+_LOCAL_PATH_PATTERNS = (
+    re.compile(r"/Users/([A-Za-z0-9._-]+)", re.IGNORECASE),
+    re.compile(r"/home/([A-Za-z0-9._-]+)", re.IGNORECASE),
+    # Match both a runtime path and the doubled backslashes used in source.
+    re.compile(r"[A-Za-z]:\\+Users\\+([A-Za-z0-9._-]+)", re.IGNORECASE),
+)
+_MEDIA_SUFFIXES = frozenset(
+    {".aac", ".flac", ".m4a", ".mov", ".mp3", ".mp4", ".ogg", ".opus", ".srt", ".vtt", ".wav", ".webm"}
+)
+
+
+def normalize_candidate(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return " ".join(normalized.split())
+
+
+def _fingerprint(value: str) -> str:
+    return hashlib.sha256(normalize_candidate(value).encode("utf-8")).hexdigest()
+
+
+def _candidate_phrases(line: str) -> Iterable[str]:
+    words = [re.sub(r"['’]s$", "", word, flags=re.IGNORECASE) for word in _WORD_RE.findall(line)]
+    variants = (
+        words,
+        [part for word in words for part in re.split(r"[-'’]+", word) if part],
+        [
+            part
+            for word in words
+            for part in re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?![a-z])", word)
+        ],
+    )
+    seen: set[str] = set()
+    for tokens in variants:
+        for width in range(1, min(3, len(tokens)) + 1):
+            for start in range(0, len(tokens) - width + 1):
+                candidate = " ".join(tokens[start : start + width])
+                if candidate not in seen:
+                    seen.add(candidate)
+                    yield candidate
+
+
+def _contains_blocked_user_path(
+    line: str, blocked_path_fingerprints: set[str] | frozenset[str]
+) -> bool:
+    for pattern in _LOCAL_PATH_PATTERNS:
+        for match in pattern.finditer(line):
+            if _fingerprint(match.group(1)) in blocked_path_fingerprints:
+                return True
+    return False
+
+
+def _is_fixture_context(path: Path) -> bool:
+    lowered_parts = {part.casefold() for part in path.parts}
+    name = path.name.casefold()
+    return (
+        bool(lowered_parts.intersection({"tests", "test", "__tests__", "e2e", "fixtures"}))
+        or ".test." in name
+        or ".spec." in name
+        or name.startswith(("test_", "e2e-"))
+        or "_test." in name
+        or name == "conftest.py"
+        or tuple(part.casefold() for part in path.parts[:2]) == ("docs", "superpowers")
+    )
+
+
+def scan_text(
+    path: Path,
+    text: str,
+    *,
+    blocked_fingerprints: set[str] | frozenset[str] = KNOWN_PRIVATE_FINGERPRINTS,
+    fixture_only_fingerprints: set[str] | frozenset[str] = KNOWN_PRIVATE_FIXTURE_FINGERPRINTS,
+    blocked_path_fingerprints: set[str] | frozenset[str] = KNOWN_PRIVATE_PATH_FINGERPRINTS,
+) -> list[Violation]:
+    violations: list[Violation] = []
+    fingerprints = set(blocked_fingerprints)
+    if _is_fixture_context(path):
+        fingerprints.update(fixture_only_fingerprints)
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if _contains_blocked_user_path(line, blocked_path_fingerprints):
+            violations.append(Violation(path, line_number, "local-user-path"))
+
+        if any(_fingerprint(candidate) in fingerprints for candidate in _candidate_phrases(line)):
+            violations.append(Violation(path, line_number, "blocked-value"))
+    return violations
+
+
+def scan_path(
+    path: Path,
+    *,
+    blocked_fingerprints: set[str] | frozenset[str] = KNOWN_PRIVATE_FINGERPRINTS,
+    fixture_only_fingerprints: set[str] | frozenset[str] = KNOWN_PRIVATE_FIXTURE_FINGERPRINTS,
+) -> list[Violation]:
+    violations: list[Violation] = []
+    lowered_parts = {part.casefold() for part in path.parts}
+    if lowered_parts.intersection({"recordings", "transcripts"}):
+        violations.append(Violation(path, 0, "user-data-artifact"))
+    if path.suffix.casefold() in _MEDIA_SUFFIXES:
+        violations.append(Violation(path, 0, "media-artifact"))
+
+    path_matches = scan_text(
+        path,
+        path.as_posix(),
+        blocked_fingerprints=blocked_fingerprints,
+        fixture_only_fingerprints=fixture_only_fingerprints,
+        blocked_path_fingerprints=frozenset(),
+    )
+    if path_matches:
+        violations.append(Violation(path, 0, "blocked-path-value"))
+    return violations
+
+
+def _tracked_paths(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    return [Path(value.decode("utf-8")) for value in result.stdout.split(b"\0") if value]
+
+
+def scan_repository(root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    for relative_path in _tracked_paths(root):
+        path_violations = scan_path(relative_path)
+        violations.extend(path_violations)
+        if any(item.rule in {"user-data-artifact", "media-artifact"} for item in path_violations):
+            continue
+
+        absolute_path = root / relative_path
+        if absolute_path.is_symlink():
+            content = str(absolute_path.readlink()).encode("utf-8")
+        elif not absolute_path.is_file():
+            continue
+        else:
+            content = absolute_path.read_bytes()
+        if b"\0" in content:
+            continue
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        violations.extend(scan_text(relative_path, text))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    violations = scan_repository(root)
+    for violation in violations:
+        location = f"{violation.path}:{violation.line}" if violation.line else str(violation.path)
+        print(f"{location}: repository privacy check failed ({violation.rule})", file=sys.stderr)
+    if violations:
+        print(f"Privacy guard found {len(violations)} violation(s).", file=sys.stderr)
+        return 1
+    print("Repository privacy guard passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/superpowers/plans/2026-08-04-speaker-review-run-provenance.md
+++ b/docs/superpowers/plans/2026-08-04-speaker-review-run-provenance.md
@@ -214,7 +214,7 @@ This slice changes a persisted format and the evidence-mutation path, so it earn
 
 - Run `/codex:review --base origin/feat/speaker-diarization` over the whole branch diff, not per task. The failure mode this slice can produce is silent and cross-file (evidence deleted or wrongly kept), which per-task review does not see.
 - Reconcile every finding: adopt it, or reject it with a stated reason. Never drop one silently.
-- Then stop. Pushing and opening the PR is Ben's call.
+- Then stop. Pushing and opening the PR is the maintainer's call.
 
 ## Self-review notes
 

--- a/tests/test_repository_privacy_guard.py
+++ b/tests/test_repository_privacy_guard.py
@@ -1,0 +1,249 @@
+import hashlib
+import importlib.util
+from pathlib import Path
+import re
+import unittest
+
+
+_SCRIPT = Path(__file__).parents[1] / "dev" / "scripts" / "repository_privacy_guard.py"
+_SPEC = importlib.util.spec_from_file_location("repository_privacy_guard", _SCRIPT)
+if _SPEC is None or _SPEC.loader is None:
+    raise RuntimeError("Unable to load repository privacy guard")
+privacy_guard = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(privacy_guard)
+
+
+class RepositoryPrivacyGuardTests(unittest.TestCase):
+    @staticmethod
+    def fingerprint(value: str) -> str:
+        return hashlib.sha256(
+            privacy_guard.normalize_candidate(value).encode("utf-8")
+        ).hexdigest()
+
+    def test_fingerprint_detects_a_blocked_phrase_without_storing_it_in_the_guard(self):
+        blocked = "Private Fixture"
+        fingerprints = {
+            hashlib.sha256(privacy_guard.normalize_candidate(blocked).encode("utf-8")).hexdigest()
+        }
+
+        violations = privacy_guard.scan_text(
+            Path("example.test.ts"),
+            "const participant = 'Private Fixture';",
+            blocked_fingerprints=fingerprints,
+        )
+
+        self.assertEqual([(item.line, item.rule) for item in violations], [(1, "blocked-value")])
+
+    def test_fingerprint_does_not_reject_unrelated_synthetic_fixtures(self):
+        blocked = "Private Fixture"
+        fingerprints = {
+            hashlib.sha256(privacy_guard.normalize_candidate(blocked).encode("utf-8")).hexdigest()
+        }
+
+        violations = privacy_guard.scan_text(
+            Path("example.test.ts"),
+            "const participant = 'Casey Example';",
+            blocked_fingerprints=fingerprints,
+        )
+
+        self.assertEqual(violations, [])
+
+    def test_known_literal_local_home_directory_is_rejected(self):
+        local_path = "/" + "Users" + "/alice/Dev/project"
+        private_path_fingerprints = {
+            hashlib.sha256(privacy_guard.normalize_candidate("alice").encode("utf-8")).hexdigest()
+        }
+
+        violations = privacy_guard.scan_text(
+            Path("notes.md"),
+            f"Run the tool from {local_path}.",
+            blocked_fingerprints=set(),
+            blocked_path_fingerprints=private_path_fingerprints,
+        )
+
+        self.assertEqual([(item.line, item.rule) for item in violations], [(1, "local-user-path")])
+
+    def test_escaped_windows_home_directory_is_rejected(self):
+        fingerprints = {self.fingerprint("alice")}
+
+        violations = privacy_guard.scan_text(
+            Path("example.test.ts"),
+            r"const home = 'C:\\Users\\alice\\project';",
+            blocked_fingerprints=set(),
+            blocked_path_fingerprints=fingerprints,
+        )
+
+        self.assertEqual([(item.line, item.rule) for item in violations], [(1, "local-user-path")])
+
+    def test_documented_user_placeholder_is_allowed(self):
+        placeholder = "/" + "Users" + "/<user>/Dev/project"
+        fingerprints = {self.fingerprint("alice")}
+
+        violations = privacy_guard.scan_text(
+            Path("notes.md"),
+            f"Run the tool from {placeholder}.",
+            blocked_fingerprints=set(),
+            blocked_path_fingerprints=fingerprints,
+        )
+
+        self.assertEqual(violations, [])
+
+    def test_synthetic_local_home_directory_is_allowed(self):
+        synthetic_path = "/" + "Users" + "/alice/Dev/project"
+
+        violations = privacy_guard.scan_text(
+            Path("notes.md"),
+            f"The redaction test uses {synthetic_path}.",
+            blocked_fingerprints=set(),
+            blocked_path_fingerprints={self.fingerprint("bob")},
+        )
+
+        self.assertEqual(violations, [])
+
+    def test_single_name_fingerprint_is_limited_to_fixture_contexts(self):
+        fixture_name = "Fixtureperson"
+        fingerprints = {
+            hashlib.sha256(
+                privacy_guard.normalize_candidate(fixture_name).encode("utf-8")
+            ).hexdigest()
+        }
+
+        public_attribution = privacy_guard.scan_text(
+            Path("README.md"),
+            f"Maintainer: {fixture_name}",
+            blocked_fingerprints=set(),
+            fixture_only_fingerprints=fingerprints,
+        )
+        fixture = privacy_guard.scan_text(
+            Path("tests/example_test.py"),
+            f"participant = '{fixture_name}'",
+            blocked_fingerprints=set(),
+            fixture_only_fingerprints=fingerprints,
+        )
+
+        self.assertEqual(public_attribution, [])
+        self.assertEqual([(item.line, item.rule) for item in fixture], [(1, "blocked-value")])
+
+    def test_fixture_fingerprint_detects_a_possessive_name(self):
+        fixture_name = "Fixtureperson"
+        fingerprints = {
+            hashlib.sha256(
+                privacy_guard.normalize_candidate(fixture_name).encode("utf-8")
+            ).hexdigest()
+        }
+
+        violations = privacy_guard.scan_text(
+            Path("docs/superpowers/plans/example.md"),
+            "Publishing is Fixtureperson's call.",
+            blocked_fingerprints=set(),
+            fixture_only_fingerprints=fingerprints,
+        )
+
+        self.assertEqual([(item.line, item.rule) for item in violations], [(1, "blocked-value")])
+
+    def test_fixture_context_covers_repo_fixture_conventions(self):
+        fingerprints = {self.fingerprint("Fixtureperson")}
+        fixture_paths = (
+            Path("app/e2e-mock-ipc.js"),
+            Path("app/__tests__/example.js"),
+            Path("app/fixtures/example.js"),
+            Path("src/example.spec.ts"),
+            Path("src/test_example.py"),
+            Path("src/example_test.py"),
+            Path("docs/superpowers/specs/example.md"),
+        )
+
+        for path in fixture_paths:
+            with self.subTest(path=path):
+                violations = privacy_guard.scan_text(
+                    path,
+                    "Fixtureperson",
+                    blocked_fingerprints=set(),
+                    fixture_only_fingerprints=fingerprints,
+                )
+                self.assertEqual(
+                    [(item.line, item.rule) for item in violations],
+                    [(1, "blocked-value")],
+                )
+
+    def test_hyphenated_full_name_is_rejected(self):
+        fingerprints = {self.fingerprint("Private Fixture")}
+
+        violations = privacy_guard.scan_text(
+            Path("example.md"),
+            "private-fixture",
+            blocked_fingerprints=fingerprints,
+        )
+
+        self.assertEqual([(item.line, item.rule) for item in violations], [(1, "blocked-value")])
+
+    def test_camel_case_fixture_name_is_rejected(self):
+        fingerprints = {self.fingerprint("Fixtureperson")}
+
+        violations = privacy_guard.scan_text(
+            Path("example.test.ts"),
+            "const fixturepersonNotes = true;",
+            blocked_fingerprints=set(),
+            fixture_only_fingerprints=fingerprints,
+        )
+
+        self.assertEqual([(item.line, item.rule) for item in violations], [(1, "blocked-value")])
+
+    def test_blocked_name_in_a_path_is_rejected(self):
+        fingerprints = {self.fingerprint("Private Fixture")}
+
+        violations = privacy_guard.scan_path(
+            Path("docs/private-fixture-notes.md"),
+            blocked_fingerprints=fingerprints,
+        )
+
+        self.assertIn("blocked-path-value", {item.rule for item in violations})
+
+    def test_recording_and_transcript_artifacts_are_rejected_by_path(self):
+        recording = Path("recordings") / "meeting.wav"
+        transcript = Path("fixtures") / "private-transcript.m4a"
+
+        self.assertIn("user-data-artifact", {item.rule for item in privacy_guard.scan_path(recording)})
+        self.assertIn("media-artifact", {item.rule for item in privacy_guard.scan_path(transcript)})
+
+    def test_source_files_about_recording_are_allowed(self):
+        self.assertEqual(privacy_guard.scan_path(Path("docs/features/recording.mdx")), [])
+
+    def test_shipped_fingerprints_are_well_formed(self):
+        collections = (
+            privacy_guard.KNOWN_PRIVATE_FINGERPRINTS,
+            privacy_guard.KNOWN_PRIVATE_FIXTURE_FINGERPRINTS,
+            privacy_guard.KNOWN_PRIVATE_PATH_FINGERPRINTS,
+        )
+
+        for fingerprints in collections:
+            self.assertTrue(fingerprints)
+            self.assertTrue(all(re.fullmatch(r"[0-9a-f]{64}", value) for value in fingerprints))
+
+    def test_primary_ci_runs_the_repository_privacy_guard(self):
+        privacy_workflow = (
+            Path(__file__).parents[1] / ".github" / "workflows" / "privacy.yml"
+        ).read_text()
+        e2e_workflow = (
+            Path(__file__).parents[1] / ".github" / "workflows" / "e2e.yml"
+        ).read_text()
+        triggers = privacy_workflow.split("jobs:", maxsplit=1)[0]
+        required_t1_match = re.search(
+            r"(?ms)^  t1-renderer:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n)",
+            e2e_workflow,
+        )
+
+        self.assertIn("python dev/scripts/repository_privacy_guard.py", privacy_workflow)
+        self.assertIsNotNone(required_t1_match)
+        self.assertIn(
+            "python dev/scripts/repository_privacy_guard.py",
+            required_t1_match.group("body"),
+        )
+        self.assertNotIn("paths:", triggers)
+        self.assertNotIn("paths-ignore:", triggers)
+        self.assertRegex(triggers, r"push:\n\s+branches:\n\s+- main")
+        self.assertRegex(triggers, r"pull_request:\s*\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace private names in current tests and internal plan fixtures with synthetic values
- add a standard-library privacy guard for known private values, local user paths, recordings, transcripts, and media artifacts
- run the scan in the required T1 check and in a standalone workflow that also covers website-only changes

The known private values are stored as SHA-256 identifiers, not plaintext. The scanner reports only file, line, and rule.

## Verification

- repository privacy scan: passed
- privacy and logging tests: 19 passed
- app unit suite: 335 Node tests and 200 renderer tests passed
- Ruff and workflow formatting: passed
- Claude Opus read-only review completed; all High findings were addressed

The complete local Python suite cannot finish in the installed Python 3.14 environment because the existing MLX native stack aborts when no Metal device is available. The focused tests pass there, and GitHub's Python 3.11 job remains the authoritative full-suite check.

No history rewrite is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the repository against private fixtures and user-data artifacts and replaces private names in tests with synthetic values. CI now fails when the scanner detects blocked phrases, local user paths, recordings/transcripts, or media artifacts.

- Adds dev/scripts/repository_privacy_guard.py that matches SHA-256 fingerprints of known private values and reports only file, line, and rule.
- Runs the guard in the required T1 e2e job and in a new privacy workflow (.github/workflows/privacy.yml) to cover website-only changes.
- Updates tests/docs to synthetic names (for example, "Casey Example", "Morgan Example"); no product behavior change.
- Required: replace real names, local user paths, and media artifacts in tests/fixtures with synthetic examples; if needed, run python dev/scripts/repository_privacy_guard.py locally before pushing.

<sup>Written for commit fd6ac8f334211a1b780b91a1a0c01393e0989127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

