### PR TITLE
fix(transcript): show diarized speaker labels

### DIFF
--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -195,7 +195,11 @@ const SPEAKER_SEED_MEETING = {
   transcript: '',
   is_diarised: true,
   has_speaker_sidecar: true,
-  diarised_text: '[00:05] [Speaker 2] hello there',
+  diarised_text:
+    '[00:05] [Speaker 2] hello there\n\n' +
+    '[00:10] [Speaker 3] another participant\n\n' +
+    '[00:15] [Speaker 4] a third participant\n\n' +
+    '[00:20] [Others] fallback channel speech',
   participants: [],
   summary: 'A test meeting for speaker review.',
   key_points: [],

--- a/app/main.js
+++ b/app/main.js
@@ -2842,58 +2842,6 @@ function parseMeetingMarkdown(content, mdPath) {
   };
 }
 
-/** Return the transcript body from the saved `*_transcript.txt` artifact.
- * Recorder-written files carry a short metadata header followed by a line of
- * `=` characters. Older/imported fixtures may contain only the body, so fall
- * back to the complete trimmed file when no separator is present. */
-function savedTranscriptBody(content) {
-  const lines = content.split('\n');
-  const separator = lines[0]?.startsWith('Session:')
-    ? lines.slice(0, 12).findIndex((line) => /^={20,}\s*$/.test(line))
-    : -1;
-  return (separator === -1 ? content : lines.slice(separator + 1).join('\n')).trim();
-}
-
-/** Prefer the separately saved diarised transcript over the copy embedded in
- * a summary. Speaker confirmation rewrites the separate artifact, and older
- * releases did not keep the embedded copy in sync. The path is derived from
- * an already validated summary and is realpath-checked inside the matching
- * user-data root before reading, so a transcript symlink cannot escape it. */
-async function withCurrentDiarisedTranscript(meeting, summaryPath, allowedOutputDirs) {
-  if (!meeting?.is_diarised) return meeting;
-  const suffix = summaryPath.endsWith('_summary.md')
-    ? '_summary.md'
-    : summaryPath.endsWith('_summary.json')
-      ? '_summary.json'
-      : null;
-  if (!suffix) return meeting;
-
-  const matchingOutputDir = allowedOutputDirs.find(
-    (base) => base && summaryPath.startsWith(base),
-  );
-  if (!matchingOutputDir) return meeting;
-
-  const stem = path.basename(summaryPath).slice(0, -suffix.length);
-  const dataRoot = path.dirname(matchingOutputDir.slice(0, -path.sep.length));
-  const transcriptDir = path.join(dataRoot, 'transcripts');
-  const candidate = path.join(transcriptDir, `${stem}_transcript.txt`);
-
-  try {
-    const [realDataRoot, realTranscriptDir, realTranscript] = await Promise.all([
-      fs.promises.realpath(dataRoot),
-      fs.promises.realpath(transcriptDir),
-      fs.promises.realpath(candidate),
-    ]);
-    if (realTranscriptDir !== path.join(realDataRoot, 'transcripts')) return meeting;
-    if (!realTranscript.startsWith(realTranscriptDir + path.sep)) return meeting;
-    const body = savedTranscriptBody(await fs.promises.readFile(realTranscript, 'utf-8'));
-    if (!body) return meeting;
-    return { ...meeting, diarised_text: body };
-  } catch {
-    return meeting;
-  }
-}
-
 /**
  * Validate a renderer-supplied meeting summary path (symlink-safe containment).
  *
@@ -2972,21 +2920,11 @@ ipcMain.handle('get-meeting', async (_event, summaryFile) => {
       // pages route through here. Unlike the list payload, the detail page
       // needs the full data INCLUDING the transcript (for the AskBar /
       // TranscriptPanel), so we return everything parseMeetingMarkdown yields.
-      const parsedMeeting = parseMeetingMarkdown(content, realResolved);
-      const mdMeeting = await withCurrentDiarisedTranscript(
-        parsedMeeting,
-        realResolved,
-        allowedOutputDirs,
-      );
+      const mdMeeting = parseMeetingMarkdown(content, realResolved);
       const mdSidecar = await readReportsSidecar(realResolved, allowedOutputDirs);
       return { success: true, meeting: { ...mdMeeting, has_speaker_sidecar: hasSpeakerSidecar, reports: mdSidecar.reports, active_report: mdSidecar.active_report } };
     }
-    const parsedMeeting = JSON.parse(content);
-    const jsonMeeting = await withCurrentDiarisedTranscript(
-      parsedMeeting,
-      realResolved,
-      allowedOutputDirs,
-    );
+    const jsonMeeting = JSON.parse(content);
     const jsonSidecar = await readReportsSidecar(realResolved, allowedOutputDirs);
     return { success: true, meeting: { ...jsonMeeting, has_speaker_sidecar: hasSpeakerSidecar, reports: jsonSidecar.reports, active_report: jsonSidecar.active_report } };
   } catch (error) {

--- a/app/main.js
+++ b/app/main.js
@@ -2842,6 +2842,58 @@ function parseMeetingMarkdown(content, mdPath) {
   };
 }
 
+/** Return the transcript body from the saved `*_transcript.txt` artifact.
+ * Recorder-written files carry a short metadata header followed by a line of
+ * `=` characters. Older/imported fixtures may contain only the body, so fall
+ * back to the complete trimmed file when no separator is present. */
+function savedTranscriptBody(content) {
+  const lines = content.split('\n');
+  const separator = lines[0]?.startsWith('Session:')
+    ? lines.slice(0, 12).findIndex((line) => /^={20,}\s*$/.test(line))
+    : -1;
+  return (separator === -1 ? content : lines.slice(separator + 1).join('\n')).trim();
+}
+
+/** Prefer the separately saved diarised transcript over the copy embedded in
+ * a summary. Speaker confirmation rewrites the separate artifact, and older
+ * releases did not keep the embedded copy in sync. The path is derived from
+ * an already validated summary and is realpath-checked inside the matching
+ * user-data root before reading, so a transcript symlink cannot escape it. */
+async function withCurrentDiarisedTranscript(meeting, summaryPath, allowedOutputDirs) {
+  if (!meeting?.is_diarised) return meeting;
+  const suffix = summaryPath.endsWith('_summary.md')
+    ? '_summary.md'
+    : summaryPath.endsWith('_summary.json')
+      ? '_summary.json'
+      : null;
+  if (!suffix) return meeting;
+
+  const matchingOutputDir = allowedOutputDirs.find(
+    (base) => base && summaryPath.startsWith(base),
+  );
+  if (!matchingOutputDir) return meeting;
+
+  const stem = path.basename(summaryPath).slice(0, -suffix.length);
+  const dataRoot = path.dirname(matchingOutputDir.slice(0, -path.sep.length));
+  const transcriptDir = path.join(dataRoot, 'transcripts');
+  const candidate = path.join(transcriptDir, `${stem}_transcript.txt`);
+
+  try {
+    const [realDataRoot, realTranscriptDir, realTranscript] = await Promise.all([
+      fs.promises.realpath(dataRoot),
+      fs.promises.realpath(transcriptDir),
+      fs.promises.realpath(candidate),
+    ]);
+    if (realTranscriptDir !== path.join(realDataRoot, 'transcripts')) return meeting;
+    if (!realTranscript.startsWith(realTranscriptDir + path.sep)) return meeting;
+    const body = savedTranscriptBody(await fs.promises.readFile(realTranscript, 'utf-8'));
+    if (!body) return meeting;
+    return { ...meeting, diarised_text: body };
+  } catch {
+    return meeting;
+  }
+}
+
 /**
  * Validate a renderer-supplied meeting summary path (symlink-safe containment).
  *
@@ -2920,11 +2972,21 @@ ipcMain.handle('get-meeting', async (_event, summaryFile) => {
       // pages route through here. Unlike the list payload, the detail page
       // needs the full data INCLUDING the transcript (for the AskBar /
       // TranscriptPanel), so we return everything parseMeetingMarkdown yields.
-      const mdMeeting = parseMeetingMarkdown(content, realResolved);
+      const parsedMeeting = parseMeetingMarkdown(content, realResolved);
+      const mdMeeting = await withCurrentDiarisedTranscript(
+        parsedMeeting,
+        realResolved,
+        allowedOutputDirs,
+      );
       const mdSidecar = await readReportsSidecar(realResolved, allowedOutputDirs);
       return { success: true, meeting: { ...mdMeeting, has_speaker_sidecar: hasSpeakerSidecar, reports: mdSidecar.reports, active_report: mdSidecar.active_report } };
     }
-    const jsonMeeting = JSON.parse(content);
+    const parsedMeeting = JSON.parse(content);
+    const jsonMeeting = await withCurrentDiarisedTranscript(
+      parsedMeeting,
+      realResolved,
+      allowedOutputDirs,
+    );
     const jsonSidecar = await readReportsSidecar(realResolved, allowedOutputDirs);
     return { success: true, meeting: { ...jsonMeeting, has_speaker_sidecar: hasSpeakerSidecar, reports: jsonSidecar.reports, active_report: jsonSidecar.active_report } };
   } catch (error) {

--- a/app/renderer/src/components/TranscriptPanel.tsx
+++ b/app/renderer/src/components/TranscriptPanel.tsx
@@ -137,17 +137,15 @@ function TranscriptRow({ segment, highlight }: { segment: Segment; highlight: st
   // (transcriber.py's _resolve_speaker_placeholders) both render as
   // grey/left — only an exact "You" (or no marker at all) is "self".
   const isYou = segment.speaker === 'You' || segment.speaker == null;
-  // A confirmed real name (via the speaker-review panel's relabeling) is
-  // genuinely new information, unlike the generic "Others"/"Speaker N"
-  // placeholders the comment above is about -- show it.
-  const isGenericLabel =
-    segment.speaker === 'Others' || (segment.speaker != null && /^Speaker \d+$/.test(segment.speaker));
-  const realName = !isYou && !isGenericLabel ? segment.speaker : null;
+  // Every acoustic speaker label carries information because several
+  // distinct speakers can share the grey/left lane. Keep only the channel-
+  // level "Others" marker implicit; show both confirmed names and Speaker N.
+  const speakerLabel = !isYou && segment.speaker !== 'Others' ? segment.speaker : null;
   return (
     <div className={cn('flex flex-col gap-0.5 px-1 py-0.5', isYou ? 'items-end' : 'items-start')}>
-      {(segment.timestamp || realName) && (
+      {(segment.timestamp || speakerLabel) && (
         <span className="flex items-center gap-1.5 px-1.5 text-[10.5px] tabular-nums" style={{ color: 'var(--fg-2)' }}>
-          {realName && <span className="font-medium">{realName}</span>}
+          {speakerLabel && <span className="font-medium">{speakerLabel}</span>}
           {segment.timestamp}
         </span>
       )}
@@ -192,5 +190,4 @@ function renderHighlighted(text: string, highlight: string): React.ReactNode {
   if (cursor < text.length) parts.push(text.slice(cursor));
   return parts;
 }
-
 

--- a/app/renderer/src/hooks/useSpeakerSuggestions.test.tsx
+++ b/app/renderer/src/hooks/useSpeakerSuggestions.test.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  markCluster: vi.fn(),
+}));
+
+vi.mock('@/lib/ipc', () => ({
+  ipc: () => ({
+    speakers: {
+      confirm: h.confirm,
+      markCluster: h.markCluster,
+    },
+  }),
+}));
+
+import { meetingsKeys } from './meetingKeys';
+import {
+  speakersKeys,
+  useConfirmSpeaker,
+  useMarkSpeakerCluster,
+} from './useSpeakerSuggestions';
+
+function renderMutation<T>(hook: () => T) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidate = vi.spyOn(qc, 'invalidateQueries').mockResolvedValue();
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { ...renderHook(hook, { wrapper }), invalidate };
+}
+
+describe('speaker mutation recovery refreshes committed backend state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.confirm.mockResolvedValue({ success: false, error: 'transcript write failed' });
+    h.markCluster.mockResolvedValue({ success: false, error: 'transcript write failed' });
+  });
+
+  test('a failed confirm refreshes suggestions, profiles, and the meeting detail', async () => {
+    const summaryFile = '/data/mtg001_summary.md';
+    const { result, invalidate } = renderMutation(useConfirmSpeaker);
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        meetingStem: 'mtg001',
+        channel: 'mic',
+        diarizationSpeakerId: 'SPEAKER_00',
+        expectedRunId: 'run-1',
+        newPersonName: 'Person Alpha',
+        summaryFile,
+      }).catch(() => {});
+    });
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: speakersKeys.suggestions('mtg001'),
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: speakersKeys.profiles() });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: meetingsKeys.detail(summaryFile) });
+  });
+
+  test('a failed mark refreshes all speaker state and the meeting detail', async () => {
+    const summaryFile = '/data/mtg001_summary.md';
+    const { result, invalidate } = renderMutation(useMarkSpeakerCluster);
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        meetingStem: 'mtg001',
+        channel: 'mic',
+        diarizationSpeakerId: 'SPEAKER_00',
+        expectedRunId: 'run-1',
+        containsMultipleSpeakers: true,
+        summaryFile,
+      }).catch(() => {});
+    });
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: speakersKeys.all });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: meetingsKeys.detail(summaryFile) });
+  });
+});

--- a/app/renderer/src/hooks/useSpeakerSuggestions.ts
+++ b/app/renderer/src/hooks/useSpeakerSuggestions.ts
@@ -78,7 +78,11 @@ export function useConfirmSpeaker() {
     // moment, producing exactly the contradiction a real user hit: "✓
     // Confirmed as X" appearing while the row still says "Unidentified
     // speaker" from the stale pre-confirm data.
-    onSuccess: async (_data, args) => {
+    // The backend can fail after committing the profile and pending recovery
+    // marker (for example when the canonical transcript temp-write fails).
+    // Refresh on either outcome so the panel never keeps pre-mutation state
+    // after a truthful success:false response.
+    onSettled: async (_data, _error, args) => {
       await Promise.all([
         qc.invalidateQueries({ queryKey: speakersKeys.suggestions(args.meetingStem) }),
         qc.invalidateQueries({ queryKey: speakersKeys.profiles() }),
@@ -188,7 +192,10 @@ export function useMarkSpeakerCluster() {
       const { summaryFile: _ignored, ...call } = args;
       return unwrap(await ipc().speakers.markCluster(call));
     },
-    onSuccess: async (_data, args) => {
+    // Profile cleanup and the mixed-speaker sidecar mark are durable before
+    // transcript recovery. A later I/O failure is still a mutation, so error
+    // responses need the same cache refresh as success responses.
+    onSettled: async (_data, _error, args) => {
       await qc.invalidateQueries({ queryKey: speakersKeys.all });
       if (args.summaryFile) {
         await qc.invalidateQueries({ queryKey: meetingsKeys.detail(args.summaryFile) });

--- a/e2e/specs/meeting-detail-flags.t2.spec.ts
+++ b/e2e/specs/meeting-detail-flags.t2.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from '../fixtures/electron';
-import { writeMeetingMarkdown } from '../fixtures/user-config';
+import { writeMeetingMarkdown, writeTranscriptFile } from '../fixtures/user-config';
+import { mkdtempSync, rmSync, symlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
 
 /**
  * T2 — the meeting-DETAIL parser (get-meeting) must surface the optional
@@ -36,6 +39,7 @@ type Meeting = {
   user_notes?: string | null;
   folders?: string[];
   transcript?: string;
+  diarised_text?: string | null;
 };
 type GetResult = { success: boolean; meeting?: Meeting; error?: string };
 type ListResult = { success: boolean; meetings: Meeting[] };
@@ -120,6 +124,62 @@ test('get-meeting leaves the markers unset for a normal summarised note', async 
   expect(res.meeting!.session_info.notes_stale).toBeFalsy();
   expect(res.meeting!.session_info.processing).toBeFalsy();
   expect(res.meeting!.session_info.is_live_transcript).toBeFalsy();
+});
+
+test('get-meeting prefers the current diarised transcript over a stale embedded copy', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const file = writeMeetingMarkdown(userDataDir, 'named-speakers', {
+    name: 'Named speakers',
+    summaryMarkdown: '## Summary\nThree people discussed the plan.',
+    transcript: '[00:05] [Others] first remote speaker\n\n[00:10] [Speaker 2] second remote speaker',
+    frontmatter: { is_diarised: true },
+  });
+  writeTranscriptFile(
+    userDataDir,
+    'named-speakers',
+    '[00:05] [Person Alpha] first remote speaker\n\n[00:10] [Speaker 2] second remote speaker',
+  );
+
+  const { page } = await launchApp();
+
+  const res = await getMeeting(page, file);
+  expect(res.success, res.error).toBe(true);
+  expect(res.meeting!.diarised_text).toBe(
+    '[00:05] [Person Alpha] first remote speaker\n\n[00:10] [Speaker 2] second remote speaker',
+  );
+  expect(res.meeting!.diarised_text).not.toContain('[Others]');
+});
+
+test('get-meeting refuses a diarised transcript reached through a directory symlink', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  const file = writeMeetingMarkdown(userDataDir, 'symlinked-transcript', {
+    name: 'Symlinked transcript',
+    summaryMarkdown: '## Summary\nThe embedded copy remains authoritative.',
+    transcript: '[00:05] [Others] embedded speaker',
+    frontmatter: { is_diarised: true },
+  });
+  const outsideDir = mkdtempSync(path.join(tmpdir(), 'stenoai-transcript-outside-'));
+  const transcriptLink = path.join(userDataDir, 'transcripts');
+  symlinkSync(outsideDir, transcriptLink, process.platform === 'win32' ? 'junction' : 'dir');
+
+  try {
+    writeTranscriptFile(
+      userDataDir,
+      'symlinked-transcript',
+      '[00:05] [Person Outside] content outside the user-data root',
+    );
+    const { page } = await launchApp();
+
+    const res = await getMeeting(page, file);
+    expect(res.success, res.error).toBe(true);
+    expect(res.meeting!.diarised_text).toBe('[00:05] [Others] embedded speaker');
+  } finally {
+    rmSync(outsideDir, { recursive: true, force: true });
+  }
 });
 
 test('LIST (Python parser) and DETAIL (JS parser) agree on the session_info markers', async ({

--- a/e2e/specs/meeting-detail-flags.t2.spec.ts
+++ b/e2e/specs/meeting-detail-flags.t2.spec.ts
@@ -1,8 +1,5 @@
 import { test, expect } from '../fixtures/electron';
 import { writeMeetingMarkdown, writeTranscriptFile } from '../fixtures/user-config';
-import { mkdtempSync, rmSync, symlinkSync } from 'fs';
-import { tmpdir } from 'os';
-import path from 'path';
 
 /**
  * T2 — the meeting-DETAIL parser (get-meeting) must surface the optional
@@ -126,60 +123,28 @@ test('get-meeting leaves the markers unset for a normal summarised note', async 
   expect(res.meeting!.session_info.is_live_transcript).toBeFalsy();
 });
 
-test('get-meeting prefers the current diarised transcript over a stale embedded copy', async ({
+test('get-meeting keeps a manually redacted diarised summary transcript authoritative', async ({
   launchApp,
   userDataDir,
 }) => {
-  const file = writeMeetingMarkdown(userDataDir, 'named-speakers', {
-    name: 'Named speakers',
-    summaryMarkdown: '## Summary\nThree people discussed the plan.',
-    transcript: '[00:05] [Others] first remote speaker\n\n[00:10] [Speaker 2] second remote speaker',
+  const file = writeMeetingMarkdown(userDataDir, 'redacted-speakers', {
+    name: 'Redacted speakers',
+    summaryMarkdown: '## Summary\nSensitive wording was removed.',
+    transcript: '[00:05] [Speaker 2] [redacted]',
     frontmatter: { is_diarised: true },
   });
   writeTranscriptFile(
     userDataDir,
-    'named-speakers',
-    '[00:05] [Person Alpha] first remote speaker\n\n[00:10] [Speaker 2] second remote speaker',
+    'redacted-speakers',
+    '[00:05] [Person Alpha] sensitive wording that must stay hidden',
   );
 
   const { page } = await launchApp();
 
   const res = await getMeeting(page, file);
   expect(res.success, res.error).toBe(true);
-  expect(res.meeting!.diarised_text).toBe(
-    '[00:05] [Person Alpha] first remote speaker\n\n[00:10] [Speaker 2] second remote speaker',
-  );
-  expect(res.meeting!.diarised_text).not.toContain('[Others]');
-});
-
-test('get-meeting refuses a diarised transcript reached through a directory symlink', async ({
-  launchApp,
-  userDataDir,
-}) => {
-  const file = writeMeetingMarkdown(userDataDir, 'symlinked-transcript', {
-    name: 'Symlinked transcript',
-    summaryMarkdown: '## Summary\nThe embedded copy remains authoritative.',
-    transcript: '[00:05] [Others] embedded speaker',
-    frontmatter: { is_diarised: true },
-  });
-  const outsideDir = mkdtempSync(path.join(tmpdir(), 'stenoai-transcript-outside-'));
-  const transcriptLink = path.join(userDataDir, 'transcripts');
-  symlinkSync(outsideDir, transcriptLink, process.platform === 'win32' ? 'junction' : 'dir');
-
-  try {
-    writeTranscriptFile(
-      userDataDir,
-      'symlinked-transcript',
-      '[00:05] [Person Outside] content outside the user-data root',
-    );
-    const { page } = await launchApp();
-
-    const res = await getMeeting(page, file);
-    expect(res.success, res.error).toBe(true);
-    expect(res.meeting!.diarised_text).toBe('[00:05] [Others] embedded speaker');
-  } finally {
-    rmSync(outsideDir, { recursive: true, force: true });
-  }
+  expect(res.meeting!.diarised_text).toBe('[00:05] [Speaker 2] [redacted]');
+  expect(res.meeting!.diarised_text).not.toContain('sensitive wording that must stay hidden');
 });
 
 test('LIST (Python parser) and DETAIL (JS parser) agree on the session_info markers', async ({

--- a/e2e/specs/speaker-naming.t2.spec.ts
+++ b/e2e/specs/speaker-naming.t2.spec.ts
@@ -4,6 +4,7 @@ import {
   enableSpeakerIdentification,
   fixtureDiarizationRunId,
   readUserConfig,
+  writeMeetingMarkdown,
   writeSpeakersSidecar,
   writeTranscriptFile,
 } from '../fixtures/user-config';
@@ -36,6 +37,13 @@ type ConfirmSpeakerResult = {
 
 type StenoWindow = Window & {
   stenoai: {
+    meetings: {
+      get: (summaryFile: string) => Promise<{
+        success: boolean;
+        error?: string;
+        meeting?: { diarised_text?: string | null };
+      }>;
+    };
     speakers: {
       confirm: (params: {
         meetingStem: string;
@@ -241,6 +249,12 @@ test('confirm-speaker --relabel-transcript persists a PersonProfile and relabels
     stem,
     '[00:05] [Speaker 2] hello there\n\n[00:20] [You] hi back',
   );
+  const summaryFile = writeMeetingMarkdown(userDataDir, stem, {
+    name: 'Speaker naming',
+    summaryMarkdown: '## Summary\nTwo people discussed the plan.',
+    transcript: '[00:05] [Speaker 2] hello there\n\n[00:20] [You] hi back',
+    frontmatter: { is_diarised: true },
+  });
 
   enableSpeakerIdentification(userDataDir);
 
@@ -268,6 +282,12 @@ test('confirm-speaker --relabel-transcript persists a PersonProfile and relabels
     expect.stringContaining('[00:05] [Person Alpha] hello there'),
   );
   expect(readFileSync(transcriptFile, 'utf8')).toContain('[00:20] [You] hi back');
+  const firstMeeting = await page.evaluate(
+    (file) => (window as StenoWindow).stenoai.meetings.get(file),
+    summaryFile,
+  );
+  expect(firstMeeting.success, firstMeeting.error).toBe(true);
+  expect(firstMeeting.meeting!.diarised_text).toContain('[00:05] [Person Alpha] hello there');
 
   // A second confirm of the SAME cluster (the review UI's "Change"
   // correction) REASSIGNS it: the transcript re-labels idempotently rather
@@ -283,6 +303,13 @@ test('confirm-speaker --relabel-transcript persists a PersonProfile and relabels
     expect.stringContaining('[00:05] [Person Gamma] hello there'),
   );
   expect(readFileSync(transcriptFile, 'utf8')).not.toContain('[Person Alpha]');
+  const correctedMeeting = await page.evaluate(
+    (file) => (window as StenoWindow).stenoai.meetings.get(file),
+    summaryFile,
+  );
+  expect(correctedMeeting.success, correctedMeeting.error).toBe(true);
+  expect(correctedMeeting.meeting!.diarised_text).toContain('[00:05] [Person Gamma] hello there');
+  expect(correctedMeeting.meeting!.diarised_text).not.toContain('[Person Alpha]');
 
   // On disk: Person Alpha keeps his (now evidence-less) profile, Person Gamma owns the
   // cluster with a prototype marked as a correction.

--- a/e2e/specs/speaker-review.t1.spec.ts
+++ b/e2e/specs/speaker-review.t1.spec.ts
@@ -25,6 +25,22 @@ async function openDetail(page: Page) {
   await expect(page.getByTestId('speaker-review-panel')).toBeVisible();
 }
 
+test('saved transcript identifies each acoustically diarised speaker', async ({ launchApp }) => {
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { STENOAI_E2E_SEED_SPEAKER_SUGGESTIONS: '1' },
+  });
+  await navigateToDetail(page);
+
+  await page.getByRole('button', { name: 'Show transcript' }).click();
+  const transcript = page.locator('.mv-transcript.open');
+
+  await expect(transcript.getByText('Speaker 2', { exact: true })).toBeVisible();
+  await expect(transcript.getByText('Speaker 3', { exact: true })).toBeVisible();
+  await expect(transcript.getByText('Speaker 4', { exact: true })).toBeVisible();
+  await expect(transcript.getByText('Others', { exact: true })).toHaveCount(0);
+});
+
 test('sidecar has multiple clusters opens review even when the transcript is not diarised', async ({
   launchApp,
 }) => {

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -18,6 +18,7 @@ transcribes/summarizes the resulting file. Usage (called by Electron):
 import click
 import asyncio
 import filelock
+import hashlib
 import logging
 import json
 import os
@@ -5650,11 +5651,14 @@ def confirm_speaker(
         sys.exit(1)
 
     relabeled_lines = 0
+    summary_artifacts_ready = True
     if relabel_transcript:
         transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
         previous_transcript_body = _saved_transcript_body(transcript_path)
         turn_manifest = sidecar.get("transcript_lines")
         retry_relabel_target_ids = None
+        summary_sync_ready = True
+        summary_sync_marker = None
         if turn_manifest:
             # Exact recorded provenance -- immune to the fuzzy-matching
             # cross-channel/same-channel mislabeling below (see
@@ -5675,36 +5679,50 @@ def confirm_speaker(
                 target_ids,
                 lock_held=True,
             )
-            relabeled_lines = relabel_transcript_exact(
-                transcript_path, turn_manifest, target_ids, person["display_name"],
-            )
+            # record_original_labels rewrites the sidecar. Refresh the manifest
+            # before persisting the pending transition so this write cannot
+            # accidentally put its pre-write copy back on disk.
+            refreshed_sidecar = store.read(meeting_stem)
+            if isinstance(refreshed_sidecar, dict):
+                sidecar = refreshed_sidecar
+                turn_manifest = sidecar.get("transcript_lines") or turn_manifest
+            if previous_transcript_body is not None:
+                summary_sync_ready, summary_sync_marker = _prepare_summary_transcript_sync(
+                    output_dir,
+                    meeting_stem,
+                    previous_transcript_body,
+                    target_ids,
+                    person["display_name"],
+                )
+                summary_artifacts_ready = summary_sync_ready
+            if summary_sync_ready:
+                relabeled_lines = relabel_transcript_exact(
+                    transcript_path, turn_manifest, target_ids, person["display_name"],
+                )
         else:
             raw_clusters_by_id = channel_data.get("clusters") or {}
             pooled_segments = []
             for fragment_id in [resolved_id, *context.merged_from]:
                 pooled_segments.extend(raw_clusters_by_id.get(fragment_id, {}).get("segments") or [])
             relabeled_lines = relabel_transcript_speaker(transcript_path, pooled_segments, person["display_name"])
-        if previous_transcript_body is not None:
-            if relabeled_lines > 0:
-                _update_summary_transcript(
-                    output_dir,
-                    meeting_stem,
-                    transcript_path,
-                    previous_transcript_body,
-                )
-            elif turn_manifest and retry_relabel_target_ids:
-                # The transcript can be durable while its best-effort summary
-                # write fails. A same-cluster confirmation retry has no newly
-                # relabelled lines, but may safely repair a matching embedded
-                # copy only through exact manifest provenance.
-                _update_summary_transcript(
-                    output_dir,
-                    meeting_stem,
-                    transcript_path,
-                    previous_transcript_body,
-                    restore_manifest=turn_manifest,
-                    restore_target_ids=retry_relabel_target_ids,
-                    retry_relabel_to=person["display_name"],
+        if (
+            previous_transcript_body is not None
+            and summary_sync_ready
+            and (relabeled_lines > 0 or summary_sync_marker is not None)
+        ):
+            sync_outcome = _update_summary_transcript(
+                output_dir,
+                meeting_stem,
+                transcript_path,
+                previous_transcript_body,
+                restore_manifest=turn_manifest,
+                restore_target_ids=retry_relabel_target_ids,
+                retry_relabel_to=person["display_name"],
+                sync_marker=summary_sync_marker,
+            )
+            if summary_sync_marker is not None and sync_outcome != "io_error":
+                _clear_summary_transcript_sync(
+                    output_dir, meeting_stem, summary_sync_marker,
                 )
 
     # Naming the cluster supersedes "a human kept this generic": the row is
@@ -5724,7 +5742,8 @@ def confirm_speaker(
     # gate this behind a flag) -- keeps the meeting's Participants chip in
     # sync with every confirm, including plain CLI/backfill-validation use.
     participant_names = confirmed_participant_names(meeting_stem, config.get_person_profiles())
-    _update_summary_participants(output_dir, meeting_stem, participant_names)
+    if summary_artifacts_ready:
+        _update_summary_participants(output_dir, meeting_stem, participant_names)
 
     print(json.dumps({
         "success": True,
@@ -5996,6 +6015,7 @@ def mark_speaker_cluster(
     config = get_config()
     cleared_from = []
     restored_lines = 0
+    summary_artifacts_ready = True
     if multiple and fragment_ids:
         if not config.begin_transaction():
             print(json.dumps({
@@ -6088,37 +6108,47 @@ def mark_speaker_cluster(
         # but it must still repair the transcript and Participants section.
         transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
         previous_transcript_body = _saved_transcript_body(transcript_path)
-        restored_lines = restore_transcript_labels(
-            transcript_path,
-            sidecar.get("transcript_lines") or [],
-            {(channel, fid) for fid in fragment_ids},
-        )
-        if previous_transcript_body is not None:
-            # A prior attempt can have restored the canonical transcript and
-            # then lost the best-effort summary write.  Its retry sees no
-            # newly restored lines, but the old person label can still be in
-            # the summary's embedded transcript.  Repair just labels whose
-            # provenance matches this cluster; never replace user text.
-            if restored_lines > 0:
-                _update_summary_transcript(
-                    output_dir,
-                    meeting_stem,
-                    transcript_path,
-                    previous_transcript_body,
+        restore_target_ids = {(channel, fid) for fid in fragment_ids}
+        summary_sync_ready = True
+        summary_sync_marker = None
+        if previous_transcript_body is not None and sidecar.get("transcript_lines"):
+            summary_sync_ready, summary_sync_marker = _prepare_summary_transcript_sync(
+                output_dir,
+                meeting_stem,
+                previous_transcript_body,
+                restore_target_ids,
+                None,
+            )
+            summary_artifacts_ready = summary_sync_ready
+        if summary_sync_ready:
+            restored_lines = restore_transcript_labels(
+                transcript_path,
+                sidecar.get("transcript_lines") or [],
+                restore_target_ids,
+            )
+        if (
+            previous_transcript_body is not None
+            and summary_sync_ready
+            and (restored_lines > 0 or summary_sync_marker is not None)
+        ):
+            sync_outcome = _update_summary_transcript(
+                output_dir,
+                meeting_stem,
+                transcript_path,
+                previous_transcript_body,
+                restore_manifest=sidecar.get("transcript_lines") or [],
+                restore_target_ids=restore_target_ids,
+                sync_marker=summary_sync_marker,
+            )
+            if summary_sync_marker is not None and sync_outcome != "io_error":
+                _clear_summary_transcript_sync(
+                    output_dir, meeting_stem, summary_sync_marker,
                 )
-            else:
-                _update_summary_transcript(
-                    output_dir,
-                    meeting_stem,
-                    transcript_path,
-                    previous_transcript_body,
-                    restore_manifest=sidecar.get("transcript_lines") or [],
-                    restore_target_ids={(channel, fid) for fid in fragment_ids},
-                )
-        _update_summary_participants(
-            output_dir, meeting_stem,
-            confirmed_participant_names(meeting_stem, config.get_person_profiles()),
-        )
+        if summary_artifacts_ready:
+            _update_summary_participants(
+                output_dir, meeting_stem,
+                confirmed_participant_names(meeting_stem, config.get_person_profiles()),
+            )
 
     print(json.dumps({
         "success": True,
@@ -6703,6 +6733,149 @@ def _enumerate_meeting_stems(output_dir):
 
 
 _MD_SECTION_HEADER_RE = re.compile(r"^## (.+?)\s*$")
+_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY = "pending_summary_transcript_sync"
+_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION = 1
+
+
+def _transcript_body_hash(body: str) -> str:
+    """Hash the exact extracted body without persisting its contents."""
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _summary_transcript_copy(
+    output_dir: Path, meeting_stem: str,
+) -> tuple[Optional[str], Optional[str], bool]:
+    """Return ``(format, body, io_failed)`` using the normal JSON priority."""
+    json_path = output_dir / f"{meeting_stem}_summary.json"
+    md_path = output_dir / f"{meeting_stem}_summary.md"
+    if json_path.exists():
+        try:
+            data = json.loads(json_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as error:
+            logger.warning("Could not read %s to prepare transcript sync: %s", json_path, error)
+            return "json", None, True
+        embedded = data.get("diarised_text")
+        return "json", embedded if isinstance(embedded, str) else None, False
+
+    if not md_path.exists():
+        return None, None, False
+    try:
+        original = md_path.read_text(encoding="utf-8")
+    except OSError as error:
+        logger.warning("Could not read %s to prepare transcript sync: %s", md_path, error)
+        return "md", None, True
+
+    lines = original.split("\n")
+    i = 0
+    while i < len(lines):
+        match = _MD_SECTION_HEADER_RE.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        body_end = i + 1
+        while body_end < len(lines) and not _MD_SECTION_HEADER_RE.match(lines[body_end]):
+            body_end += 1
+        if match.group(1).strip().lower() == "transcript":
+            return "md", "\n".join(lines[i + 1:body_end]).strip(), False
+        i = body_end
+    return "md", None, False
+
+
+def _summary_sync_operation_hash(target_ids: set, replacement_label: Optional[str]) -> str:
+    payload = {
+        "replacement_label_sha256": (
+            hashlib.sha256(replacement_label.encode("utf-8")).hexdigest()
+            if replacement_label is not None else None
+        ),
+        "target_ids": sorted([list(target_id) for target_id in target_ids]),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _prepare_summary_transcript_sync(
+    output_dir: Path,
+    meeting_stem: str,
+    previous_transcript_body: str,
+    target_ids: set,
+    replacement_label: Optional[str],
+) -> tuple[bool, Optional[dict]]:
+    """Persist exact pre-write proof for a possible summary retry.
+
+    The marker contains hashes and operation identity only. It is written to
+    the already crash-safe speaker sidecar while the caller holds its meeting
+    lock, before either transcript artifact changes.
+    """
+    from src.speaker_sidecar_store import SpeakerSidecarStore, StaleDiarizationRun
+
+    store = SpeakerSidecarStore(output_dir)
+    sidecar = store.read(meeting_stem)
+    if not isinstance(sidecar, dict):
+        return False, None
+    operation_hash = _summary_sync_operation_hash(target_ids, replacement_label)
+    existing = sidecar.get(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY)
+    if existing is not None:
+        if (
+            isinstance(existing, dict)
+            and existing.get("version") == _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION
+            and existing.get("operation_sha256") == operation_hash
+        ):
+            return True, existing
+        # Never replace proof for a transition that has not been reconciled.
+        return False, None
+
+    summary_format, embedded_body, io_failed = _summary_transcript_copy(output_dir, meeting_stem)
+    if io_failed:
+        return False, None
+    if summary_format is None or embedded_body is None:
+        return True, None
+    if embedded_body != previous_transcript_body:
+        # The embedded copy already diverged before this operation. Preserve it
+        # and do not mint provenance that could make a later retry overwrite it.
+        return True, None
+
+    marker = {
+        "version": _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+        "summary_format": summary_format,
+        "canonical_before_sha256": _transcript_body_hash(previous_transcript_body),
+        "embedded_before_sha256": _transcript_body_hash(embedded_body),
+        "operation_sha256": operation_hash,
+    }
+
+    def persist(document):
+        document[_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY] = marker
+
+    try:
+        store.mutate_locked(meeting_stem, store.run_token(sidecar), persist)
+    except (FileNotFoundError, OSError, StaleDiarizationRun, ValueError) as error:
+        logger.warning("Could not persist pending transcript sync for %s: %s", meeting_stem, error)
+        return False, None
+    return True, marker
+
+
+def _clear_summary_transcript_sync(
+    output_dir: Path, meeting_stem: str, marker: dict,
+) -> bool:
+    """Remove only the exact marker this operation consumed."""
+    from src.speaker_sidecar_store import SpeakerSidecarStore, StaleDiarizationRun
+
+    store = SpeakerSidecarStore(output_dir)
+    sidecar = store.read(meeting_stem)
+    if not isinstance(sidecar, dict):
+        return False
+    if sidecar.get(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY) != marker:
+        return True
+
+    def clear(document):
+        if document.get(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY) == marker:
+            document.pop(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY, None)
+
+    try:
+        store.mutate_locked(meeting_stem, store.run_token(sidecar), clear)
+    except (FileNotFoundError, OSError, StaleDiarizationRun, ValueError) as error:
+        logger.warning("Could not clear pending transcript sync for %s: %s", meeting_stem, error)
+        return False
+    return True
 
 
 def _saved_transcript_body(transcript_path: Path) -> Optional[str]:
@@ -6735,22 +6908,39 @@ def _update_summary_transcript(
     restore_manifest: Optional[list] = None,
     restore_target_ids: Optional[set] = None,
     retry_relabel_to: Optional[str] = None,
-) -> None:
+    sync_marker: Optional[dict] = None,
+) -> str:
     """Keep a summary's embedded diarised transcript aligned after naming.
 
     The separate transcript is the relabel operation's canonical artifact. An
     embedded copy is replaced only when it still exactly matches the canonical
-    body from before relabeling. A user-edited or independently redacted copy is
-    preserved. When a prior attempt restored the canonical transcript but its
-    summary write failed, a provenance-checked label-only repair can bring the
-    embedded copy forward without replacing its text. JSON remains preferred
-    when both summary formats exist, matching the rest of the meeting-store
-    code. Missing or unreadable artifacts are best-effort no-ops because
-    speaker-profile confirmation already succeeded.
+    body from before relabeling. A retry additionally needs the crash-safe hash
+    marker written before that first canonical change. Manifest/timestamps alone
+    are never authority to overwrite a divergent copy. The return value lets the
+    caller retain the marker only for I/O failures and clear it after a completed
+    update or a deliberate user-edit no-op.
     """
     transcript_body = _saved_transcript_body(transcript_path)
     if not transcript_body:
-        return
+        return "io_error"
+
+    expected_operation_hash = None
+    if restore_target_ids is not None:
+        expected_operation_hash = _summary_sync_operation_hash(
+            restore_target_ids, retry_relabel_to,
+        )
+
+    def _marker_allows_retry(summary_format: str, embedded_body: str) -> bool:
+        return bool(
+            isinstance(sync_marker, dict)
+            and sync_marker.get("version") == _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION
+            and sync_marker.get("summary_format") == summary_format
+            and sync_marker.get("operation_sha256") == expected_operation_hash
+            and sync_marker.get("canonical_before_sha256")
+            == sync_marker.get("embedded_before_sha256")
+            and sync_marker.get("embedded_before_sha256")
+            == _transcript_body_hash(embedded_body)
+        )
 
     def _repair_embedded_labels(embedded_body: str) -> tuple[str, int]:
         if restore_manifest is None or restore_target_ids is None:
@@ -6773,38 +6963,45 @@ def _update_summary_transcript(
             data = json.loads(json_path.read_text(encoding="utf-8"))
         except (OSError, ValueError) as e:
             logger.warning(f"Could not read {json_path} to update transcript: {e}")
-            return
+            return "io_error"
         embedded_body = data.get("diarised_text")
         if not isinstance(embedded_body, str):
-            return
-        if embedded_body.strip() == previous_transcript_body.strip():
+            return "diverged"
+        if embedded_body == transcript_body:
+            return "complete"
+        if embedded_body == previous_transcript_body:
             replacement_body = transcript_body
             repaired_labels = False
-        elif restore_manifest is not None and restore_target_ids is not None:
+        elif (
+            restore_manifest is not None
+            and restore_target_ids is not None
+            and _marker_allows_retry("json", embedded_body)
+        ):
             replacement_body, restored_lines = _repair_embedded_labels(embedded_body)
             if restored_lines == 0:
-                return
+                return "unsafe"
             repaired_labels = True
         else:
-            return
-        if repaired_labels and replacement_body.strip() != transcript_body:
-            return
-        if replacement_body.strip() == embedded_body.strip():
-            return
+            return "diverged"
+        if repaired_labels and replacement_body != transcript_body:
+            return "unsafe"
+        if replacement_body == embedded_body:
+            return "complete"
         data["diarised_text"] = replacement_body
         try:
             _atomic_write_json(json_path, data)
         except OSError as e:
             logger.warning(f"Could not update transcript in {json_path}: {e}")
-        return
+            return "io_error"
+        return "updated"
 
     if not md_path.exists():
-        return
+        return "missing"
     try:
         original = md_path.read_text(encoding="utf-8")
     except OSError as e:
         logger.warning(f"Could not read {md_path} to update transcript: {e}")
-        return
+        return "io_error"
 
     lines = original.split("\n")
     section_start = None
@@ -6824,30 +7021,38 @@ def _update_summary_transcript(
         i = body_end
 
     if section_start is None:
-        return
+        return "diverged"
     embedded_body = "\n".join(lines[section_start + 1:section_end]).strip()
-    if embedded_body == previous_transcript_body.strip():
+    if embedded_body == transcript_body:
+        return "complete"
+    if embedded_body == previous_transcript_body:
         replacement_body = transcript_body
         repaired_labels = False
-    elif restore_manifest is not None and restore_target_ids is not None:
+    elif (
+        restore_manifest is not None
+        and restore_target_ids is not None
+        and _marker_allows_retry("md", embedded_body)
+    ):
         replacement_body, restored_lines = _repair_embedded_labels(embedded_body)
         if restored_lines == 0:
-            return
+            return "unsafe"
         repaired_labels = True
     else:
-        return
-    if repaired_labels and replacement_body.strip() != transcript_body:
-        return
-    if replacement_body.strip() == embedded_body:
-        return
+        return "diverged"
+    if repaired_labels and replacement_body != transcript_body:
+        return "unsafe"
+    if replacement_body == embedded_body:
+        return "complete"
     new_section = ["## Transcript", "", *replacement_body.split("\n"), ""]
     spliced = lines[:section_start] + new_section + lines[section_end:]
     if spliced == lines:
-        return
+        return "complete"
     try:
         _atomic_write_text(md_path, "\n".join(spliced))
     except OSError as e:
         logger.warning(f"Could not update transcript in {md_path}: {e}")
+        return "io_error"
+    return "updated"
 
 
 def _update_summary_participants(output_dir: Path, meeting_stem: str, participant_names: list) -> None:

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -6115,6 +6115,12 @@ def mark_speaker_cluster(
                 "error": "Could not read the transcript. Retry the speaker marking.",
             }))
             sys.exit(1)
+        if prepared_transcript_body is None:
+            print(json.dumps({
+                "success": False,
+                "error": "The transcript is missing. Restore it before marking the speaker.",
+            }))
+            sys.exit(1)
         prepared_restore_target_ids = {(channel, fid) for fid in fragment_ids}
         if not _reconcile_pending_summary_transcript_sync(
             output_dir,
@@ -7014,11 +7020,13 @@ def _prepare_summary_transcript_sync(
     target_ids: set,
     replacement_label: Optional[str],
 ) -> tuple[bool, Optional[dict]]:
-    """Persist exact pre-write proof for a possible summary retry.
+    """Persist exact pre-write provenance for an interrupted operation.
 
     The marker contains hashes and operation identity only. It is written to
     the already crash-safe speaker sidecar while the caller holds its meeting
-    lock, before either transcript artifact changes.
+    lock, before either transcript artifact changes. The operation identity is
+    durable even when the Summary is absent or already divergent, so a failed
+    canonical write can still retry the exact committed profile operation.
     """
     from src.speaker_sidecar_store import SpeakerSidecarStore, StaleDiarizationRun
 
@@ -7044,18 +7052,15 @@ def _prepare_summary_transcript_sync(
     summary_format, embedded_body, io_failed = _summary_transcript_copy(output_dir, meeting_stem)
     if io_failed:
         return False, None
-    if summary_format is None or embedded_body is None:
-        return True, None
-    if embedded_body != previous_transcript_body:
-        # The embedded copy already diverged before this operation. Preserve it
-        # and do not mint provenance that could make a later retry overwrite it.
-        return True, None
 
     marker = {
         "version": _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
         "summary_format": summary_format,
         "canonical_before_sha256": _transcript_body_hash(previous_transcript_body),
-        "embedded_before_sha256": _transcript_body_hash(embedded_body),
+        "embedded_before_sha256": (
+            _transcript_body_hash(embedded_body)
+            if isinstance(embedded_body, str) else None
+        ),
         "canonical_after_sha256": _transcript_body_hash(expected_transcript_body),
         "operation_sha256": operation_hash,
     }
@@ -7100,10 +7105,27 @@ def _reconcile_pending_summary_transcript_sync(
 
     operation_hash = _summary_sync_operation_hash(target_ids, replacement_label)
     transcript_body = _saved_transcript_body(transcript_path)
+    if transcript_body is None:
+        logger.warning("Could not safely reconcile pending transcript sync for %s", meeting_stem)
+        return False
+
+    if (
+        isinstance(marker, dict)
+        and marker.get("version") in {
+            _LEGACY_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+            _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+        }
+        and marker.get("operation_sha256") == operation_hash
+    ):
+        # This is the exact interrupted operation. Its later update path
+        # preserves an absent Summary and still verifies the original embedded
+        # hash before changing a divergent one.
+        return True
+
     summary_format, embedded_body, io_failed = _summary_transcript_copy(
         output_dir, meeting_stem,
     )
-    if transcript_body is None or io_failed or summary_format is None or embedded_body is None:
+    if io_failed or summary_format is None or embedded_body is None:
         logger.warning("Could not safely reconcile pending transcript sync for %s", meeting_stem)
         return False
 
@@ -7123,18 +7145,6 @@ def _reconcile_pending_summary_transcript_sync(
             return True
         logger.warning("Could not clear completed pending transcript sync for %s", meeting_stem)
         return False
-
-    if (
-        isinstance(marker, dict)
-        and marker.get("version") in {
-            _LEGACY_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
-            _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
-        }
-        and marker.get("operation_sha256") == operation_hash
-    ):
-        # This is the exact interrupted operation.  Its later update path
-        # still verifies the original embedded hash before changing anything.
-        return True
 
     logger.warning("Pending transcript sync for %s cannot be safely reconciled", meeting_stem)
     return False

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5456,11 +5456,22 @@ def confirm_speaker(
         sys.exit(1)
     target_ids = {(channel, sid) for sid in fragment_ids}
     try:
+        profiles = config.get_person_profiles()
+        # Every confirmed profile from this meeting can participate in the
+        # evidence and Participants updates below. Do not let a persisted
+        # reserved/self lookalike become biometric or display evidence just
+        # because it is adjacent to, rather than selected by, this confirm.
+        for existing_profile in profiles:
+            if any(
+                prototype.get("meeting_id") == meeting_stem
+                for prototype in (existing_profile.get("prototypes") or [])
+            ):
+                validate_display_name(existing_profile.get("display_name"))
         if new_person:
             normalized_new_person = validate_display_name(new_person)
             retry_person = (
                 _pending_new_person_confirmation_retry(
-                    config.get_person_profiles(),
+                    profiles,
                     sidecar,
                     meeting_stem,
                     channel,
@@ -5487,6 +5498,27 @@ def confirm_speaker(
             intended_display_name = validate_display_name(
                 selected_person.get("display_name"),
             )
+            if selected_person.get("display_name") != intended_display_name:
+                # Keep the durable profile and every operation artefact on
+                # the same canonical spelling. Without this, the pending
+                # marker hashes the validated value while transcript writes
+                # use the raw persisted spelling, making an otherwise exact
+                # retry look like a foreign operation.
+                if not config.rename_person_profile(person_id, intended_display_name):
+                    config.rollback_transaction()
+                    print(json.dumps({
+                        "success": False,
+                        "error": "Could not normalize the person profile.",
+                    }))
+                    sys.exit(1)
+                selected_person = config.get_person_profile(person_id)
+                if selected_person is None:
+                    config.rollback_transaction()
+                    print(json.dumps({
+                        "success": False,
+                        "error": f"No person profile with id {person_id!r}",
+                    }))
+                    sys.exit(1)
     except ValueError as error:
         config.rollback_transaction()
         print(json.dumps({"success": False, "error": str(error)}))
@@ -6183,6 +6215,16 @@ def mark_speaker_cluster(
     legacy_display_names = set()
     try:
         profiles = config.get_person_profiles()
+        # A confirmation can update hard-negative evidence and Participants
+        # for another confirmed profile in this meeting. Validate all of
+        # those profiles before either a mixed mark or a --single clear
+        # changes durable state.
+        for person in profiles:
+            if any(
+                prototype.get("meeting_id") == meeting_stem
+                for prototype in (person.get("prototypes") or [])
+            ):
+                validate_display_name(person.get("display_name"))
         for person in profiles:
             if not any(
                 prototype.get("meeting_id") == meeting_stem
@@ -6198,8 +6240,34 @@ def mark_speaker_cluster(
     except ValueError as error:
         print(json.dumps({"success": False, "error": str(error)}))
         sys.exit(1)
-    pending_marker = sidecar.get(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY)
     legacy_target_ids = {(channel, fid) for fid in fragment_ids}
+    pending_transcript_path = (
+        get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+    )
+    if not _reconcile_pending_summary_transcript_sync(
+        output_dir,
+        meeting_stem,
+        pending_transcript_path,
+        legacy_target_ids,
+        None,
+        # A --single clear is never the recovery operation that wrote a
+        # pending marker. It must finalize a proved-complete marker or fail
+        # closed, rather than clearing the mixed state underneath it.
+        allow_operation_retry=multiple,
+    ):
+        print(json.dumps({
+            "success": False,
+            "error": "Could not safely reconcile a pending transcript update.",
+        }))
+        sys.exit(1)
+    sidecar = store.read(meeting_stem)
+    if not isinstance(sidecar, dict):
+        print(json.dumps({
+            "success": False,
+            "error": "The speaker analysis is missing or invalid.",
+        }))
+        sys.exit(1)
+    pending_marker = sidecar.get(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY)
     if (
         not sidecar.get("transcript_lines")
         and isinstance(pending_marker, dict)
@@ -6217,17 +6285,21 @@ def mark_speaker_cluster(
             }))
             sys.exit(1)
         unresolved_hashes = set(label_hashes)
-        for person in profiles:
-            try:
+        try:
+            for person in profiles:
+                # Legacy markers contain the validated canonical name. Validate before
+                # comparing hashes so valid non-canonical Unicode names can reconcile.
+                # Do not skip malformed or reserved neighbouring profiles.
                 display_name = validate_display_name(person.get("display_name"))
-            except ValueError:
-                continue
-            display_name_hash = hashlib.sha256(
-                display_name.encode("utf-8"),
-            ).hexdigest()
-            if display_name_hash in unresolved_hashes:
-                legacy_display_names.add(display_name)
-                unresolved_hashes.remove(display_name_hash)
+                display_name_hash = hashlib.sha256(
+                    display_name.encode("utf-8"),
+                ).hexdigest()
+                if display_name_hash in unresolved_hashes:
+                    legacy_display_names.add(display_name)
+                    unresolved_hashes.remove(display_name_hash)
+        except ValueError as error:
+            print(json.dumps({"success": False, "error": str(error)}))
+            sys.exit(1)
         if unresolved_hashes:
             print(json.dumps({
                 "success": False,
@@ -6271,18 +6343,6 @@ def mark_speaker_cluster(
                 }))
                 sys.exit(1)
         else:
-            if not _reconcile_pending_summary_transcript_sync(
-                output_dir,
-                meeting_stem,
-                prepared_transcript_path,
-                prepared_restore_target_ids,
-                None,
-            ):
-                print(json.dumps({
-                    "success": False,
-                    "error": "Could not safely reconcile a pending transcript update.",
-                }))
-                sys.exit(1)
             if sidecar.get("transcript_lines"):
                 expected_transcript_body, _ = restore_transcript_text_labels(
                     prepared_transcript_body,

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5652,6 +5652,7 @@ def confirm_speaker(
     relabeled_lines = 0
     if relabel_transcript:
         transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+        previous_transcript_body = _saved_transcript_body(transcript_path)
         turn_manifest = sidecar.get("transcript_lines")
         if turn_manifest:
             # Exact recorded provenance -- immune to the fuzzy-matching
@@ -5681,6 +5682,13 @@ def confirm_speaker(
             for fragment_id in [resolved_id, *context.merged_from]:
                 pooled_segments.extend(raw_clusters_by_id.get(fragment_id, {}).get("segments") or [])
             relabeled_lines = relabel_transcript_speaker(transcript_path, pooled_segments, person["display_name"])
+        if relabeled_lines > 0 and previous_transcript_body is not None:
+            _update_summary_transcript(
+                output_dir,
+                meeting_stem,
+                transcript_path,
+                previous_transcript_body,
+            )
 
     # Naming the cluster supersedes "a human kept this generic": the row is
     # now decided, and leaving the marking would have the panel report a
@@ -6654,6 +6662,108 @@ def _enumerate_meeting_stems(output_dir):
 
 
 _MD_SECTION_HEADER_RE = re.compile(r"^## (.+?)\s*$")
+
+
+def _saved_transcript_body(transcript_path: Path) -> Optional[str]:
+    """Read the user-facing body from a recorder-written transcript file.
+
+    `_write_transcript_file` prefixes metadata and a line of `=` characters.
+    Legacy/imported transcripts can be body-only, so a missing separator is a
+    valid fallback rather than an error.
+    """
+    try:
+        content = transcript_path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning(f"Could not read {transcript_path} to update summary transcript: {e}")
+        return None
+    lines = content.split("\n")
+    separator = (
+        next((i for i, line in enumerate(lines[:12]) if re.fullmatch(r"={20,}\s*", line)), None)
+        if lines and lines[0].startswith("Session:")
+        else None
+    )
+    body = "\n".join(lines[separator + 1:]) if separator is not None else content
+    return body.strip()
+
+
+def _update_summary_transcript(
+    output_dir: Path,
+    meeting_stem: str,
+    transcript_path: Path,
+    previous_transcript_body: str,
+) -> None:
+    """Keep a summary's embedded diarised transcript aligned after naming.
+
+    The separate transcript is the relabel operation's canonical artifact. An
+    embedded copy is replaced only when it still exactly matches the canonical
+    body from before relabeling. A user-edited or independently redacted copy is
+    preserved. JSON remains preferred when both summary formats exist, matching
+    the rest of the meeting-store code. Missing or unreadable artifacts are
+    best-effort no-ops because speaker-profile confirmation already succeeded.
+    """
+    transcript_body = _saved_transcript_body(transcript_path)
+    if not transcript_body:
+        return
+
+    json_path = output_dir / f"{meeting_stem}_summary.json"
+    md_path = output_dir / f"{meeting_stem}_summary.md"
+
+    if json_path.exists():
+        try:
+            data = json.loads(json_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as e:
+            logger.warning(f"Could not read {json_path} to update transcript: {e}")
+            return
+        embedded_body = data.get("diarised_text")
+        if not isinstance(embedded_body, str) or embedded_body.strip() != previous_transcript_body.strip():
+            return
+        if embedded_body.strip() == transcript_body:
+            return
+        data["diarised_text"] = transcript_body
+        try:
+            _atomic_write_json(json_path, data)
+        except OSError as e:
+            logger.warning(f"Could not update transcript in {json_path}: {e}")
+        return
+
+    if not md_path.exists():
+        return
+    try:
+        original = md_path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning(f"Could not read {md_path} to update transcript: {e}")
+        return
+
+    lines = original.split("\n")
+    section_start = None
+    section_end = None
+    i = 0
+    while i < len(lines):
+        match = _MD_SECTION_HEADER_RE.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        body_end = i + 1
+        while body_end < len(lines) and not _MD_SECTION_HEADER_RE.match(lines[body_end]):
+            body_end += 1
+        if match.group(1).strip().lower() == "transcript":
+            section_start, section_end = i, body_end
+            break
+        i = body_end
+
+    if section_start is None:
+        return
+    embedded_body = "\n".join(lines[section_start + 1:section_end]).strip()
+    if embedded_body != previous_transcript_body.strip():
+        return
+    new_section = ["## Transcript", "", *transcript_body.split("\n"), ""]
+    spliced = lines[:section_start] + new_section + lines[section_end:]
+    if spliced == lines:
+        return
+    try:
+        _atomic_write_text(md_path, "\n".join(spliced))
+    except OSError as e:
+        logger.warning(f"Could not update transcript in {md_path}: {e}")
 
 
 def _update_summary_participants(output_dir: Path, meeting_stem: str, participant_names: list) -> None:

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5351,6 +5351,7 @@ def confirm_speaker(
         record_original_labels,
         relabel_transcript_exact,
         relabel_transcript_speaker,
+        restore_transcript_text_labels,
     )
 
     if bool(person_id) == bool(new_person):
@@ -5435,6 +5436,10 @@ def confirm_speaker(
         }))
         sys.exit(1)
 
+    embedding, context = clusters[resolved_id]
+    fragment_ids = {resolved_id, *context.merged_from}
+    channel_recording_type = channel_data.get("recording_type")
+
     if not config.begin_transaction():
         print(json.dumps({
             "success": False,
@@ -5455,9 +5460,22 @@ def confirm_speaker(
             print(json.dumps({"success": False, "error": f"No person profile with id {person_id!r}"}))
             sys.exit(1)
 
-    embedding, context = clusters[resolved_id]
-    fragment_ids = {resolved_id, *context.merged_from}
-    channel_recording_type = channel_data.get("recording_type")
+    if relabel_transcript and sidecar.get("transcript_lines"):
+        transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+        target_ids = {(channel, sid) for sid in fragment_ids}
+        if not _reconcile_pending_summary_transcript_sync(
+            output_dir,
+            meeting_stem,
+            transcript_path,
+            target_ids,
+            person["display_name"],
+        ):
+            config.rollback_transaction()
+            print(json.dumps({
+                "success": False,
+                "error": "Could not safely reconcile a pending transcript update.",
+            }))
+            sys.exit(1)
 
     # Reassignment: if this exact cluster (or one of its merged fragments)
     # was already confirmed as someone, this confirm supersedes that -- the
@@ -5687,10 +5705,17 @@ def confirm_speaker(
                 sidecar = refreshed_sidecar
                 turn_manifest = sidecar.get("transcript_lines") or turn_manifest
             if previous_transcript_body is not None:
+                expected_transcript_body, _ = restore_transcript_text_labels(
+                    previous_transcript_body,
+                    turn_manifest,
+                    target_ids,
+                    replacement_label=person["display_name"],
+                )
                 summary_sync_ready, summary_sync_marker = _prepare_summary_transcript_sync(
                     output_dir,
                     meeting_stem,
                     previous_transcript_body,
+                    expected_transcript_body,
                     target_ids,
                     person["display_name"],
                 )
@@ -5721,9 +5746,14 @@ def confirm_speaker(
                 sync_marker=summary_sync_marker,
             )
             if summary_sync_marker is not None and sync_outcome != "io_error":
-                _clear_summary_transcript_sync(
+                if not _clear_summary_transcript_sync(
                     output_dir, meeting_stem, summary_sync_marker,
-                )
+                ):
+                    print(json.dumps({
+                        "success": False,
+                        "error": "Could not finalize the pending transcript update. Retry the confirmation.",
+                    }))
+                    sys.exit(1)
 
     # Naming the cluster supersedes "a human kept this generic": the row is
     # now decided, and leaving the marking would have the panel report a
@@ -5934,6 +5964,7 @@ def mark_speaker_cluster(
         clusters_from_sidecar_channel,
         minimum_speaker_count,
         restore_transcript_labels,
+        restore_transcript_text_labels,
         set_cluster_multi_speaker,
     )
 
@@ -5996,6 +6027,22 @@ def mark_speaker_cluster(
     fragment_ids = {diarization_speaker_id}
     if resolved_id in clusters:
         fragment_ids = {resolved_id, *clusters[resolved_id][1].merged_from}
+
+    if multiple and fragment_ids and sidecar.get("transcript_lines"):
+        transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+        restore_target_ids = {(channel, fid) for fid in fragment_ids}
+        if not _reconcile_pending_summary_transcript_sync(
+            output_dir,
+            meeting_stem,
+            transcript_path,
+            restore_target_ids,
+            None,
+        ):
+            print(json.dumps({
+                "success": False,
+                "error": "Could not safely reconcile a pending transcript update.",
+            }))
+            sys.exit(1)
 
     # Marking a cluster mixed must UNDO any name already on it, not just
     # stop future ones. Order matters: someone typically confirms a cluster
@@ -6112,10 +6159,16 @@ def mark_speaker_cluster(
         summary_sync_ready = True
         summary_sync_marker = None
         if previous_transcript_body is not None and sidecar.get("transcript_lines"):
+            expected_transcript_body, _ = restore_transcript_text_labels(
+                previous_transcript_body,
+                sidecar.get("transcript_lines") or [],
+                restore_target_ids,
+            )
             summary_sync_ready, summary_sync_marker = _prepare_summary_transcript_sync(
                 output_dir,
                 meeting_stem,
                 previous_transcript_body,
+                expected_transcript_body,
                 restore_target_ids,
                 None,
             )
@@ -6141,9 +6194,15 @@ def mark_speaker_cluster(
                 sync_marker=summary_sync_marker,
             )
             if summary_sync_marker is not None and sync_outcome != "io_error":
-                _clear_summary_transcript_sync(
+                if not _clear_summary_transcript_sync(
                     output_dir, meeting_stem, summary_sync_marker,
-                )
+                ):
+                    print(json.dumps({
+                        "success": False,
+                        "error": "Could not finalize the pending transcript update. Retry the speaker marking.",
+                        "cleared_confirmation_from": cleared_from,
+                    }))
+                    sys.exit(1)
         if summary_artifacts_ready:
             _update_summary_participants(
                 output_dir, meeting_stem,
@@ -6734,7 +6793,8 @@ def _enumerate_meeting_stems(output_dir):
 
 _MD_SECTION_HEADER_RE = re.compile(r"^## (.+?)\s*$")
 _PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY = "pending_summary_transcript_sync"
-_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION = 1
+_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION = 2
+_LEGACY_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION = 1
 
 
 def _transcript_body_hash(body: str) -> str:
@@ -6797,6 +6857,7 @@ def _prepare_summary_transcript_sync(
     output_dir: Path,
     meeting_stem: str,
     previous_transcript_body: str,
+    expected_transcript_body: str,
     target_ids: set,
     replacement_label: Optional[str],
 ) -> tuple[bool, Optional[dict]]:
@@ -6817,7 +6878,10 @@ def _prepare_summary_transcript_sync(
     if existing is not None:
         if (
             isinstance(existing, dict)
-            and existing.get("version") == _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION
+            and existing.get("version") in {
+                _LEGACY_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+                _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+            }
             and existing.get("operation_sha256") == operation_hash
         ):
             return True, existing
@@ -6839,6 +6903,7 @@ def _prepare_summary_transcript_sync(
         "summary_format": summary_format,
         "canonical_before_sha256": _transcript_body_hash(previous_transcript_body),
         "embedded_before_sha256": _transcript_body_hash(embedded_body),
+        "canonical_after_sha256": _transcript_body_hash(expected_transcript_body),
         "operation_sha256": operation_hash,
     }
 
@@ -6851,6 +6916,75 @@ def _prepare_summary_transcript_sync(
         logger.warning("Could not persist pending transcript sync for %s: %s", meeting_stem, error)
         return False, None
     return True, marker
+
+
+def _reconcile_pending_summary_transcript_sync(
+    output_dir: Path,
+    meeting_stem: str,
+    transcript_path: Path,
+    target_ids: set,
+    replacement_label: Optional[str],
+) -> bool:
+    """Clear only a proved-complete marker before a different operation.
+
+    A marker is deliberately retained after a summary I/O failure so the
+    same operation can safely retry.  It must not, however, turn a later
+    confirmation or mixed-speaker marking into a silent partial success.  A
+    completed v2 marker records the expected canonical result, so it can be
+    removed only when both artifacts exactly have that result.  Anything
+    else is either the retry itself or ambiguous and must fail closed before
+    callers mutate profiles, sidecar state, or Participants.
+    """
+    from src.speaker_sidecar_store import SpeakerSidecarStore
+
+    store = SpeakerSidecarStore(output_dir)
+    sidecar = store.read(meeting_stem)
+    if not isinstance(sidecar, dict):
+        return False
+    marker = sidecar.get(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY)
+    if marker is None:
+        return True
+
+    operation_hash = _summary_sync_operation_hash(target_ids, replacement_label)
+    transcript_body = _saved_transcript_body(transcript_path)
+    summary_format, embedded_body, io_failed = _summary_transcript_copy(
+        output_dir, meeting_stem,
+    )
+    if transcript_body is None or io_failed or summary_format is None or embedded_body is None:
+        logger.warning("Could not safely reconcile pending transcript sync for %s", meeting_stem)
+        return False
+
+    expected_after_hash = (
+        marker.get("canonical_after_sha256") if isinstance(marker, dict) else None
+    )
+    marker_is_complete = (
+        isinstance(marker, dict)
+        and marker.get("version") == _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION
+        and marker.get("summary_format") == summary_format
+        and isinstance(expected_after_hash, str)
+        and _transcript_body_hash(transcript_body) == expected_after_hash
+        and _transcript_body_hash(embedded_body) == expected_after_hash
+    )
+    if marker_is_complete:
+        if _clear_summary_transcript_sync(output_dir, meeting_stem, marker):
+            return True
+        logger.warning("Could not clear completed pending transcript sync for %s", meeting_stem)
+        return False
+
+    if (
+        isinstance(marker, dict)
+        and marker.get("version") in {
+            _LEGACY_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+            _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+        }
+        and marker.get("operation_sha256") == operation_hash
+    ):
+        # This is the exact interrupted operation.  Its later update path
+        # still verifies the original embedded hash before changing anything.
+        return True
+
+    logger.warning("Pending transcript sync for %s cannot be safely reconciled", meeting_stem)
+    return False
 
 
 def _clear_summary_transcript_sync(
@@ -6933,7 +7067,10 @@ def _update_summary_transcript(
     def _marker_allows_retry(summary_format: str, embedded_body: str) -> bool:
         return bool(
             isinstance(sync_marker, dict)
-            and sync_marker.get("version") == _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION
+            and sync_marker.get("version") in {
+                _LEGACY_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+                _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+            }
             and sync_marker.get("summary_format") == summary_format
             and sync_marker.get("operation_sha256") == expected_operation_hash
             and sync_marker.get("canonical_before_sha256")

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5439,6 +5439,11 @@ def confirm_speaker(
     embedding, context = clusters[resolved_id]
     fragment_ids = {resolved_id, *context.merged_from}
     channel_recording_type = channel_data.get("recording_type")
+    prepared_transcript_path = None
+    prepared_transcript_body = None
+    prepared_turn_manifest = None
+    prepared_relabel_target_ids = None
+    prepared_summary_sync_marker = None
 
     if not config.begin_transaction():
         print(json.dumps({
@@ -5461,12 +5466,16 @@ def confirm_speaker(
             sys.exit(1)
 
     if relabel_transcript and sidecar.get("transcript_lines"):
-        transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+        prepared_transcript_path = (
+            get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+        )
+        prepared_transcript_body = _saved_transcript_body(prepared_transcript_path)
+        prepared_turn_manifest = sidecar.get("transcript_lines")
         target_ids = {(channel, sid) for sid in fragment_ids}
         if not _reconcile_pending_summary_transcript_sync(
             output_dir,
             meeting_stem,
-            transcript_path,
+            prepared_transcript_path,
             target_ids,
             person["display_name"],
         ):
@@ -5476,6 +5485,55 @@ def confirm_speaker(
                 "error": "Could not safely reconcile a pending transcript update.",
             }))
             sys.exit(1)
+        if prepared_transcript_body is not None:
+            expected_transcript_body, _ = restore_transcript_text_labels(
+                prepared_transcript_body,
+                prepared_turn_manifest,
+                target_ids,
+                replacement_label=person["display_name"],
+            )
+            summary_sync_ready, prepared_summary_sync_marker = (
+                _prepare_summary_transcript_sync(
+                    output_dir,
+                    meeting_stem,
+                    prepared_transcript_body,
+                    expected_transcript_body,
+                    target_ids,
+                    person["display_name"],
+                )
+            )
+            if not summary_sync_ready:
+                config.rollback_transaction()
+                print(json.dumps({
+                    "success": False,
+                    "error": "Could not prepare the transcript update. Retry the confirmation.",
+                }))
+                sys.exit(1)
+
+        # Only persist reversible transcript provenance after the pending
+        # marker is durable. A marker failure must leave the sidecar, profile,
+        # transcript, summary and Participants state exactly as they were.
+        try:
+            record_original_labels(
+                output_dir,
+                meeting_stem,
+                prepared_transcript_path,
+                target_ids,
+                lock_held=True,
+            )
+        except OSError as error:
+            config.rollback_transaction()
+            logger.warning("Could not record transcript provenance for %s: %s", meeting_stem, error)
+            print(json.dumps({
+                "success": False,
+                "error": "Could not prepare the transcript update. Retry the confirmation.",
+            }))
+            sys.exit(1)
+        refreshed_sidecar = store.read(meeting_stem)
+        if isinstance(refreshed_sidecar, dict):
+            sidecar = refreshed_sidecar
+            prepared_turn_manifest = sidecar.get("transcript_lines") or prepared_turn_manifest
+        prepared_relabel_target_ids = target_ids
 
     # Reassignment: if this exact cluster (or one of its merged fragments)
     # was already confirmed as someone, this confirm supersedes that -- the
@@ -5669,61 +5727,31 @@ def confirm_speaker(
         sys.exit(1)
 
     relabeled_lines = 0
-    summary_artifacts_ready = True
     if relabel_transcript:
-        transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
-        previous_transcript_body = _saved_transcript_body(transcript_path)
-        turn_manifest = sidecar.get("transcript_lines")
-        retry_relabel_target_ids = None
-        summary_sync_ready = True
-        summary_sync_marker = None
+        transcript_path = prepared_transcript_path or (
+            get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+        )
+        previous_transcript_body = (
+            prepared_transcript_body
+            if prepared_transcript_path is not None
+            else _saved_transcript_body(transcript_path)
+        )
+        turn_manifest = prepared_turn_manifest or sidecar.get("transcript_lines")
+        retry_relabel_target_ids = prepared_relabel_target_ids
+        summary_sync_marker = prepared_summary_sync_marker
         if turn_manifest:
             # Exact recorded provenance -- immune to the fuzzy-matching
             # cross-channel/same-channel mislabeling below (see
             # relabel_transcript_exact's docstring and the plan doc's
             # Phase 8). Only meetings processed after this manifest
             # existed have one; everything else falls back.
-            target_ids = {(channel, sid) for sid in [resolved_id, *context.merged_from]}
+            target_ids = prepared_relabel_target_ids or {
+                (channel, sid) for sid in [resolved_id, *context.merged_from]
+            }
             retry_relabel_target_ids = target_ids
-            # BEFORE the rename, so the label each line carries today is
-            # still readable. Without it, naming a cluster is irreversible
-            # in the transcript and marking it as mixed later would leave
-            # the name standing. First write wins, so re-confirming (the
-            # "Change" flow) never records a person's name as the original.
-            record_original_labels(
-                output_dir,
-                meeting_stem,
-                transcript_path,
-                target_ids,
-                lock_held=True,
+            relabeled_lines = relabel_transcript_exact(
+                transcript_path, turn_manifest, target_ids, person["display_name"],
             )
-            # record_original_labels rewrites the sidecar. Refresh the manifest
-            # before persisting the pending transition so this write cannot
-            # accidentally put its pre-write copy back on disk.
-            refreshed_sidecar = store.read(meeting_stem)
-            if isinstance(refreshed_sidecar, dict):
-                sidecar = refreshed_sidecar
-                turn_manifest = sidecar.get("transcript_lines") or turn_manifest
-            if previous_transcript_body is not None:
-                expected_transcript_body, _ = restore_transcript_text_labels(
-                    previous_transcript_body,
-                    turn_manifest,
-                    target_ids,
-                    replacement_label=person["display_name"],
-                )
-                summary_sync_ready, summary_sync_marker = _prepare_summary_transcript_sync(
-                    output_dir,
-                    meeting_stem,
-                    previous_transcript_body,
-                    expected_transcript_body,
-                    target_ids,
-                    person["display_name"],
-                )
-                summary_artifacts_ready = summary_sync_ready
-            if summary_sync_ready:
-                relabeled_lines = relabel_transcript_exact(
-                    transcript_path, turn_manifest, target_ids, person["display_name"],
-                )
         else:
             raw_clusters_by_id = channel_data.get("clusters") or {}
             pooled_segments = []
@@ -5732,7 +5760,6 @@ def confirm_speaker(
             relabeled_lines = relabel_transcript_speaker(transcript_path, pooled_segments, person["display_name"])
         if (
             previous_transcript_body is not None
-            and summary_sync_ready
             and (relabeled_lines > 0 or summary_sync_marker is not None)
         ):
             sync_outcome = _update_summary_transcript(
@@ -5778,8 +5805,7 @@ def confirm_speaker(
     # gate this behind a flag) -- keeps the meeting's Participants chip in
     # sync with every confirm, including plain CLI/backfill-validation use.
     participant_names = confirmed_participant_names(meeting_stem, config.get_person_profiles())
-    if summary_artifacts_ready:
-        _update_summary_participants(output_dir, meeting_stem, participant_names)
+    _update_summary_participants(output_dir, meeting_stem, participant_names)
 
     print(json.dumps({
         "success": True,
@@ -6033,15 +6059,22 @@ def mark_speaker_cluster(
     fragment_ids = {diarization_speaker_id}
     if resolved_id in clusters:
         fragment_ids = {resolved_id, *clusters[resolved_id][1].merged_from}
+    prepared_transcript_path = None
+    prepared_transcript_body = None
+    prepared_restore_target_ids = None
+    prepared_summary_sync_marker = None
 
     if multiple and fragment_ids and sidecar.get("transcript_lines"):
-        transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
-        restore_target_ids = {(channel, fid) for fid in fragment_ids}
+        prepared_transcript_path = (
+            get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+        )
+        prepared_transcript_body = _saved_transcript_body(prepared_transcript_path)
+        prepared_restore_target_ids = {(channel, fid) for fid in fragment_ids}
         if not _reconcile_pending_summary_transcript_sync(
             output_dir,
             meeting_stem,
-            transcript_path,
-            restore_target_ids,
+            prepared_transcript_path,
+            prepared_restore_target_ids,
             None,
         ):
             print(json.dumps({
@@ -6049,6 +6082,28 @@ def mark_speaker_cluster(
                 "error": "Could not safely reconcile a pending transcript update.",
             }))
             sys.exit(1)
+        if prepared_transcript_body is not None:
+            expected_transcript_body, _ = restore_transcript_text_labels(
+                prepared_transcript_body,
+                sidecar.get("transcript_lines") or [],
+                prepared_restore_target_ids,
+            )
+            summary_sync_ready, prepared_summary_sync_marker = (
+                _prepare_summary_transcript_sync(
+                    output_dir,
+                    meeting_stem,
+                    prepared_transcript_body,
+                    expected_transcript_body,
+                    prepared_restore_target_ids,
+                    None,
+                )
+            )
+            if not summary_sync_ready:
+                print(json.dumps({
+                    "success": False,
+                    "error": "Could not prepare the transcript update. Retry the speaker marking.",
+                }))
+                sys.exit(1)
 
     # Marking a cluster mixed must UNDO any name already on it, not just
     # stop future ones. Order matters: someone typically confirms a cluster
@@ -6068,7 +6123,6 @@ def mark_speaker_cluster(
     config = get_config()
     cleared_from = []
     restored_lines = 0
-    summary_artifacts_ready = True
     if multiple and fragment_ids:
         if not config.begin_transaction():
             print(json.dumps({
@@ -6159,35 +6213,25 @@ def mark_speaker_cluster(
         # A previous attempt can commit profile cleanup and then fail its
         # sidecar write. Retrying then has no newly-cleared person to report,
         # but it must still repair the transcript and Participants section.
-        transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
-        previous_transcript_body = _saved_transcript_body(transcript_path)
-        restore_target_ids = {(channel, fid) for fid in fragment_ids}
-        summary_sync_ready = True
-        summary_sync_marker = None
-        if previous_transcript_body is not None and sidecar.get("transcript_lines"):
-            expected_transcript_body, _ = restore_transcript_text_labels(
-                previous_transcript_body,
-                sidecar.get("transcript_lines") or [],
-                restore_target_ids,
-            )
-            summary_sync_ready, summary_sync_marker = _prepare_summary_transcript_sync(
-                output_dir,
-                meeting_stem,
-                previous_transcript_body,
-                expected_transcript_body,
-                restore_target_ids,
-                None,
-            )
-            summary_artifacts_ready = summary_sync_ready
-        if summary_sync_ready:
-            restored_lines = restore_transcript_labels(
-                transcript_path,
-                sidecar.get("transcript_lines") or [],
-                restore_target_ids,
-            )
+        transcript_path = prepared_transcript_path or (
+            get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+        )
+        previous_transcript_body = (
+            prepared_transcript_body
+            if prepared_transcript_path is not None
+            else _saved_transcript_body(transcript_path)
+        )
+        restore_target_ids = prepared_restore_target_ids or {
+            (channel, fid) for fid in fragment_ids
+        }
+        summary_sync_marker = prepared_summary_sync_marker
+        restored_lines = restore_transcript_labels(
+            transcript_path,
+            sidecar.get("transcript_lines") or [],
+            restore_target_ids,
+        )
         if (
             previous_transcript_body is not None
-            and summary_sync_ready
             and (restored_lines > 0 or summary_sync_marker is not None)
         ):
             sync_outcome = _update_summary_transcript(
@@ -6215,11 +6259,10 @@ def mark_speaker_cluster(
                         "cleared_confirmation_from": cleared_from,
                     }))
                     sys.exit(1)
-        if summary_artifacts_ready:
-            _update_summary_participants(
-                output_dir, meeting_stem,
-                confirmed_participant_names(meeting_stem, config.get_person_profiles()),
-            )
+        _update_summary_participants(
+            output_dir, meeting_stem,
+            confirmed_participant_names(meeting_stem, config.get_person_profiles()),
+        )
 
     print(json.dumps({
         "success": True,

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5654,6 +5654,7 @@ def confirm_speaker(
         transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
         previous_transcript_body = _saved_transcript_body(transcript_path)
         turn_manifest = sidecar.get("transcript_lines")
+        retry_relabel_target_ids = None
         if turn_manifest:
             # Exact recorded provenance -- immune to the fuzzy-matching
             # cross-channel/same-channel mislabeling below (see
@@ -5661,6 +5662,7 @@ def confirm_speaker(
             # Phase 8). Only meetings processed after this manifest
             # existed have one; everything else falls back.
             target_ids = {(channel, sid) for sid in [resolved_id, *context.merged_from]}
+            retry_relabel_target_ids = target_ids
             # BEFORE the rename, so the label each line carries today is
             # still readable. Without it, naming a cluster is irreversible
             # in the transcript and marking it as mixed later would leave
@@ -5682,13 +5684,28 @@ def confirm_speaker(
             for fragment_id in [resolved_id, *context.merged_from]:
                 pooled_segments.extend(raw_clusters_by_id.get(fragment_id, {}).get("segments") or [])
             relabeled_lines = relabel_transcript_speaker(transcript_path, pooled_segments, person["display_name"])
-        if relabeled_lines > 0 and previous_transcript_body is not None:
-            _update_summary_transcript(
-                output_dir,
-                meeting_stem,
-                transcript_path,
-                previous_transcript_body,
-            )
+        if previous_transcript_body is not None:
+            if relabeled_lines > 0:
+                _update_summary_transcript(
+                    output_dir,
+                    meeting_stem,
+                    transcript_path,
+                    previous_transcript_body,
+                )
+            elif turn_manifest and retry_relabel_target_ids:
+                # The transcript can be durable while its best-effort summary
+                # write fails. A same-cluster confirmation retry has no newly
+                # relabelled lines, but may safely repair a matching embedded
+                # copy only through exact manifest provenance.
+                _update_summary_transcript(
+                    output_dir,
+                    meeting_stem,
+                    transcript_path,
+                    previous_transcript_body,
+                    restore_manifest=turn_manifest,
+                    restore_target_ids=retry_relabel_target_ids,
+                    retry_relabel_to=person["display_name"],
+                )
 
     # Naming the cluster supersedes "a human kept this generic": the row is
     # now decided, and leaving the marking would have the panel report a
@@ -6076,13 +6093,28 @@ def mark_speaker_cluster(
             sidecar.get("transcript_lines") or [],
             {(channel, fid) for fid in fragment_ids},
         )
-        if restored_lines > 0 and previous_transcript_body is not None:
-            _update_summary_transcript(
-                output_dir,
-                meeting_stem,
-                transcript_path,
-                previous_transcript_body,
-            )
+        if previous_transcript_body is not None:
+            # A prior attempt can have restored the canonical transcript and
+            # then lost the best-effort summary write.  Its retry sees no
+            # newly restored lines, but the old person label can still be in
+            # the summary's embedded transcript.  Repair just labels whose
+            # provenance matches this cluster; never replace user text.
+            if restored_lines > 0:
+                _update_summary_transcript(
+                    output_dir,
+                    meeting_stem,
+                    transcript_path,
+                    previous_transcript_body,
+                )
+            else:
+                _update_summary_transcript(
+                    output_dir,
+                    meeting_stem,
+                    transcript_path,
+                    previous_transcript_body,
+                    restore_manifest=sidecar.get("transcript_lines") or [],
+                    restore_target_ids={(channel, fid) for fid in fragment_ids},
+                )
         _update_summary_participants(
             output_dir, meeting_stem,
             confirmed_participant_names(meeting_stem, config.get_person_profiles()),
@@ -6700,19 +6732,38 @@ def _update_summary_transcript(
     meeting_stem: str,
     transcript_path: Path,
     previous_transcript_body: str,
+    restore_manifest: Optional[list] = None,
+    restore_target_ids: Optional[set] = None,
+    retry_relabel_to: Optional[str] = None,
 ) -> None:
     """Keep a summary's embedded diarised transcript aligned after naming.
 
     The separate transcript is the relabel operation's canonical artifact. An
     embedded copy is replaced only when it still exactly matches the canonical
     body from before relabeling. A user-edited or independently redacted copy is
-    preserved. JSON remains preferred when both summary formats exist, matching
-    the rest of the meeting-store code. Missing or unreadable artifacts are
-    best-effort no-ops because speaker-profile confirmation already succeeded.
+    preserved. When a prior attempt restored the canonical transcript but its
+    summary write failed, a provenance-checked label-only repair can bring the
+    embedded copy forward without replacing its text. JSON remains preferred
+    when both summary formats exist, matching the rest of the meeting-store
+    code. Missing or unreadable artifacts are best-effort no-ops because
+    speaker-profile confirmation already succeeded.
     """
     transcript_body = _saved_transcript_body(transcript_path)
     if not transcript_body:
         return
+
+    def _repair_embedded_labels(embedded_body: str) -> tuple[str, int]:
+        if restore_manifest is None or restore_target_ids is None:
+            return embedded_body, 0
+        from src.speaker_suggestions import restore_transcript_text_labels
+
+        return restore_transcript_text_labels(
+            embedded_body,
+            restore_manifest,
+            restore_target_ids,
+            require_unique_target_timestamps=True,
+            replacement_label=retry_relabel_to,
+        )
 
     json_path = output_dir / f"{meeting_stem}_summary.json"
     md_path = output_dir / f"{meeting_stem}_summary.md"
@@ -6724,11 +6775,23 @@ def _update_summary_transcript(
             logger.warning(f"Could not read {json_path} to update transcript: {e}")
             return
         embedded_body = data.get("diarised_text")
-        if not isinstance(embedded_body, str) or embedded_body.strip() != previous_transcript_body.strip():
+        if not isinstance(embedded_body, str):
             return
-        if embedded_body.strip() == transcript_body:
+        if embedded_body.strip() == previous_transcript_body.strip():
+            replacement_body = transcript_body
+            repaired_labels = False
+        elif restore_manifest is not None and restore_target_ids is not None:
+            replacement_body, restored_lines = _repair_embedded_labels(embedded_body)
+            if restored_lines == 0:
+                return
+            repaired_labels = True
+        else:
             return
-        data["diarised_text"] = transcript_body
+        if repaired_labels and replacement_body.strip() != transcript_body:
+            return
+        if replacement_body.strip() == embedded_body.strip():
+            return
+        data["diarised_text"] = replacement_body
         try:
             _atomic_write_json(json_path, data)
         except OSError as e:
@@ -6763,9 +6826,21 @@ def _update_summary_transcript(
     if section_start is None:
         return
     embedded_body = "\n".join(lines[section_start + 1:section_end]).strip()
-    if embedded_body != previous_transcript_body.strip():
+    if embedded_body == previous_transcript_body.strip():
+        replacement_body = transcript_body
+        repaired_labels = False
+    elif restore_manifest is not None and restore_target_ids is not None:
+        replacement_body, restored_lines = _repair_embedded_labels(embedded_body)
+        if restored_lines == 0:
+            return
+        repaired_labels = True
+    else:
         return
-    new_section = ["## Transcript", "", *transcript_body.split("\n"), ""]
+    if repaired_labels and replacement_body.strip() != transcript_body:
+        return
+    if replacement_body.strip() == embedded_body:
+        return
+    new_section = ["## Transcript", "", *replacement_body.split("\n"), ""]
     spliced = lines[:section_start] + new_section + lines[section_end:]
     if spliced == lines:
         return

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5454,10 +5454,11 @@ def confirm_speaker(
             "error": "Could not lock the person profile store.",
         }))
         sys.exit(1)
-    if new_person:
-        try:
+    target_ids = {(channel, sid) for sid in fragment_ids}
+    try:
+        if new_person:
             normalized_new_person = validate_display_name(new_person)
-            person = (
+            retry_person = (
                 _pending_new_person_confirmation_retry(
                     config.get_person_profiles(),
                     sidecar,
@@ -5471,6 +5472,47 @@ def confirm_speaker(
                 if relabel_transcript
                 else None
             )
+            selected_person = None
+            intended_display_name = normalized_new_person
+        else:
+            retry_person = None
+            selected_person = config.get_person_profile(person_id)
+            if selected_person is None:
+                config.rollback_transaction()
+                print(json.dumps({
+                    "success": False,
+                    "error": f"No person profile with id {person_id!r}",
+                }))
+                sys.exit(1)
+            intended_display_name = validate_display_name(
+                selected_person.get("display_name"),
+            )
+    except ValueError as error:
+        config.rollback_transaction()
+        print(json.dumps({"success": False, "error": str(error)}))
+        sys.exit(1)
+
+    pending_transcript_path = (
+        get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+    )
+    if not _reconcile_pending_summary_transcript_sync(
+        output_dir,
+        meeting_stem,
+        pending_transcript_path,
+        target_ids,
+        intended_display_name,
+        allow_operation_retry=relabel_transcript,
+    ):
+        config.rollback_transaction()
+        print(json.dumps({
+            "success": False,
+            "error": "Could not safely reconcile a pending transcript update.",
+        }))
+        sys.exit(1)
+
+    if new_person:
+        try:
+            person = retry_person
             if person is None:
                 person = config.create_person_profile(normalized_new_person)
         except ValueError as e:
@@ -5478,11 +5520,7 @@ def confirm_speaker(
             print(json.dumps({"success": False, "error": str(e)}))
             sys.exit(1)
     else:
-        person = config.get_person_profile(person_id)
-        if person is None:
-            config.rollback_transaction()
-            print(json.dumps({"success": False, "error": f"No person profile with id {person_id!r}"}))
-            sys.exit(1)
+        person = selected_person
 
     if relabel_transcript:
         prepared_transcript_path = (
@@ -5499,20 +5537,6 @@ def confirm_speaker(
             }))
             sys.exit(1)
         prepared_turn_manifest = sidecar.get("transcript_lines")
-        target_ids = {(channel, sid) for sid in fragment_ids}
-        if not _reconcile_pending_summary_transcript_sync(
-            output_dir,
-            meeting_stem,
-            prepared_transcript_path,
-            target_ids,
-            person["display_name"],
-        ):
-            config.rollback_transaction()
-            print(json.dumps({
-                "success": False,
-                "error": "Could not safely reconcile a pending transcript update.",
-            }))
-            sys.exit(1)
         if prepared_transcript_body is not None:
             if prepared_turn_manifest:
                 expected_transcript_body, _ = restore_transcript_text_labels(
@@ -6073,6 +6097,7 @@ def mark_speaker_cluster(
     nothing consumes that number yet.
     """
     from src.config import get_config, get_data_dirs
+    from src.speaker_schema import validate_display_name
     from src.speaker_sidecar_store import SpeakerSidecarStore, StaleDiarizationRun
     from src.speaker_suggestions import (
         clear_cluster_review_state,
@@ -6080,7 +6105,11 @@ def mark_speaker_cluster(
         merge_same_channel_fragments,
         clusters_from_sidecar_channel,
         minimum_speaker_count,
+        prototype_channel_matches,
+        prototype_run_matches,
         restore_transcript_labels,
+        restore_transcript_speaker_labels,
+        restore_transcript_text_speaker,
         restore_transcript_text_labels,
         set_cluster_multi_speaker,
     )
@@ -6150,8 +6179,69 @@ def mark_speaker_cluster(
     prepared_summary_sync_marker = None
     summary_sync_outcome = None
     review_state_cleared = True
+    config = get_config()
+    legacy_display_names = set()
+    try:
+        profiles = config.get_person_profiles()
+        for person in profiles:
+            if not any(
+                prototype.get("meeting_id") == meeting_stem
+                and prototype.get("diarization_speaker_id") in fragment_ids
+                and prototype_channel_matches(
+                    prototype, channel, channel_recording_type,
+                )
+                and prototype_run_matches(prototype, run_id)
+                for prototype in person.get("prototypes") or []
+            ):
+                continue
+            legacy_display_names.add(validate_display_name(person.get("display_name")))
+    except ValueError as error:
+        print(json.dumps({"success": False, "error": str(error)}))
+        sys.exit(1)
+    pending_marker = sidecar.get(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY)
+    legacy_target_ids = {(channel, fid) for fid in fragment_ids}
+    if (
+        not sidecar.get("transcript_lines")
+        and isinstance(pending_marker, dict)
+        and pending_marker.get("recovery_mode") == "whole_copy"
+        and pending_marker.get("operation_sha256")
+        == _summary_sync_operation_hash(legacy_target_ids, None)
+    ):
+        label_hashes = pending_marker.get("legacy_label_sha256s")
+        if not isinstance(label_hashes, list) or not all(
+            isinstance(label_hash, str) for label_hash in label_hashes
+        ):
+            print(json.dumps({
+                "success": False,
+                "error": "Could not safely recover the speaker marking.",
+            }))
+            sys.exit(1)
+        unresolved_hashes = set(label_hashes)
+        for person in profiles:
+            try:
+                display_name = validate_display_name(person.get("display_name"))
+            except ValueError:
+                continue
+            display_name_hash = hashlib.sha256(
+                display_name.encode("utf-8"),
+            ).hexdigest()
+            if display_name_hash in unresolved_hashes:
+                legacy_display_names.add(display_name)
+                unresolved_hashes.remove(display_name_hash)
+        if unresolved_hashes:
+            print(json.dumps({
+                "success": False,
+                "error": "Could not safely recover the speaker marking.",
+            }))
+            sys.exit(1)
+    raw_clusters_by_id = channel_data.get("clusters") or {}
+    pooled_segments = [
+        segment
+        for fragment_id in fragment_ids
+        for segment in raw_clusters_by_id.get(fragment_id, {}).get("segments") or []
+    ]
 
-    if multiple and fragment_ids and sidecar.get("transcript_lines"):
+    if multiple and fragment_ids:
         prepared_transcript_path = (
             get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
         )
@@ -6164,31 +6254,47 @@ def mark_speaker_cluster(
                 "error": "Could not read the transcript. Retry the speaker marking.",
             }))
             sys.exit(1)
-        if prepared_transcript_body is None:
-            print(json.dumps({
-                "success": False,
-                "error": "The transcript is missing. Restore it before marking the speaker.",
-            }))
-            sys.exit(1)
         prepared_restore_target_ids = {(channel, fid) for fid in fragment_ids}
-        if not _reconcile_pending_summary_transcript_sync(
-            output_dir,
-            meeting_stem,
-            prepared_transcript_path,
-            prepared_restore_target_ids,
-            None,
-        ):
-            print(json.dumps({
-                "success": False,
-                "error": "Could not safely reconcile a pending transcript update.",
-            }))
-            sys.exit(1)
-        if prepared_transcript_body is not None:
-            expected_transcript_body, _ = restore_transcript_text_labels(
-                prepared_transcript_body,
-                sidecar.get("transcript_lines") or [],
-                prepared_restore_target_ids,
+        if prepared_transcript_body is None:
+            _summary_format, embedded_body, summary_read_failed = (
+                _summary_transcript_copy(output_dir, meeting_stem)
             )
+            if (
+                sidecar.get("transcript_lines")
+                or sidecar.get(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY) is not None
+                or summary_read_failed
+                or embedded_body is not None
+            ):
+                print(json.dumps({
+                    "success": False,
+                    "error": "The transcript is missing. Restore it before marking the speaker.",
+                }))
+                sys.exit(1)
+        else:
+            if not _reconcile_pending_summary_transcript_sync(
+                output_dir,
+                meeting_stem,
+                prepared_transcript_path,
+                prepared_restore_target_ids,
+                None,
+            ):
+                print(json.dumps({
+                    "success": False,
+                    "error": "Could not safely reconcile a pending transcript update.",
+                }))
+                sys.exit(1)
+            if sidecar.get("transcript_lines"):
+                expected_transcript_body, _ = restore_transcript_text_labels(
+                    prepared_transcript_body,
+                    sidecar.get("transcript_lines") or [],
+                    prepared_restore_target_ids,
+                )
+            else:
+                expected_transcript_body, _ = restore_transcript_text_speaker(
+                    prepared_transcript_body,
+                    pooled_segments,
+                    legacy_display_names,
+                )
             summary_sync_ready, prepared_summary_sync_marker = (
                 _prepare_summary_transcript_sync(
                     output_dir,
@@ -6197,6 +6303,12 @@ def mark_speaker_cluster(
                     expected_transcript_body,
                     prepared_restore_target_ids,
                     None,
+                    whole_copy_retry=not bool(sidecar.get("transcript_lines")),
+                    legacy_recovery_labels=(
+                        legacy_display_names
+                        if not sidecar.get("transcript_lines")
+                        else None
+                    ),
                 )
             )
             if not summary_sync_ready:
@@ -6221,7 +6333,6 @@ def mark_speaker_cluster(
     # only ever recorded because this cluster was believed to be that
     # person, and a negative derived from a blended voice is wrong in both
     # directions.
-    config = get_config()
     cleared_from = []
     restored_lines = 0
     if multiple and fragment_ids:
@@ -6330,11 +6441,18 @@ def mark_speaker_cluster(
         }
         summary_sync_marker = prepared_summary_sync_marker
         try:
-            restored_lines = restore_transcript_labels(
-                transcript_path,
-                sidecar.get("transcript_lines") or [],
-                restore_target_ids,
-            )
+            if sidecar.get("transcript_lines"):
+                restored_lines = restore_transcript_labels(
+                    transcript_path,
+                    sidecar.get("transcript_lines") or [],
+                    restore_target_ids,
+                )
+            else:
+                restored_lines = restore_transcript_speaker_labels(
+                    transcript_path,
+                    pooled_segments,
+                    legacy_display_names,
+                )
         except OSError:
             logger.warning("Could not update canonical transcript during speaker marking")
             print(json.dumps({
@@ -7061,7 +7179,10 @@ def _pending_new_person_confirmation_retry(
     target_ids = {(channel, fragment_id) for fragment_id in fragment_ids}
     if not (
         isinstance(marker, dict)
-        and marker.get("version") == _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION
+        and marker.get("version") in {
+            _LEGACY_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+            _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+        }
         and marker.get("operation_sha256")
         == _summary_sync_operation_hash(target_ids, display_name)
     ):
@@ -7091,6 +7212,7 @@ def _prepare_summary_transcript_sync(
     replacement_label: Optional[str],
     *,
     whole_copy_retry: bool = False,
+    legacy_recovery_labels: Optional[set] = None,
 ) -> tuple[bool, Optional[dict]]:
     """Persist exact pre-write provenance for an interrupted operation.
 
@@ -7099,6 +7221,8 @@ def _prepare_summary_transcript_sync(
     lock, before either transcript artifact changes. The operation identity is
     durable even when the Summary is absent or already divergent, so a failed
     canonical write can still retry the exact committed profile operation.
+    Legacy fuzzy marking stores only hashes of withdrawn profile labels, enough
+    to recover them after the first attempt has removed their prototypes.
     """
     from src.speaker_sidecar_store import SpeakerSidecarStore, StaleDiarizationRun
 
@@ -7127,6 +7251,7 @@ def _prepare_summary_transcript_sync(
 
     marker = {
         "version": _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+        "target_ids": sorted([list(target_id) for target_id in target_ids]),
         "summary_format": summary_format,
         "canonical_before_sha256": _transcript_body_hash(previous_transcript_body),
         "embedded_before_sha256": (
@@ -7138,6 +7263,11 @@ def _prepare_summary_transcript_sync(
     }
     if whole_copy_retry:
         marker["recovery_mode"] = "whole_copy"
+    if legacy_recovery_labels is not None:
+        marker["legacy_label_sha256s"] = sorted(
+            hashlib.sha256(label.encode("utf-8")).hexdigest()
+            for label in legacy_recovery_labels
+        )
 
     def persist(document):
         document[_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY] = marker
@@ -7150,12 +7280,35 @@ def _prepare_summary_transcript_sync(
     return True, marker
 
 
+def _marker_review_state_is_clear(sidecar: dict, marker: dict) -> bool:
+    """Verify every review target recorded by a pending v2 operation."""
+    raw_target_ids = marker.get("target_ids")
+    if not isinstance(raw_target_ids, list) or not raw_target_ids:
+        return False
+    targets_by_channel = {}
+    for target_id in raw_target_ids:
+        if (
+            not isinstance(target_id, list)
+            or len(target_id) != 2
+            or not all(isinstance(value, str) and value for value in target_id)
+        ):
+            return False
+        channel, speaker_id = target_id
+        targets_by_channel.setdefault(channel, set()).add(speaker_id)
+    return all(
+        _cluster_review_state_is_clear(sidecar, channel, speaker_ids)
+        for channel, speaker_ids in targets_by_channel.items()
+    )
+
+
 def _reconcile_pending_summary_transcript_sync(
     output_dir: Path,
     meeting_stem: str,
     transcript_path: Path,
     target_ids: set,
     replacement_label: Optional[str],
+    *,
+    allow_operation_retry: bool = True,
 ) -> bool:
     """Clear only a proved-complete marker before a different operation.
 
@@ -7184,7 +7337,8 @@ def _reconcile_pending_summary_transcript_sync(
         return False
 
     if (
-        isinstance(marker, dict)
+        allow_operation_retry
+        and isinstance(marker, dict)
         and marker.get("version") in {
             _LEGACY_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
             _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
@@ -7213,6 +7367,7 @@ def _reconcile_pending_summary_transcript_sync(
         and isinstance(expected_after_hash, str)
         and _transcript_body_hash(transcript_body) == expected_after_hash
         and _transcript_body_hash(embedded_body) == expected_after_hash
+        and _marker_review_state_is_clear(sidecar, marker)
     )
     if marker_is_complete:
         if _clear_summary_transcript_sync(output_dir, meeting_stem, marker):

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -6069,11 +6069,20 @@ def mark_speaker_cluster(
         # A previous attempt can commit profile cleanup and then fail its
         # sidecar write. Retrying then has no newly-cleared person to report,
         # but it must still repair the transcript and Participants section.
+        transcript_path = get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
+        previous_transcript_body = _saved_transcript_body(transcript_path)
         restored_lines = restore_transcript_labels(
-            get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt",
+            transcript_path,
             sidecar.get("transcript_lines") or [],
             {(channel, fid) for fid in fragment_ids},
         )
+        if restored_lines > 0 and previous_transcript_body is not None:
+            _update_summary_transcript(
+                output_dir,
+                meeting_stem,
+                transcript_path,
+                previous_transcript_body,
+            )
         _update_summary_participants(
             output_dir, meeting_stem,
             confirmed_participant_names(meeting_stem, config.get_person_profiles()),

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5352,6 +5352,7 @@ def confirm_speaker(
         record_original_labels,
         relabel_transcript_exact,
         relabel_transcript_speaker,
+        relabel_transcript_text_speaker,
         restore_transcript_text_labels,
     )
 
@@ -5445,6 +5446,7 @@ def confirm_speaker(
     prepared_turn_manifest = None
     prepared_relabel_target_ids = None
     prepared_summary_sync_marker = None
+    summary_sync_outcome = None
 
     if not config.begin_transaction():
         print(json.dumps({
@@ -5482,7 +5484,7 @@ def confirm_speaker(
             print(json.dumps({"success": False, "error": f"No person profile with id {person_id!r}"}))
             sys.exit(1)
 
-    if relabel_transcript and sidecar.get("transcript_lines"):
+    if relabel_transcript:
         prepared_transcript_path = (
             get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
         )
@@ -5512,12 +5514,27 @@ def confirm_speaker(
             }))
             sys.exit(1)
         if prepared_transcript_body is not None:
-            expected_transcript_body, _ = restore_transcript_text_labels(
-                prepared_transcript_body,
-                prepared_turn_manifest,
-                target_ids,
-                replacement_label=person["display_name"],
-            )
+            if prepared_turn_manifest:
+                expected_transcript_body, _ = restore_transcript_text_labels(
+                    prepared_transcript_body,
+                    prepared_turn_manifest,
+                    target_ids,
+                    replacement_label=person["display_name"],
+                )
+            else:
+                raw_clusters_by_id = channel_data.get("clusters") or {}
+                pooled_segments = [
+                    segment
+                    for fragment_id in [resolved_id, *context.merged_from]
+                    for segment in (
+                        raw_clusters_by_id.get(fragment_id, {}).get("segments") or []
+                    )
+                ]
+                expected_transcript_body, _ = relabel_transcript_text_speaker(
+                    prepared_transcript_body,
+                    pooled_segments,
+                    person["display_name"],
+                )
             summary_sync_ready, prepared_summary_sync_marker = (
                 _prepare_summary_transcript_sync(
                     output_dir,
@@ -5526,6 +5543,7 @@ def confirm_speaker(
                     expected_transcript_body,
                     target_ids,
                     person["display_name"],
+                    whole_copy_retry=not bool(prepared_turn_manifest),
                 )
             )
             if not summary_sync_ready:
@@ -5536,29 +5554,36 @@ def confirm_speaker(
                 }))
                 sys.exit(1)
 
-        # Only persist reversible transcript provenance after the pending
-        # marker is durable. A marker failure must leave the sidecar, profile,
-        # transcript, summary and Participants state exactly as they were.
-        try:
-            record_original_labels(
-                output_dir,
-                meeting_stem,
-                prepared_transcript_path,
-                target_ids,
-                lock_held=True,
-            )
-        except OSError as error:
-            config.rollback_transaction()
-            logger.warning("Could not record transcript provenance for %s: %s", meeting_stem, error)
-            print(json.dumps({
-                "success": False,
-                "error": "Could not prepare the transcript update. Retry the confirmation.",
-            }))
-            sys.exit(1)
-        refreshed_sidecar = store.read(meeting_stem)
-        if isinstance(refreshed_sidecar, dict):
-            sidecar = refreshed_sidecar
-            prepared_turn_manifest = sidecar.get("transcript_lines") or prepared_turn_manifest
+        if prepared_turn_manifest:
+            # Only persist reversible transcript provenance after the pending
+            # marker is durable. A marker failure must leave the sidecar,
+            # profile, transcript, summary and Participants state unchanged.
+            try:
+                record_original_labels(
+                    output_dir,
+                    meeting_stem,
+                    prepared_transcript_path,
+                    target_ids,
+                    lock_held=True,
+                )
+            except OSError as error:
+                config.rollback_transaction()
+                logger.warning(
+                    "Could not record transcript provenance for %s: %s",
+                    meeting_stem,
+                    error,
+                )
+                print(json.dumps({
+                    "success": False,
+                    "error": "Could not prepare the transcript update. Retry the confirmation.",
+                }))
+                sys.exit(1)
+            refreshed_sidecar = store.read(meeting_stem)
+            if isinstance(refreshed_sidecar, dict):
+                sidecar = refreshed_sidecar
+                prepared_turn_manifest = (
+                    sidecar.get("transcript_lines") or prepared_turn_manifest
+                )
         prepared_relabel_target_ids = target_ids
 
     # Reassignment: if this exact cluster (or one of its merged fragments)
@@ -5810,21 +5835,7 @@ def confirm_speaker(
                 retry_relabel_to=person["display_name"],
                 sync_marker=summary_sync_marker,
             )
-            if summary_sync_marker is not None:
-                finalization_failure = _finalize_summary_transcript_sync(
-                    output_dir, meeting_stem, summary_sync_marker, sync_outcome,
-                )
-                if finalization_failure is not None:
-                    errors = {
-                        "io_error": "Could not update the summary transcript. Retry the confirmation.",
-                        "unsafe": "Could not safely update the summary transcript. Retry the confirmation.",
-                        "clear_error": "Could not finalize the pending transcript update. Retry the confirmation.",
-                    }
-                    print(json.dumps({
-                        "success": False,
-                        "error": errors[finalization_failure],
-                    }))
-                    sys.exit(1)
+            summary_sync_outcome = sync_outcome
 
     # Naming the cluster supersedes "a human kept this generic": the row is
     # now decided, and leaving the marking would have the panel report a
@@ -5838,12 +5849,48 @@ def confirm_speaker(
         current_run_token,
         lock_held=True,
     )
+    review_state_cleared = _cluster_review_state_is_clear(
+        store.read(meeting_stem), channel, fragment_ids,
+    )
 
     # Cheap and always-safe (unlike transcript relabeling, no reason to
     # gate this behind a flag) -- keeps the meeting's Participants chip in
     # sync with every confirm, including plain CLI/backfill-validation use.
     participant_names = confirmed_participant_names(meeting_stem, config.get_person_profiles())
-    _update_summary_participants(output_dir, meeting_stem, participant_names)
+    participants_updated = _update_summary_participants(
+        output_dir, meeting_stem, participant_names,
+    )
+
+    if prepared_summary_sync_marker is not None:
+        if not review_state_cleared:
+            print(json.dumps({
+                "success": False,
+                "error": "Could not clear the speaker review state. Retry the confirmation.",
+            }))
+            sys.exit(1)
+        if not participants_updated:
+            print(json.dumps({
+                "success": False,
+                "error": "Could not update summary participants. Retry the confirmation.",
+            }))
+            sys.exit(1)
+        finalization_failure = _finalize_summary_transcript_sync(
+            output_dir,
+            meeting_stem,
+            prepared_summary_sync_marker,
+            summary_sync_outcome or "unsafe",
+        )
+        if finalization_failure is not None:
+            errors = {
+                "io_error": "Could not update the summary transcript. Retry the confirmation.",
+                "unsafe": "Could not safely update the summary transcript. Retry the confirmation.",
+                "clear_error": "Could not finalize the pending transcript update. Retry the confirmation.",
+            }
+            print(json.dumps({
+                "success": False,
+                "error": errors[finalization_failure],
+            }))
+            sys.exit(1)
 
     print(json.dumps({
         "success": True,
@@ -6101,6 +6148,8 @@ def mark_speaker_cluster(
     prepared_transcript_body = None
     prepared_restore_target_ids = None
     prepared_summary_sync_marker = None
+    summary_sync_outcome = None
+    review_state_cleared = True
 
     if multiple and fragment_ids and sidecar.get("transcript_lines"):
         prepared_transcript_path = (
@@ -6261,6 +6310,9 @@ def mark_speaker_cluster(
             current_run_token,
             lock_held=True,
         )
+        review_state_cleared = _cluster_review_state_is_clear(
+            store.read(meeting_stem), channel, fragment_ids,
+        )
         # Derive the readable artefacts from durable state on every attempt.
         # A previous attempt can commit profile cleanup and then fail its
         # sidecar write. Retrying then has no newly-cleared person to report,
@@ -6304,26 +6356,44 @@ def mark_speaker_cluster(
                 restore_target_ids=restore_target_ids,
                 sync_marker=summary_sync_marker,
             )
-            if summary_sync_marker is not None:
-                finalization_failure = _finalize_summary_transcript_sync(
-                    output_dir, meeting_stem, summary_sync_marker, sync_outcome,
-                )
-                if finalization_failure is not None:
-                    errors = {
-                        "io_error": "Could not update the summary transcript. Retry the speaker marking.",
-                        "unsafe": "Could not safely update the summary transcript. Retry the speaker marking.",
-                        "clear_error": "Could not finalize the pending transcript update. Retry the speaker marking.",
-                    }
-                    print(json.dumps({
-                        "success": False,
-                        "error": errors[finalization_failure],
-                        "cleared_confirmation_from": cleared_from,
-                    }))
-                    sys.exit(1)
-        _update_summary_participants(
+            summary_sync_outcome = sync_outcome
+        participants_updated = _update_summary_participants(
             output_dir, meeting_stem,
             confirmed_participant_names(meeting_stem, config.get_person_profiles()),
         )
+        if prepared_summary_sync_marker is not None:
+            if not review_state_cleared:
+                print(json.dumps({
+                    "success": False,
+                    "error": "Could not clear the speaker review state. Retry the speaker marking.",
+                    "cleared_confirmation_from": cleared_from,
+                }))
+                sys.exit(1)
+            if not participants_updated:
+                print(json.dumps({
+                    "success": False,
+                    "error": "Could not update summary participants. Retry the speaker marking.",
+                    "cleared_confirmation_from": cleared_from,
+                }))
+                sys.exit(1)
+            finalization_failure = _finalize_summary_transcript_sync(
+                output_dir,
+                meeting_stem,
+                prepared_summary_sync_marker,
+                summary_sync_outcome or "unsafe",
+            )
+            if finalization_failure is not None:
+                errors = {
+                    "io_error": "Could not update the summary transcript. Retry the speaker marking.",
+                    "unsafe": "Could not safely update the summary transcript. Retry the speaker marking.",
+                    "clear_error": "Could not finalize the pending transcript update. Retry the speaker marking.",
+                }
+                print(json.dumps({
+                    "success": False,
+                    "error": errors[finalization_failure],
+                    "cleared_confirmation_from": cleared_from,
+                }))
+                sys.exit(1)
 
     print(json.dumps({
         "success": True,
@@ -7019,6 +7089,8 @@ def _prepare_summary_transcript_sync(
     expected_transcript_body: str,
     target_ids: set,
     replacement_label: Optional[str],
+    *,
+    whole_copy_retry: bool = False,
 ) -> tuple[bool, Optional[dict]]:
     """Persist exact pre-write provenance for an interrupted operation.
 
@@ -7064,6 +7136,8 @@ def _prepare_summary_transcript_sync(
         "canonical_after_sha256": _transcript_body_hash(expected_transcript_body),
         "operation_sha256": operation_hash,
     }
+    if whole_copy_retry:
+        marker["recovery_mode"] = "whole_copy"
 
     def persist(document):
         document[_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY] = marker
@@ -7175,6 +7249,26 @@ def _clear_summary_transcript_sync(
     return True
 
 
+def _cluster_review_state_is_clear(
+    sidecar: Optional[dict],
+    channel: str,
+    diarization_speaker_ids: set,
+) -> bool:
+    """Verify that every raw cluster in a completed merged-row action is clear."""
+    if not isinstance(sidecar, dict):
+        return False
+    channels = sidecar.get("channels")
+    channel_data = channels.get(channel) if isinstance(channels, dict) else None
+    clusters = channel_data.get("clusters") if isinstance(channel_data, dict) else None
+    if not isinstance(clusters, dict):
+        return False
+    for speaker_id in diarization_speaker_ids:
+        cluster = clusters.get(speaker_id)
+        if not isinstance(cluster, dict) or cluster.get("review_state") is not None:
+            return False
+    return True
+
+
 def _finalize_summary_transcript_sync(
     output_dir: Path,
     meeting_stem: str,
@@ -7274,6 +7368,17 @@ def _update_summary_transcript(
             == _transcript_body_hash(embedded_body)
         )
 
+    def _marker_allows_whole_copy_retry(
+        summary_format: str,
+        embedded_body: str,
+    ) -> bool:
+        return bool(
+            _marker_allows_retry(summary_format, embedded_body)
+            and sync_marker.get("recovery_mode") == "whole_copy"
+            and sync_marker.get("canonical_after_sha256")
+            == _transcript_body_hash(transcript_body)
+        )
+
     def _repair_embedded_labels(embedded_body: str) -> tuple[str, int]:
         if restore_manifest is None or restore_target_ids is None:
             return embedded_body, 0
@@ -7302,6 +7407,9 @@ def _update_summary_transcript(
         if embedded_body == transcript_body:
             return "complete"
         if embedded_body == previous_transcript_body:
+            replacement_body = transcript_body
+            repaired_labels = False
+        elif _marker_allows_whole_copy_retry("json", embedded_body):
             replacement_body = transcript_body
             repaired_labels = False
         elif (
@@ -7360,6 +7468,9 @@ def _update_summary_transcript(
     if embedded_body == previous_transcript_body:
         replacement_body = transcript_body
         repaired_labels = False
+    elif _marker_allows_whole_copy_retry("md", embedded_body):
+        replacement_body = transcript_body
+        repaired_labels = False
     elif (
         restore_manifest is not None
         and restore_target_ids is not None
@@ -7387,7 +7498,11 @@ def _update_summary_transcript(
     return "updated"
 
 
-def _update_summary_participants(output_dir: Path, meeting_stem: str, participant_names: list) -> None:
+def _update_summary_participants(
+    output_dir: Path,
+    meeting_stem: str,
+    participant_names: list,
+) -> bool:
     """Overwrite {meeting_stem}_summary.{json,md}'s participants with
     `participant_names` (a full replace, not an append -- so a later
     Change/rename/delete on the person-profile side stays in sync the next
@@ -7395,7 +7510,8 @@ def _update_summary_participants(output_dir: Path, meeting_stem: str, participan
     both exist, matching list_meetings' convention. Silently no-ops if
     neither summary file exists (a meeting can be deleted out from under a
     stale sidecar) -- this is a best-effort enhancement on a successful
-    confirm/rename/delete, never something that should fail the caller.
+    confirm/rename/delete. Returns whether the existing Summary was safely
+    updated or already current; a missing Summary is also a successful no-op.
     """
     json_path = output_dir / f"{meeting_stem}_summary.json"
     md_path = output_dir / f"{meeting_stem}_summary.md"
@@ -7406,20 +7522,24 @@ def _update_summary_participants(output_dir: Path, meeting_stem: str, participan
                 data = json.load(f)
         except (OSError, ValueError) as e:
             logger.warning(f"Could not read {json_path} to update participants: {e}")
-            return
+            return False
         if data.get("participants") == participant_names:
-            return
+            return True
         data["participants"] = participant_names
-        _atomic_write_json(json_path, data)
-        return
+        try:
+            _atomic_write_json(json_path, data)
+        except OSError as e:
+            logger.warning(f"Could not write {json_path} to update participants: {e}")
+            return False
+        return True
 
     if not md_path.exists():
-        return
+        return True
     try:
         original = md_path.read_text(encoding="utf-8")
     except OSError as e:
         logger.warning(f"Could not read {md_path} to update participants: {e}")
-        return
+        return False
 
     lines = original.split("\n")
     # Locate an existing "## Participants" section's span (header line plus
@@ -7475,14 +7595,19 @@ def _update_summary_participants(output_dir: Path, meeting_stem: str, participan
             # needed here, or every insertion would leave a double blank.
             spliced = lines[:summary_end] + new_section + lines[summary_end:]
     else:
-        return  # nothing to add, nothing to remove
+        return True  # nothing to add, nothing to remove
 
     if spliced == lines:
-        return
+        return True
 
     tmp_path = md_path.with_name(md_path.name + ".tmp")
-    tmp_path.write_text("\n".join(spliced), encoding="utf-8")
-    tmp_path.replace(md_path)
+    try:
+        tmp_path.write_text("\n".join(spliced), encoding="utf-8")
+        tmp_path.replace(md_path)
+    except OSError as e:
+        logger.warning(f"Could not write {md_path} to update participants: {e}")
+        return False
+    return True
 
 
 @cli.command(name='backfill-speaker-embeddings')

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5745,13 +5745,19 @@ def confirm_speaker(
                 retry_relabel_to=person["display_name"],
                 sync_marker=summary_sync_marker,
             )
-            if summary_sync_marker is not None and sync_outcome != "io_error":
-                if not _clear_summary_transcript_sync(
-                    output_dir, meeting_stem, summary_sync_marker,
-                ):
+            if summary_sync_marker is not None:
+                finalization_failure = _finalize_summary_transcript_sync(
+                    output_dir, meeting_stem, summary_sync_marker, sync_outcome,
+                )
+                if finalization_failure is not None:
+                    errors = {
+                        "io_error": "Could not update the summary transcript. Retry the confirmation.",
+                        "unsafe": "Could not safely update the summary transcript. Retry the confirmation.",
+                        "clear_error": "Could not finalize the pending transcript update. Retry the confirmation.",
+                    }
                     print(json.dumps({
                         "success": False,
-                        "error": "Could not finalize the pending transcript update. Retry the confirmation.",
+                        "error": errors[finalization_failure],
                     }))
                     sys.exit(1)
 
@@ -6193,13 +6199,19 @@ def mark_speaker_cluster(
                 restore_target_ids=restore_target_ids,
                 sync_marker=summary_sync_marker,
             )
-            if summary_sync_marker is not None and sync_outcome != "io_error":
-                if not _clear_summary_transcript_sync(
-                    output_dir, meeting_stem, summary_sync_marker,
-                ):
+            if summary_sync_marker is not None:
+                finalization_failure = _finalize_summary_transcript_sync(
+                    output_dir, meeting_stem, summary_sync_marker, sync_outcome,
+                )
+                if finalization_failure is not None:
+                    errors = {
+                        "io_error": "Could not update the summary transcript. Retry the speaker marking.",
+                        "unsafe": "Could not safely update the summary transcript. Retry the speaker marking.",
+                        "clear_error": "Could not finalize the pending transcript update. Retry the speaker marking.",
+                    }
                     print(json.dumps({
                         "success": False,
-                        "error": "Could not finalize the pending transcript update. Retry the speaker marking.",
+                        "error": errors[finalization_failure],
                         "cleared_confirmation_from": cleared_from,
                     }))
                     sys.exit(1)
@@ -7012,6 +7024,31 @@ def _clear_summary_transcript_sync(
     return True
 
 
+def _finalize_summary_transcript_sync(
+    output_dir: Path,
+    meeting_stem: str,
+    marker: dict,
+    sync_outcome: str,
+) -> Optional[str]:
+    """Consume a pending marker only after an unambiguously safe outcome.
+
+    I/O failures and ambiguous provenance remain retryable and visible to the
+    caller. Unexpected outcomes fail closed rather than silently discarding
+    the only durable evidence that can authorize a later repair.
+    """
+    safe_outcomes = {"updated", "complete", "diverged", "missing"}
+    if sync_outcome not in safe_outcomes:
+        if sync_outcome not in {"io_error", "unsafe"}:
+            logger.warning(
+                "Unexpected summary transcript sync outcome for %s",
+                meeting_stem,
+            )
+        return "io_error" if sync_outcome == "io_error" else "unsafe"
+    if not _clear_summary_transcript_sync(output_dir, meeting_stem, marker):
+        return "clear_error"
+    return None
+
+
 def _saved_transcript_body(transcript_path: Path) -> Optional[str]:
     """Read the user-facing body from a recorder-written transcript file.
 
@@ -7051,8 +7088,8 @@ def _update_summary_transcript(
     body from before relabeling. A retry additionally needs the crash-safe hash
     marker written before that first canonical change. Manifest/timestamps alone
     are never authority to overwrite a divergent copy. The return value lets the
-    caller retain the marker only for I/O failures and clear it after a completed
-    update or a deliberate user-edit no-op.
+    caller retain the marker for I/O failures or ambiguous provenance and clear
+    it only after a completed update or a deliberate user-edit no-op.
     """
     transcript_body = _saved_transcript_body(transcript_path)
     if not transcript_body:

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -5340,6 +5340,7 @@ def confirm_speaker(
     confirm itself if the transcript is missing or nothing matches.
     """
     from src.config import get_config, get_data_dirs
+    from src.speaker_schema import validate_display_name
     from src.speaker_sidecar_store import SpeakerSidecarStore, StaleDiarizationRun
     from src.speaker_suggestions import (
         clear_cluster_review_state,
@@ -5453,7 +5454,23 @@ def confirm_speaker(
         sys.exit(1)
     if new_person:
         try:
-            person = config.create_person_profile(new_person)
+            normalized_new_person = validate_display_name(new_person)
+            person = (
+                _pending_new_person_confirmation_retry(
+                    config.get_person_profiles(),
+                    sidecar,
+                    meeting_stem,
+                    channel,
+                    resolved_id,
+                    fragment_ids,
+                    run_id,
+                    normalized_new_person,
+                )
+                if relabel_transcript
+                else None
+            )
+            if person is None:
+                person = config.create_person_profile(normalized_new_person)
         except ValueError as e:
             config.rollback_transaction()
             print(json.dumps({"success": False, "error": str(e)}))
@@ -5469,7 +5486,16 @@ def confirm_speaker(
         prepared_transcript_path = (
             get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
         )
-        prepared_transcript_body = _saved_transcript_body(prepared_transcript_path)
+        prepared_transcript_body, transcript_read_failed = _read_saved_transcript_body(
+            prepared_transcript_path
+        )
+        if transcript_read_failed:
+            config.rollback_transaction()
+            print(json.dumps({
+                "success": False,
+                "error": "Could not read the transcript. Retry the confirmation.",
+            }))
+            sys.exit(1)
         prepared_turn_manifest = sidecar.get("transcript_lines")
         target_ids = {(channel, sid) for sid in fragment_ids}
         if not _reconcile_pending_summary_transcript_sync(
@@ -5739,25 +5765,37 @@ def confirm_speaker(
         turn_manifest = prepared_turn_manifest or sidecar.get("transcript_lines")
         retry_relabel_target_ids = prepared_relabel_target_ids
         summary_sync_marker = prepared_summary_sync_marker
-        if turn_manifest:
-            # Exact recorded provenance -- immune to the fuzzy-matching
-            # cross-channel/same-channel mislabeling below (see
-            # relabel_transcript_exact's docstring and the plan doc's
-            # Phase 8). Only meetings processed after this manifest
-            # existed have one; everything else falls back.
-            target_ids = prepared_relabel_target_ids or {
-                (channel, sid) for sid in [resolved_id, *context.merged_from]
-            }
-            retry_relabel_target_ids = target_ids
-            relabeled_lines = relabel_transcript_exact(
-                transcript_path, turn_manifest, target_ids, person["display_name"],
-            )
-        else:
-            raw_clusters_by_id = channel_data.get("clusters") or {}
-            pooled_segments = []
-            for fragment_id in [resolved_id, *context.merged_from]:
-                pooled_segments.extend(raw_clusters_by_id.get(fragment_id, {}).get("segments") or [])
-            relabeled_lines = relabel_transcript_speaker(transcript_path, pooled_segments, person["display_name"])
+        try:
+            if turn_manifest:
+                # Exact recorded provenance -- immune to the fuzzy-matching
+                # cross-channel/same-channel mislabeling below (see
+                # relabel_transcript_exact's docstring and the plan doc's
+                # Phase 8). Only meetings processed after this manifest
+                # existed have one; everything else falls back.
+                target_ids = prepared_relabel_target_ids or {
+                    (channel, sid) for sid in [resolved_id, *context.merged_from]
+                }
+                retry_relabel_target_ids = target_ids
+                relabeled_lines = relabel_transcript_exact(
+                    transcript_path, turn_manifest, target_ids, person["display_name"],
+                )
+            else:
+                raw_clusters_by_id = channel_data.get("clusters") or {}
+                pooled_segments = []
+                for fragment_id in [resolved_id, *context.merged_from]:
+                    pooled_segments.extend(
+                        raw_clusters_by_id.get(fragment_id, {}).get("segments") or []
+                    )
+                relabeled_lines = relabel_transcript_speaker(
+                    transcript_path, pooled_segments, person["display_name"]
+                )
+        except OSError:
+            logger.warning("Could not update canonical transcript during speaker confirmation")
+            print(json.dumps({
+                "success": False,
+                "error": "Could not update the transcript. Retry the confirmation.",
+            }))
+            sys.exit(1)
         if (
             previous_transcript_body is not None
             and (relabeled_lines > 0 or summary_sync_marker is not None)
@@ -6068,7 +6106,15 @@ def mark_speaker_cluster(
         prepared_transcript_path = (
             get_data_dirs()["transcripts"] / f"{meeting_stem}_transcript.txt"
         )
-        prepared_transcript_body = _saved_transcript_body(prepared_transcript_path)
+        prepared_transcript_body, transcript_read_failed = _read_saved_transcript_body(
+            prepared_transcript_path
+        )
+        if transcript_read_failed:
+            print(json.dumps({
+                "success": False,
+                "error": "Could not read the transcript. Retry the speaker marking.",
+            }))
+            sys.exit(1)
         prepared_restore_target_ids = {(channel, fid) for fid in fragment_ids}
         if not _reconcile_pending_summary_transcript_sync(
             output_dir,
@@ -6225,11 +6271,20 @@ def mark_speaker_cluster(
             (channel, fid) for fid in fragment_ids
         }
         summary_sync_marker = prepared_summary_sync_marker
-        restored_lines = restore_transcript_labels(
-            transcript_path,
-            sidecar.get("transcript_lines") or [],
-            restore_target_ids,
-        )
+        try:
+            restored_lines = restore_transcript_labels(
+                transcript_path,
+                sidecar.get("transcript_lines") or [],
+                restore_target_ids,
+            )
+        except OSError:
+            logger.warning("Could not update canonical transcript during speaker marking")
+            print(json.dumps({
+                "success": False,
+                "error": "Could not update the transcript. Retry the speaker marking.",
+                "cleared_confirmation_from": cleared_from,
+            }))
+            sys.exit(1)
         if (
             previous_transcript_body is not None
             and (restored_lines > 0 or summary_sync_marker is not None)
@@ -6908,6 +6963,49 @@ def _summary_sync_operation_hash(target_ids: set, replacement_label: Optional[st
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _pending_new_person_confirmation_retry(
+    profiles: list,
+    sidecar: dict,
+    meeting_stem: str,
+    channel: str,
+    resolved_id: str,
+    fragment_ids: set,
+    run_id,
+    display_name: str,
+) -> Optional[dict]:
+    """Resolve only the profile created by this exact interrupted request.
+
+    ``--new-person`` normally rejects every duplicate name. The sole exception
+    is a retry whose still-pending marker proves the same name and cluster
+    operation, and whose profile has the matching committed prototype. This
+    keeps the real CLI request idempotent without turning name collisions into
+    a general existing-person lookup.
+    """
+    marker = sidecar.get(_PENDING_SUMMARY_TRANSCRIPT_SYNC_KEY)
+    target_ids = {(channel, fragment_id) for fragment_id in fragment_ids}
+    if not (
+        isinstance(marker, dict)
+        and marker.get("version") == _PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION
+        and marker.get("operation_sha256")
+        == _summary_sync_operation_hash(target_ids, display_name)
+    ):
+        return None
+    candidates = [
+        profile
+        for profile in profiles
+        if profile.get("display_name") == display_name
+        and any(
+            prototype.get("meeting_id") == meeting_stem
+            and prototype.get("channel") == channel
+            and prototype.get("diarization_speaker_id") == resolved_id
+            and prototype.get("diarization_run_id") == run_id
+            and prototype.get("created_from") in {"user_confirmed", "user_corrected"}
+            for prototype in profile.get("prototypes") or []
+        )
+    ]
+    return candidates[0] if len(candidates) == 1 else None
+
+
 def _prepare_summary_transcript_sync(
     output_dir: Path,
     meeting_stem: str,
@@ -7092,7 +7190,7 @@ def _finalize_summary_transcript_sync(
     return None
 
 
-def _saved_transcript_body(transcript_path: Path) -> Optional[str]:
+def _read_saved_transcript_body(transcript_path: Path) -> tuple[Optional[str], bool]:
     """Read the user-facing body from a recorder-written transcript file.
 
     `_write_transcript_file` prefixes metadata and a line of `=` characters.
@@ -7101,9 +7199,11 @@ def _saved_transcript_body(transcript_path: Path) -> Optional[str]:
     """
     try:
         content = transcript_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None, False
     except OSError as e:
         logger.warning(f"Could not read {transcript_path} to update summary transcript: {e}")
-        return None
+        return None, True
     lines = content.split("\n")
     separator = (
         next((i for i, line in enumerate(lines[:12]) if re.fullmatch(r"={20,}\s*", line)), None)
@@ -7111,7 +7211,12 @@ def _saved_transcript_body(transcript_path: Path) -> Optional[str]:
         else None
     )
     body = "\n".join(lines[separator + 1:]) if separator is not None else content
-    return body.strip()
+    return body.strip(), False
+
+
+def _saved_transcript_body(transcript_path: Path) -> Optional[str]:
+    body, _io_failed = _read_saved_transcript_body(transcript_path)
+    return body
 
 
 def _update_summary_transcript(

--- a/src/speaker_schema.py
+++ b/src/speaker_schema.py
@@ -31,6 +31,7 @@ def validate_display_name(value: str) -> str:
     normalized = " ".join(unicodedata.normalize("NFKC", value).split())
     if (
         not normalized
+        or normalized.casefold() == "you"
         or "[" in normalized
         or "]" in normalized
         or not normalized.isprintable()

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1217,38 +1217,13 @@ def relabel_transcript_speaker(
         logger.warning("Could not read transcript %s for relabeling: %s", transcript_path, e)
         return 0
 
-    lines = original.split("\n")
-    new_lines = []
-    changed = 0
-    for line in lines:
-        match = _TRANSCRIPT_LINE_RE.match(line)
-        if not match:
-            new_lines.append(line)
-            continue
-        timestamp_str, label, text = match.groups()
-        if label == "You":
-            new_lines.append(line)
-            continue
-        try:
-            timestamp_seconds = _parse_transcript_timestamp(timestamp_str)
-        except ValueError:
-            new_lines.append(line)
-            continue
-        in_range = any(
-            seg.get("start", 0) - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-            <= timestamp_seconds
-            <= seg.get("end", 0) + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
-            for seg in segments
-        )
-        if in_range and label != display_name:
-            new_lines.append(f"[{timestamp_str}] [{display_name}] {text}")
-            changed += 1
-        else:
-            new_lines.append(line)
+    relabeled_text, changed = relabel_transcript_text_speaker(
+        original, segments, display_name,
+    )
 
     if changed:
         tmp_path = transcript_path.with_name(transcript_path.name + ".tmp")
-        tmp_path.write_text("\n".join(new_lines), encoding="utf-8")
+        tmp_path.write_text(relabeled_text, encoding="utf-8")
         tmp_path.replace(transcript_path)
     return changed
 
@@ -1534,6 +1509,9 @@ def restore_transcript_text_labels(
                 continue
             if (entry.get("channel"), entry.get("diarization_speaker_id")) not in target_ids:
                 continue
+            current_label = _TRANSCRIPT_LINE_RE.match(lines[indices[index]]).group(2)
+            if replacement_label is not None and current_label == "You":
+                continue
             start = entry.get("start")
             if not isinstance(start, (int, float)) or not math.isfinite(start):
                 logger.warning(
@@ -1560,6 +1538,8 @@ def restore_transcript_text_labels(
         if (entry.get("channel"), entry.get("diarization_speaker_id")) not in target_ids:
             continue
         timestamp_str, label, text = _TRANSCRIPT_LINE_RE.match(lines[line_idx]).groups()
+        if replacement_label is not None and label == "You":
+            continue
         if replacement_label is not None:
             restored = replacement_label
         else:
@@ -1573,6 +1553,40 @@ def restore_transcript_text_labels(
         lines[line_idx] = f"[{timestamp_str}] [{restored}] {text}"
         changed += 1
 
+    return "\n".join(lines), changed
+
+
+def relabel_transcript_text_speaker(
+    transcript_text: str,
+    segments: list,
+    display_name: str,
+) -> tuple[str, int]:
+    """Apply the legacy segment-based relabeling rules to in-memory text."""
+    if not segments:
+        return transcript_text, 0
+
+    lines = transcript_text.split("\n")
+    changed = 0
+    for index, line in enumerate(lines):
+        match = _TRANSCRIPT_LINE_RE.match(line)
+        if not match:
+            continue
+        timestamp_str, label, text = match.groups()
+        if label == "You":
+            continue
+        try:
+            timestamp_seconds = _parse_transcript_timestamp(timestamp_str)
+        except ValueError:
+            continue
+        in_range = any(
+            seg.get("start", 0) - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+            <= timestamp_seconds
+            <= seg.get("end", 0) + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+            for seg in segments
+        )
+        if in_range and label != display_name:
+            lines[index] = f"[{timestamp_str}] [{display_name}] {text}"
+            changed += 1
     return "\n".join(lines), changed
 
 

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -47,7 +47,6 @@ import subprocess
 import tempfile
 import time
 import uuid
-from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -1698,20 +1697,11 @@ def relabel_transcript_exact(transcript_path: Path, turn_manifest: list, target_
         )
         return 0
 
-    # Diagnostic trail for a real, unexplained incident: two confirm-speaker
-    # calls on the same meeting (different clusters) left one raw cluster's
-    # lines scattered across three different labels instead of the uniform
-    # result this function's own logic (and a controlled replay of it)
-    # produces. Never reproduced from a clean replay, so this call's exact
-    # inputs/outcome are logged to give a real trail if it recurs, rather
-    # than reconstructing after the fact from the file alone.
-    before_labels = Counter(
-        _TRANSCRIPT_LINE_RE.match(lines[i]).group(2) for i in diarised_line_indices
-    )
+    # Keep the diagnostic trail metadata-only. Speaker display names and raw
+    # transcript labels are meeting content and must never enter logs.
     logger.info(
-        "relabel_transcript_exact: %s target_ids=%s display_name=%r lines=%d before_labels=%s",
-        transcript_path, sorted(target_ids), display_name, len(diarised_line_indices),
-        dict(before_labels),
+        "relabel_transcript_exact: %s targets=%d lines=%d",
+        transcript_path, len(target_ids), len(diarised_line_indices),
     )
 
     changed = 0

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1488,48 +1488,71 @@ def record_original_labels(
     return recorded
 
 
-def restore_transcript_labels(
-    transcript_path: Path, turn_manifest: list, target_ids: set,
-) -> int:
-    """Undo a confirmation's rename on ONE cluster's lines, putting back the
-    label each line carried before it. Where nothing was recorded, an
-    existing generic diarization label remains unchanged and a person name
-    is replaced with `MULTI_SPEAKER_TRANSCRIPT_LABEL`.
+def restore_transcript_text_labels(
+    transcript_text: str,
+    turn_manifest: list,
+    target_ids: set,
+    *,
+    require_unique_target_timestamps: bool = False,
+    replacement_label: Optional[str] = None,
+) -> tuple[str, int]:
+    """Restore one cluster's labels in diarised transcript text.
 
-    The fallback is not a guess: it is the statement the user just made by
-    marking the cluster, and it is the honest thing to show for a line the
-    app can no longer attribute to one person. Guessing "You" or "Speaker
-    3" instead would invent an attribution.
-
-    Same refusals as relabel_transcript_exact -- a manifest that does not
-    line up with the transcript, by count or by turn times, is not paired
-    at all. Returns the number of lines changed; never raises.
+    This is shared by the canonical transcript file and a saved summary's
+    embedded copy.  The manifest is still the authority: malformed or
+    independently edited text is left untouched instead of guessing which
+    words belong to the cluster.  `replacement_label` switches the operation
+    from restoring the recorded label to a provenance-checked confirmation
+    relabel. A summary-retry caller can require target timestamps to be
+    unique: its embedded copy has only integer-second markers, so two turns
+    in one second are not safely distinguishable after a user reorders them.
     """
-    if not turn_manifest or not target_ids or not transcript_path.exists():
-        return 0
-    try:
-        lines = transcript_path.read_text(encoding="utf-8").split("\n")
-    except OSError as e:
-        logger.warning("Could not read transcript %s for label restore: %s", transcript_path, e)
-        return 0
-
+    if not turn_manifest or not target_ids:
+        return transcript_text, 0
+    lines = transcript_text.split("\n")
     indices = [i for i, line in enumerate(lines) if _TRANSCRIPT_LINE_RE.match(line)]
     if len(indices) != len(turn_manifest):
         logger.warning(
-            "restore_transcript_labels: %s has %d diarised lines but turn_manifest has %d -- "
-            "refusing to guess a pairing, no-op.",
-            transcript_path, len(indices), len(turn_manifest),
+            "restore_transcript_text_labels: %d diarised lines but %d manifest entries; no-op",
+            len(indices), len(turn_manifest),
         )
-        return 0
+        return transcript_text, 0
+    line_starts = [
+        _safe_transcript_timestamp(_TRANSCRIPT_LINE_RE.match(lines[i]).group(1))
+        for i in indices
+    ]
     if not _manifest_describes_lines(
-        [_safe_transcript_timestamp(_TRANSCRIPT_LINE_RE.match(lines[i]).group(1)) for i in indices],
+        line_starts,
         turn_manifest,
     ):
         logger.warning(
-            "restore_transcript_labels: %s and its turn_manifest disagree on turn times -- no-op.",
-            transcript_path,
+            "restore_transcript_text_labels: transcript markers and manifest starts disagree; no-op",
         )
-        return 0
+        return transcript_text, 0
+    if require_unique_target_timestamps:
+        for index, entry in enumerate(turn_manifest):
+            if not isinstance(entry, dict):
+                continue
+            if (entry.get("channel"), entry.get("diarization_speaker_id")) not in target_ids:
+                continue
+            start = entry.get("start")
+            if not isinstance(start, (int, float)) or not math.isfinite(start):
+                logger.warning(
+                    "restore_transcript_text_labels: target turn has no rendered timestamp; "
+                    "refusing summary label repair",
+                )
+                return transcript_text, 0
+            rendered_start = max(0, int(start))
+            # A missing start on a different manifest entry is not evidence
+            # that it belongs to another second. The saved summary carries
+            # only these rendered markers, so its actual duplicate marker is
+            # the relevant ambiguity proof.
+            if line_starts.count(rendered_start) > 1:
+                logger.warning(
+                    "restore_transcript_text_labels: target turn has no unique summary marker; "
+                    "refusing summary label repair",
+                )
+                return transcript_text, 0
 
     changed = 0
     for line_idx, entry in zip(indices, turn_manifest):
@@ -1538,19 +1561,48 @@ def restore_transcript_labels(
         if (entry.get("channel"), entry.get("diarization_speaker_id")) not in target_ids:
             continue
         timestamp_str, label, text = _TRANSCRIPT_LINE_RE.match(lines[line_idx]).groups()
-        restored = entry.get(ORIGINAL_LABEL_KEY)
-        if not restored:
-            if _is_generic_transcript_label(label):
-                continue
-            restored = MULTI_SPEAKER_TRANSCRIPT_LABEL
+        if replacement_label is not None:
+            restored = replacement_label
+        else:
+            restored = entry.get(ORIGINAL_LABEL_KEY)
+            if not restored:
+                if _is_generic_transcript_label(label):
+                    continue
+                restored = MULTI_SPEAKER_TRANSCRIPT_LABEL
         if label == restored:
             continue
         lines[line_idx] = f"[{timestamp_str}] [{restored}] {text}"
         changed += 1
 
+    return "\n".join(lines), changed
+
+
+def restore_transcript_labels(
+    transcript_path: Path, turn_manifest: list, target_ids: set,
+) -> int:
+    """Undo a confirmation's rename on ONE cluster's saved transcript lines.
+
+    Where nothing was recorded, an existing generic diarization label remains
+    unchanged and a person name is replaced with
+    `MULTI_SPEAKER_TRANSCRIPT_LABEL`.  Same refusals as
+    `relabel_transcript_exact` apply: a manifest that does not line up by
+    count and turn times is not paired at all.
+    """
+    if not turn_manifest or not target_ids or not transcript_path.exists():
+        return 0
+    try:
+        original = transcript_path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning("Could not read transcript %s for label restore: %s", transcript_path, e)
+        return 0
+
+    restored_text, changed = restore_transcript_text_labels(
+        original, turn_manifest, target_ids,
+    )
+
     if changed:
         tmp_path = transcript_path.with_name(transcript_path.name + ".tmp")
-        tmp_path.write_text("\n".join(lines), encoding="utf-8")
+        tmp_path.write_text(restored_text, encoding="utf-8")
         tmp_path.replace(transcript_path)
     return changed
 

--- a/src/speaker_suggestions.py
+++ b/src/speaker_suggestions.py
@@ -1590,6 +1590,61 @@ def relabel_transcript_text_speaker(
     return "\n".join(lines), changed
 
 
+def restore_transcript_text_speaker(
+    transcript_text: str,
+    segments: list,
+    display_names: set,
+) -> tuple[str, int]:
+    """Withdraw legacy fuzzy labels only for the confirmed names being removed."""
+    if not segments or not display_names:
+        return transcript_text, 0
+
+    lines = transcript_text.split("\n")
+    changed = 0
+    for index, line in enumerate(lines):
+        match = _TRANSCRIPT_LINE_RE.match(line)
+        if not match:
+            continue
+        timestamp_str, label, text = match.groups()
+        if label not in display_names:
+            continue
+        try:
+            timestamp_seconds = _parse_transcript_timestamp(timestamp_str)
+        except ValueError:
+            continue
+        in_range = any(
+            segment.get("start", 0) - RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+            <= timestamp_seconds
+            <= segment.get("end", 0) + RELABEL_TIMESTAMP_TOLERANCE_SECONDS
+            for segment in segments
+        )
+        if in_range:
+            lines[index] = (
+                f"[{timestamp_str}] [{MULTI_SPEAKER_TRANSCRIPT_LABEL}] {text}"
+            )
+            changed += 1
+    return "\n".join(lines), changed
+
+
+def restore_transcript_speaker_labels(
+    transcript_path: Path,
+    segments: list,
+    display_names: set,
+) -> int:
+    """Atomically apply legacy segment-based label withdrawal to a file."""
+    if not segments or not display_names or not transcript_path.exists():
+        return 0
+    original = transcript_path.read_text(encoding="utf-8")
+    restored_text, changed = restore_transcript_text_speaker(
+        original, segments, display_names,
+    )
+    if changed:
+        tmp_path = transcript_path.with_name(transcript_path.name + ".tmp")
+        tmp_path.write_text(restored_text, encoding="utf-8")
+        tmp_path.replace(transcript_path)
+    return changed
+
+
 def restore_transcript_labels(
     transcript_path: Path, turn_manifest: list, target_ids: set,
 ) -> int:

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -816,6 +816,58 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
 
             self.assertEqual(simple_recorder._saved_transcript_body(transcript_path), body)
 
+    def test_update_summary_transcript_updates_a_matching_json_copy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            summary_path = output_dir / "mtg001_summary.json"
+            previous = "[00:00] [Speaker 2] original wording"
+            summary_path.write_text(
+                json.dumps({"is_diarised": True, "diarised_text": previous}),
+                encoding="utf-8",
+            )
+            transcript_path = Path(tmp) / "mtg001_transcript.txt"
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n[00:00] [Person Gamma] original wording",
+                encoding="utf-8",
+            )
+
+            simple_recorder._update_summary_transcript(
+                output_dir,
+                "mtg001",
+                transcript_path,
+                previous,
+            )
+
+            data = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(data["diarised_text"], "[00:00] [Person Gamma] original wording")
+
+    def test_update_summary_transcript_preserves_a_redacted_json_copy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            summary_path = output_dir / "mtg001_summary.json"
+            redacted = "[00:00] [Speaker 2] [redacted]"
+            summary_path.write_text(
+                json.dumps({"is_diarised": True, "diarised_text": redacted}),
+                encoding="utf-8",
+            )
+            transcript_path = Path(tmp) / "mtg001_transcript.txt"
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n[00:00] [Person Gamma] sensitive wording",
+                encoding="utf-8",
+            )
+
+            simple_recorder._update_summary_transcript(
+                output_dir,
+                "mtg001",
+                transcript_path,
+                "[00:00] [Speaker 2] sensitive wording",
+            )
+
+            data = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(data["diarised_text"], redacted)
+
     def test_relabel_transcript_uses_exact_matching_when_sidecar_has_manifest(self):
         # See the plan doc's Phase 8: when the sidecar carries
         # transcript_lines (written by a post-Phase-8 live pipeline run),

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -945,6 +945,56 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 read_speakers_sidecar(output_dir, "mtg001"),
             )
 
+    def test_noncanonical_existing_name_uses_one_canonical_retry_operation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = (
+                self._seed_two_cluster_relabel_artifacts(tmp)
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            person = cfg.create_person_profile("Alice")
+            cfg._config["person_profiles"][0]["display_name"] = "\uff21\uff4c\uff49\uff43\uff45"
+            self.assertTrue(cfg._save())
+            request = [
+                "mtg001", "mic", "SPEAKER_00", "--person-id", person["person_id"],
+                "--relabel-transcript",
+            ]
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_write(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary_path and not failed_once:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text", side_effect=fail_first_summary_write,
+            ):
+                first, _ = self._run(request, tmp, cfg=cfg)
+
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertTrue(failed_once)
+            self.assertIn("[Alice] first", transcript_path.read_text(encoding="utf-8"))
+            self.assertNotIn("\uff21\uff4c\uff49\uff43\uff45", transcript_path.read_text(encoding="utf-8"))
+            marker = read_speakers_sidecar(output_dir, "mtg001")[
+                "pending_summary_transcript_sync"
+            ]
+            self.assertEqual(
+                marker["operation_sha256"],
+                simple_recorder._summary_sync_operation_hash({("mic", "SPEAKER_00")}, "Alice"),
+            )
+            self.assertEqual(cfg.get_person_profile(person["person_id"])["display_name"], "Alice")
+
+            retry, _ = self._run(request, tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertIn("[Alice] first", summary_path.read_text(encoding="utf-8"))
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
     def test_legacy_relabel_summary_io_failure_retries_same_new_person_request(self):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "output"
@@ -1196,6 +1246,40 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                     "mtg001", "mic", "SPEAKER_00", "--person-id", person["person_id"],
                     "--relabel-transcript",
                 ],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertEqual(cfg.get_person_profiles(), profiles_before)
+            self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), sidecar_before)
+            self.assertEqual(transcript_path.read_text(encoding="utf-8"), transcript_before)
+            self.assertEqual(summary_path.read_text(encoding="utf-8"), summary_before)
+
+    def test_corrupt_neighbouring_reserved_you_profile_fails_before_confirmation_mutation(self):
+        """A persisted lookalike of the reserved self label cannot become
+        hard-negative or participant evidence during a different confirm."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = (
+                self._seed_two_cluster_relabel_artifacts(tmp)
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            first, cfg = self._run(
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha"],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(first.output)["success"])
+            cfg._config["person_profiles"][0]["display_name"] = "\uff39\uff4f\uff55"
+            self.assertTrue(cfg._save())
+            profiles_before = cfg.get_person_profiles()
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
+            transcript_before = transcript_path.read_text(encoding="utf-8")
+            summary_before = summary_path.read_text(encoding="utf-8")
+
+            failed, _ = self._run(
+                ["mtg001", "mic", "SPEAKER_01", "--new-person", "Person Beta"],
                 tmp,
                 cfg=cfg,
             )

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -1177,6 +1177,198 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 read_speakers_sidecar(output_dir, "mtg001"),
             )
 
+    def test_existing_reserved_you_profile_fails_before_confirmation_mutation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = (
+                self._seed_two_cluster_relabel_artifacts(tmp)
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            person = cfg.create_person_profile("Person Alpha")
+            cfg._config["person_profiles"][0]["display_name"] = "You"
+            self.assertTrue(cfg._save())
+            profiles_before = cfg.get_person_profiles()
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
+            transcript_before = transcript_path.read_text(encoding="utf-8")
+            summary_before = summary_path.read_text(encoding="utf-8")
+
+            failed, _ = self._run(
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--person-id", person["person_id"],
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertEqual(cfg.get_person_profiles(), profiles_before)
+            self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), sidecar_before)
+            self.assertEqual(transcript_path.read_text(encoding="utf-8"), transcript_before)
+            self.assertEqual(summary_path.read_text(encoding="utf-8"), summary_before)
+
+    def test_pending_sync_blocks_confirm_without_relabel_before_profile_mutation(self):
+        for blocked_mode in ("new_person", "person_id"):
+            with self.subTest(blocked_mode=blocked_mode), tempfile.TemporaryDirectory() as tmp:
+                output_dir, summary_path, transcript_path = (
+                    self._seed_two_cluster_relabel_artifacts(tmp)
+                )
+                cfg = Config(config_path=Path(tmp) / "config.json")
+                if blocked_mode == "person_id":
+                    person_beta = cfg.create_person_profile("Person Beta")
+                    blocked_request = [
+                        "mtg001", "mic", "SPEAKER_01", "--person-id",
+                        person_beta["person_id"],
+                    ]
+                else:
+                    blocked_request = [
+                        "mtg001", "mic", "SPEAKER_01", "--new-person", "Person Beta",
+                    ]
+                original_request = [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ]
+                real_atomic_write = simple_recorder._atomic_write_text
+
+                def fail_summary_write(path, text, *args, **kwargs):
+                    if path == summary_path and "[Person Alpha]" in text:
+                        raise OSError("simulated summary write failure")
+                    return real_atomic_write(path, text, *args, **kwargs)
+
+                with mock.patch(
+                    "simple_recorder._atomic_write_text",
+                    side_effect=fail_summary_write,
+                ):
+                    interrupted, _ = self._run(original_request, tmp, cfg=cfg)
+                self.assertNotEqual(interrupted.exit_code, 0)
+                marker_state = read_speakers_sidecar(output_dir, "mtg001")
+                self.assertIn("pending_summary_transcript_sync", marker_state)
+                profiles_before = cfg.get_person_profiles()
+                transcript_before = transcript_path.read_text(encoding="utf-8")
+                summary_before = summary_path.read_text(encoding="utf-8")
+
+                blocked, _ = self._run(blocked_request, tmp, cfg=cfg)
+
+                self.assertNotEqual(blocked.exit_code, 0)
+                self.assertFalse(_last_json(blocked.output)["success"])
+                self.assertEqual(cfg.get_person_profiles(), profiles_before)
+                self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), marker_state)
+                self.assertEqual(transcript_path.read_text(encoding="utf-8"), transcript_before)
+                self.assertEqual(summary_path.read_text(encoding="utf-8"), summary_before)
+
+                original_retry, _ = self._run(original_request, tmp, cfg=cfg)
+                self.assertTrue(_last_json(original_retry.output)["success"])
+                blocked_retry, _ = self._run(blocked_request, tmp, cfg=cfg)
+                self.assertTrue(_last_json(blocked_retry.output)["success"])
+
+    def test_foreign_confirm_cannot_clear_completed_hashes_before_review_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = (
+                self._seed_two_cluster_relabel_artifacts(tmp)
+            )
+            set_cluster_review_state(
+                output_dir,
+                "mtg001",
+                "mic",
+                "SPEAKER_00",
+                REVIEW_STATE_GENERIC,
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            original_request = [
+                "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                "--relabel-transcript",
+            ]
+            with mock.patch(
+                "src.speaker_suggestions.clear_cluster_review_state",
+                return_value=0,
+            ):
+                interrupted, _ = self._run(original_request, tmp, cfg=cfg)
+            self.assertNotEqual(interrupted.exit_code, 0)
+            marker_state = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertIn("pending_summary_transcript_sync", marker_state)
+            self.assertEqual(
+                marker_state["channels"]["mic"]["clusters"]["SPEAKER_00"][
+                    REVIEW_STATE_KEY
+                ],
+                REVIEW_STATE_GENERIC,
+            )
+            profiles_before = cfg.get_person_profiles()
+            transcript_before = transcript_path.read_text(encoding="utf-8")
+            summary_before = summary_path.read_text(encoding="utf-8")
+            foreign_request = [
+                "mtg001", "mic", "SPEAKER_01", "--new-person", "Person Beta",
+                "--relabel-transcript",
+            ]
+
+            foreign, _ = self._run(foreign_request, tmp, cfg=cfg)
+
+            self.assertNotEqual(foreign.exit_code, 0)
+            self.assertFalse(_last_json(foreign.output)["success"])
+            self.assertEqual(cfg.get_person_profiles(), profiles_before)
+            self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), marker_state)
+            self.assertEqual(transcript_path.read_text(encoding="utf-8"), transcript_before)
+            self.assertEqual(summary_path.read_text(encoding="utf-8"), summary_before)
+
+            original_retry, _ = self._run(original_request, tmp, cfg=cfg)
+            self.assertTrue(_last_json(original_retry.output)["success"])
+            foreign_retry, _ = self._run(foreign_request, tmp, cfg=cfg)
+            self.assertTrue(_last_json(foreign_retry.output)["success"])
+            final_sidecar = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertNotIn("pending_summary_transcript_sync", final_sidecar)
+            self.assertNotIn(
+                REVIEW_STATE_KEY,
+                final_sidecar["channels"]["mic"]["clusters"]["SPEAKER_00"],
+            )
+            final_transcript = transcript_path.read_text(encoding="utf-8")
+            final_summary = summary_path.read_text(encoding="utf-8")
+            self.assertIn("[Person Alpha]", final_transcript)
+            self.assertIn("[Person Beta]", final_transcript)
+            self.assertIn("[Person Alpha]", final_summary)
+            self.assertIn("[Person Beta]", final_summary)
+            self.assertIn("Person Alpha, Person Beta", final_summary)
+
+    def test_new_person_retries_a_legacy_v1_summary_sync_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = (
+                self._seed_two_cluster_relabel_artifacts(tmp)
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            request = [
+                "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                "--relabel-transcript",
+            ]
+            real_atomic_write = simple_recorder._atomic_write_text
+
+            def fail_summary_write(path, text, *args, **kwargs):
+                if path == summary_path and "[Person Alpha]" in text:
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_summary_write,
+            ):
+                interrupted, _ = self._run(request, tmp, cfg=cfg)
+            self.assertNotEqual(interrupted.exit_code, 0)
+            sidecar = read_speakers_sidecar(output_dir, "mtg001")
+            marker = sidecar["pending_summary_transcript_sync"]
+            marker["version"] = simple_recorder._LEGACY_PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION
+            marker.pop("target_ids", None)
+            write_sidecar_document(output_dir, "mtg001", sidecar)
+
+            retry, _ = self._run(request, tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+            self.assertIn("[Person Alpha] first", transcript_path.read_text(encoding="utf-8"))
+            final_summary = summary_path.read_text(encoding="utf-8")
+            self.assertIn("[Person Alpha] first", final_summary)
+            self.assertIn("## Participants", final_summary)
+            self.assertIn("Person Alpha", final_summary)
+
     def test_canonical_transcript_write_failure_reports_json_and_retries_same_request(self):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir, summary_path, transcript_path = self._seed_two_cluster_relabel_artifacts(tmp)

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -10,7 +10,10 @@ from click.testing import CliRunner
 import simple_recorder
 from src.config import Config
 from src.speaker_suggestions import (
+    REVIEW_STATE_GENERIC,
+    REVIEW_STATE_KEY,
     read_speakers_sidecar,
+    set_cluster_review_state,
     write_sidecar_document,
     write_speakers_sidecar,
 )
@@ -937,6 +940,238 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             self.assertEqual(retry_data["relabeled_lines"], 0)
             self.assertIn("[Person Gamma] hello there", summary_path.read_text())
             self.assertNotIn("[Speaker 2] hello there", summary_path.read_text())
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+    def test_legacy_relabel_summary_io_failure_retries_same_new_person_request(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            summary_path = output_dir / "mtg001_summary.md"
+            summary_path.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 30.0,
+                            "segment_count": 5,
+                            "segments": [{"start": 4.0, "end": 6.0}],
+                        },
+                    },
+                },
+            })
+            transcripts_dir = Path(tmp) / "transcripts"
+            transcripts_dir.mkdir(parents=True, exist_ok=True)
+            transcript_path = transcripts_dir / "mtg001_transcript.txt"
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n"
+                "[00:05] [Speaker 2] hello there",
+                encoding="utf-8",
+            )
+            request = [
+                "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Legacy",
+                "--relabel-transcript",
+            ]
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_write(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary_path and not failed_once and "[Person Legacy]" in text:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_first_summary_write,
+            ):
+                first, cfg = self._run(request, tmp)
+
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertFalse(_last_json(first.output)["success"])
+            self.assertTrue(failed_once)
+            self.assertEqual(len(cfg.get_person_profiles()), 1)
+            committed_person_id = cfg.get_person_profiles()[0]["person_id"]
+            self.assertIn("[Person Legacy] hello there", transcript_path.read_text())
+            self.assertIn("[Speaker 2] hello there", summary_path.read_text())
+            self.assertIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+            retry, _ = self._run(request, tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertEqual(len(cfg.get_person_profiles()), 1)
+            self.assertEqual(cfg.get_person_profiles()[0]["person_id"], committed_person_id)
+            self.assertIn("[Person Legacy] hello there", summary_path.read_text())
+            self.assertNotIn("[Speaker 2] hello there", summary_path.read_text())
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+    def test_retry_marker_survives_review_or_participants_followup_failure(self):
+        for failure_stage in ("review_state", "participants"):
+            with self.subTest(failure_stage=failure_stage), tempfile.TemporaryDirectory() as tmp:
+                output_dir, summary_path, transcript_path = (
+                    self._seed_two_cluster_relabel_artifacts(tmp)
+                )
+                set_cluster_review_state(
+                    output_dir,
+                    "mtg001",
+                    "mic",
+                    "SPEAKER_00",
+                    REVIEW_STATE_GENERIC,
+                )
+                request = [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ]
+
+                if failure_stage == "review_state":
+                    failure_patch = mock.patch(
+                        "src.speaker_suggestions.clear_cluster_review_state",
+                        return_value=0,
+                    )
+                else:
+                    real_write_text = Path.write_text
+                    summary_tmp = summary_path.with_name(summary_path.name + ".tmp")
+
+                    def fail_participants_write(path, text, *args, **kwargs):
+                        if path == summary_tmp and "## Participants" in text:
+                            raise OSError("simulated participants write failure")
+                        return real_write_text(path, text, *args, **kwargs)
+
+                    failure_patch = mock.patch.object(
+                        Path,
+                        "write_text",
+                        new=fail_participants_write,
+                    )
+
+                with failure_patch:
+                    failed, cfg = self._run(request, tmp)
+
+                self.assertNotEqual(failed.exit_code, 0)
+                self.assertFalse(_last_json(failed.output)["success"])
+                self.assertEqual(len(cfg.get_person_profiles()), 1)
+                committed_person_id = cfg.get_person_profiles()[0]["person_id"]
+                sidecar_after_failure = read_speakers_sidecar(output_dir, "mtg001")
+                self.assertIn("pending_summary_transcript_sync", sidecar_after_failure)
+                self.assertIn("[00:05] [Person Alpha] first", transcript_path.read_text())
+                self.assertIn("[00:05] [Person Alpha] first", summary_path.read_text())
+                if failure_stage == "review_state":
+                    self.assertEqual(
+                        sidecar_after_failure["channels"]["mic"]["clusters"][
+                            "SPEAKER_00"
+                        ][REVIEW_STATE_KEY],
+                        REVIEW_STATE_GENERIC,
+                    )
+                else:
+                    self.assertNotIn("## Participants", summary_path.read_text())
+
+                retry, _ = self._run(request, tmp, cfg=cfg)
+
+                self.assertTrue(_last_json(retry.output)["success"])
+                self.assertEqual(len(cfg.get_person_profiles()), 1)
+                self.assertEqual(
+                    cfg.get_person_profiles()[0]["person_id"], committed_person_id,
+                )
+                sidecar_after_retry = read_speakers_sidecar(output_dir, "mtg001")
+                self.assertNotIn("pending_summary_transcript_sync", sidecar_after_retry)
+                self.assertNotIn(
+                    REVIEW_STATE_KEY,
+                    sidecar_after_retry["channels"]["mic"]["clusters"]["SPEAKER_00"],
+                )
+                self.assertIn("Person Alpha", summary_path.read_text())
+
+    def test_merged_you_turn_is_skipped_during_summary_retry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            body = "[00:05] [You] owner words\n[00:10] [Speaker 2] guest words"
+            summary_path = output_dir / "mtg001_summary.md"
+            summary_path.write_text("## Transcript\n\n" + body + "\n", encoding="utf-8")
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 20.0,
+                            "segment_count": 3,
+                            "segments": [{"start": 4.0, "end": 6.0}],
+                        },
+                        "SPEAKER_01": {
+                            "embedding": [0.999, 0.001],
+                            "speech_duration_seconds": 20.0,
+                            "segment_count": 3,
+                            "segments": [{"start": 9.0, "end": 11.0}],
+                        },
+                    },
+                },
+            }, turn_manifest=[
+                {"start": 5.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"},
+                {"start": 10.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_01"},
+            ])
+            transcripts_dir = Path(tmp) / "transcripts"
+            transcripts_dir.mkdir(parents=True, exist_ok=True)
+            transcript_path = transcripts_dir / "mtg001_transcript.txt"
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n" + body,
+                encoding="utf-8",
+            )
+            request = [
+                "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Guest",
+                "--relabel-transcript",
+            ]
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_write(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary_path and not failed_once and "[Person Guest]" in text:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_first_summary_write,
+            ):
+                first, cfg = self._run(request, tmp)
+
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertFalse(_last_json(first.output)["success"])
+            canonical_after_failure = simple_recorder._saved_transcript_body(transcript_path)
+            self.assertEqual(
+                canonical_after_failure,
+                "[00:05] [You] owner words\n[00:10] [Person Guest] guest words",
+            )
+            marker = read_speakers_sidecar(output_dir, "mtg001")[
+                "pending_summary_transcript_sync"
+            ]
+            self.assertEqual(
+                marker["canonical_after_sha256"],
+                simple_recorder._transcript_body_hash(canonical_after_failure),
+            )
+
+            retry, _ = self._run(request, tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            summary_after = summary_path.read_text(encoding="utf-8")
+            self.assertIn("[00:05] [You] owner words", summary_after)
+            self.assertIn("[00:10] [Person Guest] guest words", summary_after)
+            self.assertNotIn("[00:05] [Person Guest] owner words", summary_after)
             self.assertNotIn(
                 "pending_summary_transcript_sync",
                 read_speakers_sidecar(output_dir, "mtg001"),

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -39,10 +39,12 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             },
         })
 
-    def _seed_two_cluster_relabel_artifacts(self, tmp):
+    def _seed_two_cluster_relabel_artifacts(self, tmp, *, same_rendered_timestamp=False):
         output_dir = Path(tmp) / "output"
         output_dir.mkdir(parents=True, exist_ok=True)
-        body = "[00:05] [Speaker 2] first\n[00:10] [Speaker 3] second"
+        second_timestamp = "00:05" if same_rendered_timestamp else "00:10"
+        second_start = 5.8 if same_rendered_timestamp else 10.1
+        body = f"[00:05] [Speaker 2] first\n[{second_timestamp}] [Speaker 3] second"
         summary_path = output_dir / "mtg001_summary.md"
         summary_path.write_text("## Transcript\n\n" + body + "\n", encoding="utf-8")
         write_speakers_sidecar(output_dir, "mtg001", {
@@ -61,7 +63,7 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             },
         }, turn_manifest=[
             {"start": 5.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"},
-            {"start": 10.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_01"},
+            {"start": second_start, "channel": "mic", "diarization_speaker_id": "SPEAKER_01"},
         ])
         transcript_path = Path(tmp) / "transcripts" / "mtg001_transcript.txt"
         transcript_path.parent.mkdir(parents=True, exist_ok=True)
@@ -916,7 +918,8 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 )
 
             first_data = _last_json(first.output)
-            self.assertTrue(first_data["success"])
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertFalse(first_data["success"])
             self.assertTrue(failed_once)
             self.assertIn("[Person Gamma] hello there", transcript_path.read_text())
             self.assertIn("[Speaker 2] hello there", summary_path.read_text())
@@ -925,9 +928,10 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 read_speakers_sidecar(output_dir, "mtg001"),
             )
 
+            person_id = cfg.get_person_profiles()[0]["person_id"]
             retry, _ = self._run(
                 [
-                    "mtg001", "mic", "SPEAKER_00", "--person-id", first_data["person_id"],
+                    "mtg001", "mic", "SPEAKER_00", "--person-id", person_id,
                     "--relabel-transcript",
                 ],
                 tmp,
@@ -942,6 +946,80 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 "pending_summary_transcript_sync",
                 read_speakers_sidecar(output_dir, "mtg001"),
             )
+
+    def test_relabel_retry_keeps_marker_when_same_second_turns_make_repair_unsafe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = self._seed_two_cluster_relabel_artifacts(
+                tmp, same_rendered_timestamp=True,
+            )
+            stale_body = (
+                "[00:05] [Speaker 2] first\n"
+                "[00:05] [Speaker 3] second"
+            )
+            canonical_body = (
+                "[00:05] [Person Alpha] first\n"
+                "[00:05] [Speaker 3] second"
+            )
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_transcript_write(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary_path and not failed_once and "[Person Alpha]" in text:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_first_summary_transcript_write,
+            ):
+                first, cfg = self._run([
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ], tmp)
+
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertFalse(_last_json(first.output)["success"])
+            self.assertTrue(failed_once)
+            self.assertEqual(simple_recorder._saved_transcript_body(transcript_path), canonical_body)
+            self.assertIn(stale_body, summary_path.read_text(encoding="utf-8"))
+            marker = read_speakers_sidecar(output_dir, "mtg001")[
+                "pending_summary_transcript_sync"
+            ]
+            person_id = cfg.get_person_profiles()[0]["person_id"]
+
+            unsafe_retry, _ = self._run([
+                "mtg001", "mic", "SPEAKER_00", "--person-id", person_id,
+                "--relabel-transcript",
+            ], tmp, cfg=cfg)
+
+            self.assertNotEqual(unsafe_retry.exit_code, 0)
+            self.assertFalse(_last_json(unsafe_retry.output)["success"])
+            self.assertEqual(simple_recorder._saved_transcript_body(transcript_path), canonical_body)
+            self.assertIn(stale_body, summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                read_speakers_sidecar(output_dir, "mtg001")[
+                    "pending_summary_transcript_sync"
+                ],
+                marker,
+            )
+
+            summary_path.write_text(
+                "## Transcript\n\n" + canonical_body + "\n",
+                encoding="utf-8",
+            )
+            recovered, _ = self._run([
+                "mtg001", "mic", "SPEAKER_00", "--person-id", person_id,
+                "--relabel-transcript",
+            ], tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(recovered.output)["success"])
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+            self.assertIn(canonical_body, summary_path.read_text(encoding="utf-8"))
 
     def test_relabel_retry_preserves_a_json_copy_with_only_its_label_edited(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -990,7 +1068,8 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 ], tmp)
 
             first_data = _last_json(first.output)
-            self.assertTrue(first_data["success"])
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertFalse(first_data["success"])
             edited = json.loads(summary_path.read_text(encoding="utf-8"))
             edited["diarised_text"] = "[00:05] [Person Delta] hello there"
             summary_path.write_text(json.dumps(edited), encoding="utf-8")
@@ -1000,8 +1079,9 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             self.assertNotIn("hello there", json.dumps(pending))
             self.assertNotIn("Person Gamma", json.dumps(pending))
 
+            person_id = cfg.get_person_profiles()[0]["person_id"]
             retry, _ = self._run([
-                "mtg001", "mic", "SPEAKER_00", "--person-id", first_data["person_id"],
+                "mtg001", "mic", "SPEAKER_00", "--person-id", person_id,
                 "--relabel-transcript",
             ], tmp, cfg=cfg)
 
@@ -1084,7 +1164,7 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                     "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
                     "--relabel-transcript",
                 ], tmp)
-            self.assertTrue(_last_json(first.output)["success"])
+            self.assertFalse(_last_json(first.output)["success"])
 
             second, _ = self._run([
                 "mtg001", "mic", "SPEAKER_01", "--new-person", "Person Beta",
@@ -1267,7 +1347,8 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                     "--relabel-transcript",
                 ], tmp, cfg=cfg)
 
-            self.assertTrue(_last_json(changed.output)["success"])
+            self.assertNotEqual(changed.exit_code, 0)
+            self.assertFalse(_last_json(changed.output)["success"])
             self.assertIn("[Person Beta] hello there", transcript_path.read_text(encoding="utf-8"))
             self.assertIn("[Person Alpha] hello there", summary_path.read_text(encoding="utf-8"))
 

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -1005,6 +1005,77 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             self.assertIn("[00:05] [Person Alpha] first", summary_path.read_text())
             self.assertIn("Person Alpha", summary_path.read_text())
 
+    def test_canonical_write_failure_retry_survives_missing_or_diverged_summary(self):
+        for summary_state in ("missing", "diverged"):
+            with self.subTest(summary_state=summary_state), tempfile.TemporaryDirectory() as tmp:
+                output_dir, summary_path, transcript_path = (
+                    self._seed_two_cluster_relabel_artifacts(tmp)
+                )
+                if summary_state == "missing":
+                    summary_path.unlink()
+                    summary_before = None
+                else:
+                    summary_path.write_text(
+                        "## Summary\n\nManually edited.\n\n"
+                        "## Transcript\n\n[00:05] [Manual Person] corrected first\n",
+                        encoding="utf-8",
+                    )
+                    summary_before = summary_path.read_text(encoding="utf-8")
+
+                request = [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ]
+                transcript_before = transcript_path.read_text(encoding="utf-8")
+                real_write_text = Path.write_text
+                transcript_tmp = transcript_path.with_name(transcript_path.name + ".tmp")
+
+                def fail_canonical_tmp_write(path, text, *args, **kwargs):
+                    if path == transcript_tmp:
+                        raise OSError("simulated canonical transcript write failure")
+                    return real_write_text(path, text, *args, **kwargs)
+
+                with mock.patch.object(Path, "write_text", new=fail_canonical_tmp_write):
+                    failed, cfg = self._run(request, tmp)
+
+                self.assertNotEqual(failed.exit_code, 0)
+                self.assertFalse(_last_json(failed.output)["success"])
+                self.assertEqual(len(cfg.get_person_profiles()), 1)
+                committed_person_id = cfg.get_person_profiles()[0]["person_id"]
+                self.assertEqual(
+                    transcript_path.read_text(encoding="utf-8"), transcript_before,
+                )
+                if summary_before is None:
+                    self.assertFalse(summary_path.exists())
+                else:
+                    self.assertEqual(summary_path.read_text(encoding="utf-8"), summary_before)
+                self.assertIn(
+                    "pending_summary_transcript_sync",
+                    read_speakers_sidecar(output_dir, "mtg001"),
+                )
+
+                retry, _ = self._run(request, tmp, cfg=cfg)
+
+                self.assertTrue(_last_json(retry.output)["success"])
+                self.assertEqual(len(cfg.get_person_profiles()), 1)
+                self.assertEqual(
+                    cfg.get_person_profiles()[0]["person_id"], committed_person_id,
+                )
+                self.assertIn(
+                    "[00:05] [Person Alpha] first",
+                    transcript_path.read_text(encoding="utf-8"),
+                )
+                self.assertNotIn(
+                    "pending_summary_transcript_sync",
+                    read_speakers_sidecar(output_dir, "mtg001"),
+                )
+                if summary_before is None:
+                    self.assertFalse(summary_path.exists())
+                else:
+                    summary_after = summary_path.read_text(encoding="utf-8")
+                    self.assertIn("[00:05] [Manual Person] corrected first", summary_after)
+                    self.assertNotIn("[00:05] [Person Alpha] first", summary_after)
+
     def test_new_person_retry_does_not_reuse_name_without_matching_cluster_provenance(self):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir, _summary_path, _transcript_path = (

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -39,6 +39,38 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             },
         })
 
+    def _seed_two_cluster_relabel_artifacts(self, tmp):
+        output_dir = Path(tmp) / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        body = "[00:05] [Speaker 2] first\n[00:10] [Speaker 3] second"
+        summary_path = output_dir / "mtg001_summary.md"
+        summary_path.write_text("## Transcript\n\n" + body + "\n", encoding="utf-8")
+        write_speakers_sidecar(output_dir, "mtg001", {
+            "mic": {
+                "recording_type": "in_person",
+                "clusters": {
+                    "SPEAKER_00": {
+                        "embedding": [1.0, 0.0], "speech_duration_seconds": 30.0,
+                        "segment_count": 5, "segments": [{"start": 4.0, "end": 6.0}],
+                    },
+                    "SPEAKER_01": {
+                        "embedding": [0.0, 1.0], "speech_duration_seconds": 30.0,
+                        "segment_count": 5, "segments": [{"start": 9.0, "end": 11.0}],
+                    },
+                },
+            },
+        }, turn_manifest=[
+            {"start": 5.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"},
+            {"start": 10.1, "channel": "mic", "diarization_speaker_id": "SPEAKER_01"},
+        ])
+        transcript_path = Path(tmp) / "transcripts" / "mtg001_transcript.txt"
+        transcript_path.parent.mkdir(parents=True, exist_ok=True)
+        transcript_path.write_text(
+            "Session: mtg001\n\n" + "=" * 60 + "\n\n" + body,
+            encoding="utf-8",
+        )
+        return output_dir, summary_path, transcript_path
+
     def test_requires_exactly_one_of_person_id_or_new_person(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._seed_sidecar(tmp)
@@ -980,6 +1012,90 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 "pending_summary_transcript_sync",
                 read_speakers_sidecar(output_dir, "mtg001"),
             )
+
+    def test_completed_marker_after_clear_failure_is_reconciled_before_another_confirm(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = self._seed_two_cluster_relabel_artifacts(tmp)
+            with mock.patch("simple_recorder._clear_summary_transcript_sync", return_value=False):
+                first, cfg = self._run([
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ], tmp)
+
+            self.assertFalse(_last_json(first.output)["success"])
+            self.assertIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+            second, _ = self._run([
+                "mtg001", "mic", "SPEAKER_01", "--new-person", "Person Beta",
+                "--relabel-transcript",
+            ], tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(second.output)["success"])
+            self.assertIn("[00:10] [Person Beta] second", transcript_path.read_text(encoding="utf-8"))
+            self.assertIn("[00:10] [Person Beta] second", summary_path.read_text(encoding="utf-8"))
+            self.assertIn("Person Beta", summary_path.read_text(encoding="utf-8"))
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+    def test_change_confirmation_reconciles_a_completed_marker_from_the_old_person(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = self._seed_two_cluster_relabel_artifacts(tmp)
+            with mock.patch("simple_recorder._clear_summary_transcript_sync", return_value=False):
+                first, cfg = self._run([
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ], tmp)
+            self.assertFalse(_last_json(first.output)["success"])
+            person_beta = cfg.create_person_profile("Person Beta")
+
+            changed, _ = self._run([
+                "mtg001", "mic", "SPEAKER_00", "--person-id", person_beta["person_id"],
+                "--relabel-transcript",
+            ], tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(changed.output)["success"])
+            self.assertIn("[00:05] [Person Beta] first", transcript_path.read_text(encoding="utf-8"))
+            self.assertIn("[00:05] [Person Beta] first", summary_path.read_text(encoding="utf-8"))
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+    def test_ambiguous_pending_marker_fails_before_a_second_confirm_mutates_profiles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = self._seed_two_cluster_relabel_artifacts(tmp)
+            real_atomic_write = simple_recorder._atomic_write_text
+
+            def fail_alpha_summary_write(path, text, *args, **kwargs):
+                if path == summary_path and "[Person Alpha]" in text:
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_alpha_summary_write,
+            ):
+                first, cfg = self._run([
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ], tmp)
+            self.assertTrue(_last_json(first.output)["success"])
+
+            second, _ = self._run([
+                "mtg001", "mic", "SPEAKER_01", "--new-person", "Person Beta",
+                "--relabel-transcript",
+            ], tmp, cfg=cfg)
+
+            self.assertNotEqual(second.exit_code, 0)
+            self.assertFalse(_last_json(second.output)["success"])
+            self.assertEqual([p["display_name"] for p in cfg.get_person_profiles()], ["Person Alpha"])
+            self.assertIn("[00:10] [Speaker 3] second", transcript_path.read_text(encoding="utf-8"))
+            self.assertIn("[00:10] [Speaker 3] second", summary_path.read_text(encoding="utf-8"))
 
     def test_relabel_prefers_json_when_both_summary_formats_exist(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -9,7 +9,11 @@ from click.testing import CliRunner
 
 import simple_recorder
 from src.config import Config
-from src.speaker_suggestions import read_speakers_sidecar, write_speakers_sidecar
+from src.speaker_suggestions import (
+    read_speakers_sidecar,
+    write_sidecar_document,
+    write_speakers_sidecar,
+)
 
 
 def _last_json(output):
@@ -905,17 +909,15 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                     raise OSError("simulated summary write failure")
                 return real_atomic_write(path, text, *args, **kwargs)
 
+            request = [
+                "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma",
+                "--relabel-transcript",
+            ]
             with mock.patch(
                 "simple_recorder._atomic_write_text",
                 side_effect=fail_first_summary_transcript_write,
             ):
-                first, cfg = self._run(
-                    [
-                        "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma",
-                        "--relabel-transcript",
-                    ],
-                    tmp,
-                )
+                first, cfg = self._run(request, tmp)
 
             first_data = _last_json(first.output)
             self.assertNotEqual(first.exit_code, 0)
@@ -928,17 +930,10 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 read_speakers_sidecar(output_dir, "mtg001"),
             )
 
-            person_id = cfg.get_person_profiles()[0]["person_id"]
-            retry, _ = self._run(
-                [
-                    "mtg001", "mic", "SPEAKER_00", "--person-id", person_id,
-                    "--relabel-transcript",
-                ],
-                tmp,
-                cfg=cfg,
-            )
+            retry, _ = self._run(request, tmp, cfg=cfg)
             retry_data = _last_json(retry.output)
             self.assertTrue(retry_data["success"])
+            self.assertEqual(len(cfg.get_person_profiles()), 1)
             self.assertEqual(retry_data["relabeled_lines"], 0)
             self.assertIn("[Person Gamma] hello there", summary_path.read_text())
             self.assertNotIn("[Speaker 2] hello there", summary_path.read_text())
@@ -946,6 +941,110 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 "pending_summary_transcript_sync",
                 read_speakers_sidecar(output_dir, "mtg001"),
             )
+
+    def test_canonical_transcript_write_failure_reports_json_and_retries_same_request(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, summary_path, transcript_path = self._seed_two_cluster_relabel_artifacts(tmp)
+            summary_path.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] first\n[00:10] [Speaker 3] second\n",
+                encoding="utf-8",
+            )
+            request = [
+                "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                "--relabel-transcript",
+            ]
+            transcript_before = transcript_path.read_text(encoding="utf-8")
+            summary_before = summary_path.read_text(encoding="utf-8")
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
+            real_write_text = Path.write_text
+            transcript_tmp = transcript_path.with_name(transcript_path.name + ".tmp")
+
+            def fail_canonical_tmp_write(path, text, *args, **kwargs):
+                if path == transcript_tmp:
+                    raise OSError("simulated canonical transcript write failure")
+                return real_write_text(path, text, *args, **kwargs)
+
+            with mock.patch.object(Path, "write_text", new=fail_canonical_tmp_write):
+                failed, cfg = self._run(request, tmp)
+
+            failed_data = _last_json(failed.output)
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(failed_data["success"])
+            profiles = cfg.get_person_profiles()
+            self.assertEqual(len(profiles), 1)
+            self.assertEqual(profiles[0]["display_name"], "Person Alpha")
+            self.assertEqual(len(profiles[0]["prototypes"]), 1)
+            committed_person_id = profiles[0]["person_id"]
+            sidecar_after_failure = read_speakers_sidecar(output_dir, "mtg001")
+            marker = sidecar_after_failure["pending_summary_transcript_sync"]
+            expected_sidecar = json.loads(json.dumps(sidecar_before))
+            expected_sidecar["pending_summary_transcript_sync"] = marker
+            expected_sidecar["transcript_lines"][0]["original_label"] = "Speaker 2"
+            self.assertEqual(sidecar_after_failure, expected_sidecar)
+            self.assertEqual(transcript_path.read_text(encoding="utf-8"), transcript_before)
+            self.assertEqual(summary_path.read_text(encoding="utf-8"), summary_before)
+            self.assertNotIn("## Participants", summary_before)
+
+            retry, _ = self._run(request, tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertEqual(len(cfg.get_person_profiles()), 1)
+            self.assertEqual(cfg.get_person_profiles()[0]["person_id"], committed_person_id)
+            self.assertNotEqual(
+                read_speakers_sidecar(output_dir, "mtg001").get(
+                    "pending_summary_transcript_sync"
+                ),
+                marker,
+            )
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+            self.assertIn("[00:05] [Person Alpha] first", transcript_path.read_text())
+            self.assertIn("[00:05] [Person Alpha] first", summary_path.read_text())
+            self.assertIn("Person Alpha", summary_path.read_text())
+
+    def test_new_person_retry_does_not_reuse_name_without_matching_cluster_provenance(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir, _summary_path, _transcript_path = (
+                self._seed_two_cluster_relabel_artifacts(tmp)
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            person = cfg.create_person_profile("Person Alpha")
+            cfg.add_speaker_prototype(
+                person["person_id"],
+                [1.0, 0.0],
+                recording_type="in_person",
+                meeting_id="other-meeting",
+                diarization_speaker_id="SPEAKER_00",
+                speech_duration_seconds=30.0,
+                segment_count=5,
+                created_from="user_confirmed",
+                channel="mic",
+            )
+            sidecar = read_speakers_sidecar(output_dir, "mtg001")
+            sidecar["pending_summary_transcript_sync"] = {
+                "version": 2,
+                "operation_sha256": simple_recorder._summary_sync_operation_hash(
+                    {("mic", "SPEAKER_00")}, "Person Alpha"
+                ),
+            }
+            write_sidecar_document(output_dir, "mtg001", sidecar)
+            profiles_before = cfg.get_person_profiles()
+
+            failed, _ = self._run(
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertEqual(cfg.get_person_profiles(), profiles_before)
 
     def test_relabel_retry_keeps_marker_when_same_second_turns_make_repair_unsafe(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -740,6 +740,14 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "output"
             output_dir.mkdir(parents=True, exist_ok=True)
+            summary_path = output_dir / "mtg001_summary.md"
+            summary_path.write_text(
+                "---\nis_diarised: true\n---\n\n"
+                "## Summary\n\nA three-person meeting.\n\n"
+                "## Transcript\n\n"
+                "[00:05] [Speaker 2] hello there\n\n[00:20] [You] hi back\n",
+                encoding="utf-8",
+            )
             write_speakers_sidecar(output_dir, "mtg001", {
                 "mic": {
                     "recording_type": "in_person",
@@ -768,6 +776,45 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             text = transcript_path.read_text()
             self.assertIn("[00:05] [Person Gamma] hello there", text)
             self.assertIn("[00:20] [You] hi back", text)  # untouched
+            summary_text = summary_path.read_text()
+            self.assertIn("[00:05] [Person Gamma] hello there", summary_text)
+            self.assertNotIn("[00:05] [Speaker 2] hello there", summary_text)
+
+    def test_relabel_transcript_preserves_a_manually_edited_summary_copy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._seed_sidecar(tmp)
+            output_dir = Path(tmp) / "output"
+            summary_path = output_dir / "mtg001_summary.md"
+            edited_summary = (
+                "---\nis_diarised: true\n---\n\n## Summary\n\nEdited note.\n\n"
+                "## Transcript\n\n[00:00] [Speaker 2] manually corrected wording\n"
+            )
+            summary_path.write_text(edited_summary, encoding="utf-8")
+            transcripts_dir = Path(tmp) / "transcripts"
+            transcripts_dir.mkdir(parents=True, exist_ok=True)
+            transcript_path = transcripts_dir / "mtg001_transcript.txt"
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n[00:00] [Speaker 2] original wording",
+                encoding="utf-8",
+            )
+
+            result, _ = self._run(
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma", "--relabel-transcript"],
+                tmp,
+            )
+
+            self.assertTrue(_last_json(result.output)["success"])
+            summary_text = summary_path.read_text(encoding="utf-8")
+            self.assertIn("[00:00] [Speaker 2] manually corrected wording", summary_text)
+            self.assertNotIn("[00:00] [Speaker 2] original wording", summary_text)
+
+    def test_saved_transcript_body_does_not_treat_a_body_divider_as_a_header(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript_path = Path(tmp) / "body-only.txt"
+            body = "[00:00] [You] before\n\n" + "=" * 60 + "\n\n[00:05] [Others] after"
+            transcript_path.write_text(body, encoding="utf-8")
+
+            self.assertEqual(simple_recorder._saved_transcript_body(transcript_path), body)
 
     def test_relabel_transcript_uses_exact_matching_when_sidecar_has_manifest(self):
         # See the plan doc's Phase 8: when the sidecar carries

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -888,6 +888,10 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             self.assertTrue(failed_once)
             self.assertIn("[Person Gamma] hello there", transcript_path.read_text())
             self.assertIn("[Speaker 2] hello there", summary_path.read_text())
+            self.assertIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
 
             retry, _ = self._run(
                 [
@@ -902,6 +906,263 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             self.assertEqual(retry_data["relabeled_lines"], 0)
             self.assertIn("[Person Gamma] hello there", summary_path.read_text())
             self.assertNotIn("[Speaker 2] hello there", summary_path.read_text())
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+    def test_relabel_retry_preserves_a_json_copy_with_only_its_label_edited(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            summary_path = output_dir / "mtg001_summary.json"
+            summary_path.write_text(json.dumps({
+                "is_diarised": True,
+                "diarised_text": "[00:05] [Speaker 2] hello there",
+            }), encoding="utf-8")
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 30.0,
+                            "segment_count": 5,
+                            "segments": [{"start": 4.0, "end": 6.0}],
+                        },
+                    },
+                },
+            }, turn_manifest=[{
+                "start": 5.1,
+                "channel": "mic",
+                "diarization_speaker_id": "SPEAKER_00",
+            }])
+            transcript_path = Path(tmp) / "transcripts" / "mtg001_transcript.txt"
+            transcript_path.parent.mkdir(parents=True, exist_ok=True)
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n"
+                "[00:05] [Speaker 2] hello there",
+                encoding="utf-8",
+            )
+            real_atomic_write = simple_recorder._atomic_write_json
+
+            def fail_summary_write(path, payload, *args, **kwargs):
+                if path == summary_path and payload.get("diarised_text", "").find("Person Gamma") >= 0:
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, payload, *args, **kwargs)
+
+            with mock.patch("simple_recorder._atomic_write_json", side_effect=fail_summary_write):
+                first, cfg = self._run([
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma",
+                    "--relabel-transcript",
+                ], tmp)
+
+            first_data = _last_json(first.output)
+            self.assertTrue(first_data["success"])
+            edited = json.loads(summary_path.read_text(encoding="utf-8"))
+            edited["diarised_text"] = "[00:05] [Person Delta] hello there"
+            summary_path.write_text(json.dumps(edited), encoding="utf-8")
+            pending = read_speakers_sidecar(output_dir, "mtg001")[
+                "pending_summary_transcript_sync"
+            ]
+            self.assertNotIn("hello there", json.dumps(pending))
+            self.assertNotIn("Person Gamma", json.dumps(pending))
+
+            retry, _ = self._run([
+                "mtg001", "mic", "SPEAKER_00", "--person-id", first_data["person_id"],
+                "--relabel-transcript",
+            ], tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(summary["diarised_text"], "[00:05] [Person Delta] hello there")
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+    def test_relabel_prefers_json_when_both_summary_formats_exist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            before = "[00:05] [Speaker 2] hello there"
+            json_path = output_dir / "mtg001_summary.json"
+            json_path.write_text(json.dumps({"diarised_text": before}), encoding="utf-8")
+            md_path = output_dir / "mtg001_summary.md"
+            md_path.write_text(
+                "## Summary\n\nText.\n\n## Transcript\n\n" + before + "\n",
+                encoding="utf-8",
+            )
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 30.0,
+                            "segment_count": 5,
+                            "segments": [{"start": 4.0, "end": 6.0}],
+                        },
+                    },
+                },
+            }, turn_manifest=[{
+                "start": 5.1,
+                "channel": "mic",
+                "diarization_speaker_id": "SPEAKER_00",
+            }])
+            transcript_path = Path(tmp) / "transcripts" / "mtg001_transcript.txt"
+            transcript_path.parent.mkdir(parents=True, exist_ok=True)
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n" + before,
+                encoding="utf-8",
+            )
+
+            result, _ = self._run([
+                "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma",
+                "--relabel-transcript",
+            ], tmp)
+
+            self.assertTrue(_last_json(result.output)["success"])
+            self.assertIn(
+                "[Person Gamma] hello there",
+                json.loads(json_path.read_text(encoding="utf-8"))["diarised_text"],
+            )
+            self.assertIn("[Speaker 2] hello there", md_path.read_text(encoding="utf-8"))
+
+    def test_marker_write_failure_leaves_both_transcript_artifacts_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            before = "[00:05] [Speaker 2] hello there"
+            summary_path = output_dir / "mtg001_summary.md"
+            summary_path.write_text(
+                "## Summary\n\nText.\n\n## Transcript\n\n" + before + "\n",
+                encoding="utf-8",
+            )
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 30.0,
+                            "segment_count": 5,
+                            "segments": [{"start": 4.0, "end": 6.0}],
+                        },
+                    },
+                },
+            }, turn_manifest=[{
+                "start": 5.1,
+                "channel": "mic",
+                "diarization_speaker_id": "SPEAKER_00",
+            }])
+            transcript_path = Path(tmp) / "transcripts" / "mtg001_transcript.txt"
+            transcript_path.parent.mkdir(parents=True, exist_ok=True)
+            transcript_file_before = "Session: mtg001\n\n" + "=" * 60 + "\n\n" + before
+            transcript_path.write_text(transcript_file_before, encoding="utf-8")
+            summary_before = summary_path.read_text(encoding="utf-8")
+            import src.speaker_suggestions as speaker_suggestions
+            real_write = speaker_suggestions.write_sidecar_document
+
+            def fail_only_marker_write(output, stem, document, **kwargs):
+                if "pending_summary_transcript_sync" in document:
+                    raise OSError("simulated marker write failure")
+                return real_write(output, stem, document, **kwargs)
+
+            with mock.patch.object(
+                speaker_suggestions,
+                "write_sidecar_document",
+                side_effect=fail_only_marker_write,
+            ):
+                first, cfg = self._run([
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma",
+                    "--relabel-transcript",
+                ], tmp)
+
+            first_data = _last_json(first.output)
+            self.assertTrue(first_data["success"])
+            self.assertEqual(transcript_path.read_text(encoding="utf-8"), transcript_file_before)
+            self.assertEqual(summary_path.read_text(encoding="utf-8"), summary_before)
+
+            retry, _ = self._run([
+                "mtg001", "mic", "SPEAKER_00", "--person-id", first_data["person_id"],
+                "--relabel-transcript",
+            ], tmp, cfg=cfg)
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertIn("[Person Gamma] hello there", transcript_path.read_text(encoding="utf-8"))
+            self.assertIn("[Person Gamma] hello there", summary_path.read_text(encoding="utf-8"))
+
+    def test_change_confirmation_retry_uses_the_exact_old_person_copy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            summary_path = output_dir / "mtg001_summary.md"
+            summary_path.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 30.0,
+                            "segment_count": 5,
+                            "segments": [{"start": 4.0, "end": 6.0}],
+                        },
+                    },
+                },
+            }, turn_manifest=[{
+                "start": 5.1,
+                "channel": "mic",
+                "diarization_speaker_id": "SPEAKER_00",
+            }])
+            transcript_path = Path(tmp) / "transcripts" / "mtg001_transcript.txt"
+            transcript_path.parent.mkdir(parents=True, exist_ok=True)
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n"
+                "[00:05] [Speaker 2] hello there",
+                encoding="utf-8",
+            )
+            first, cfg = self._run([
+                "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                "--relabel-transcript",
+            ], tmp)
+            self.assertTrue(_last_json(first.output)["success"])
+            person_beta = cfg.create_person_profile("Person Beta")
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_beta_summary_write(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary_path and not failed_once and "[Person Beta]" in text:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_first_beta_summary_write,
+            ):
+                changed, _ = self._run([
+                    "mtg001", "mic", "SPEAKER_00", "--person-id", person_beta["person_id"],
+                    "--relabel-transcript",
+                ], tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(changed.output)["success"])
+            self.assertIn("[Person Beta] hello there", transcript_path.read_text(encoding="utf-8"))
+            self.assertIn("[Person Alpha] hello there", summary_path.read_text(encoding="utf-8"))
+
+            retry, _ = self._run([
+                "mtg001", "mic", "SPEAKER_00", "--person-id", person_beta["person_id"],
+                "--relabel-transcript",
+            ], tmp, cfg=cfg)
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertIn("[Person Beta] hello there", summary_path.read_text(encoding="utf-8"))
+            self.assertNotIn("[Person Alpha] hello there", summary_path.read_text(encoding="utf-8"))
 
     def test_relabel_retry_preserves_a_manually_edited_summary_copy(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -823,6 +823,120 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             self.assertNotIn("[00:00] [Person Gamma] manually corrected wording", summary_text)
             self.assertNotIn("[00:00] [Speaker 2] original wording", summary_text)
 
+    def test_relabel_retry_repairs_summary_after_its_first_write_fails(self):
+        # The canonical transcript write can complete before the best-effort
+        # summary write fails. Repeating this confirmation must repair the
+        # matching summary even though there are no new transcript relabels.
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            summary_path = output_dir / "mtg001_summary.md"
+            summary_path.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 30.0,
+                            "segment_count": 5,
+                            "segments": [{"start": 4.0, "end": 6.0}],
+                        },
+                    },
+                },
+            }, turn_manifest=[{
+                "start": 5.1,
+                "channel": "mic",
+                "diarization_speaker_id": "SPEAKER_00",
+            }])
+            transcripts_dir = Path(tmp) / "transcripts"
+            transcripts_dir.mkdir(parents=True, exist_ok=True)
+            transcript_path = transcripts_dir / "mtg001_transcript.txt"
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n"
+                "[00:05] [Speaker 2] hello there",
+                encoding="utf-8",
+            )
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_transcript_write(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary_path and not failed_once and "[Person Gamma]" in text:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_first_summary_transcript_write,
+            ):
+                first, cfg = self._run(
+                    [
+                        "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma",
+                        "--relabel-transcript",
+                    ],
+                    tmp,
+                )
+
+            first_data = _last_json(first.output)
+            self.assertTrue(first_data["success"])
+            self.assertTrue(failed_once)
+            self.assertIn("[Person Gamma] hello there", transcript_path.read_text())
+            self.assertIn("[Speaker 2] hello there", summary_path.read_text())
+
+            retry, _ = self._run(
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--person-id", first_data["person_id"],
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            retry_data = _last_json(retry.output)
+            self.assertTrue(retry_data["success"])
+            self.assertEqual(retry_data["relabeled_lines"], 0)
+            self.assertIn("[Person Gamma] hello there", summary_path.read_text())
+            self.assertNotIn("[Speaker 2] hello there", summary_path.read_text())
+
+    def test_relabel_retry_preserves_a_manually_edited_summary_copy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            transcript_path = Path(tmp) / "transcripts" / "mtg001_transcript.txt"
+            transcript_path.parent.mkdir(parents=True, exist_ok=True)
+            canonical_body = "[00:05] [Person Gamma] original wording"
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n" + canonical_body,
+                encoding="utf-8",
+            )
+            summary_path = output_dir / "mtg001_summary.md"
+            edited_summary = (
+                "## Summary\n\nEdited note.\n\n## Transcript\n\n"
+                "[00:05] [Speaker 2] manually corrected wording\n"
+            )
+            summary_path.write_text(edited_summary, encoding="utf-8")
+
+            simple_recorder._update_summary_transcript(
+                output_dir,
+                "mtg001",
+                transcript_path,
+                canonical_body,
+                restore_manifest=[{
+                    "start": 5.1,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_00",
+                }],
+                restore_target_ids={("mic", "SPEAKER_00")},
+                retry_relabel_to="Person Gamma",
+            )
+
+            self.assertEqual(summary_path.read_text(encoding="utf-8"), edited_summary)
+
     def test_saved_transcript_body_does_not_treat_a_body_divider_as_a_header(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript_path = Path(tmp) / "body-only.txt"

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -1225,7 +1225,7 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             )
             self.assertIn("[Speaker 2] hello there", md_path.read_text(encoding="utf-8"))
 
-    def test_marker_write_failure_leaves_both_transcript_artifacts_unchanged(self):
+    def test_marker_write_failure_rolls_back_confirmation_and_reports_failure(self):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "output"
             output_dir.mkdir(parents=True, exist_ok=True)
@@ -1257,6 +1257,7 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
             transcript_file_before = "Session: mtg001\n\n" + "=" * 60 + "\n\n" + before
             transcript_path.write_text(transcript_file_before, encoding="utf-8")
             summary_before = summary_path.read_text(encoding="utf-8")
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
             import src.speaker_suggestions as speaker_suggestions
             real_write = speaker_suggestions.write_sidecar_document
 
@@ -1276,12 +1277,15 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 ], tmp)
 
             first_data = _last_json(first.output)
-            self.assertTrue(first_data["success"])
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertFalse(first_data["success"])
+            self.assertEqual(cfg.get_person_profiles(), [])
             self.assertEqual(transcript_path.read_text(encoding="utf-8"), transcript_file_before)
             self.assertEqual(summary_path.read_text(encoding="utf-8"), summary_before)
+            self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), sidecar_before)
 
             retry, _ = self._run([
-                "mtg001", "mic", "SPEAKER_00", "--person-id", first_data["person_id"],
+                "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Gamma",
                 "--relabel-transcript",
             ], tmp, cfg=cfg)
             self.assertTrue(_last_json(retry.output)["success"])

--- a/tests/test_confirm_speaker_cli.py
+++ b/tests/test_confirm_speaker_cli.py
@@ -782,8 +782,19 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
 
     def test_relabel_transcript_preserves_a_manually_edited_summary_copy(self):
         with tempfile.TemporaryDirectory() as tmp:
-            self._seed_sidecar(tmp)
             output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0], "speech_duration_seconds": 30.0, "segment_count": 5,
+                            "segments": [{"start": 0.0, "end": 1.0}],
+                        },
+                    },
+                },
+            })
             summary_path = output_dir / "mtg001_summary.md"
             edited_summary = (
                 "---\nis_diarised: true\n---\n\n## Summary\n\nEdited note.\n\n"
@@ -803,9 +814,13 @@ class ConfirmSpeakerCliTests(unittest.TestCase):
                 tmp,
             )
 
-            self.assertTrue(_last_json(result.output)["success"])
+            data = _last_json(result.output)
+            self.assertTrue(data["success"])
+            self.assertEqual(data["relabeled_lines"], 1)
+            self.assertIn("[00:00] [Person Gamma] original wording", transcript_path.read_text(encoding="utf-8"))
             summary_text = summary_path.read_text(encoding="utf-8")
             self.assertIn("[00:00] [Speaker 2] manually corrected wording", summary_text)
+            self.assertNotIn("[00:00] [Person Gamma] manually corrected wording", summary_text)
             self.assertNotIn("[00:00] [Speaker 2] original wording", summary_text)
 
     def test_saved_transcript_body_does_not_treat_a_body_divider_as_a_header(self):

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1453,6 +1453,10 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertTrue(failed_once)
             self.assertNotIn("Person Alpha", transcript.read_text())
             self.assertIn("[00:05] [Person Alpha] hello there", summary.read_text())
+            self.assertIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(Path(tmp) / "output", "mtg001"),
+            )
 
             retry = self._run(
                 simple_recorder.mark_speaker_cluster,
@@ -1465,6 +1469,76 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertEqual(retry_data["transcript_lines_restored"], 0)
             self.assertIn("[00:05] [Speaker 2] hello there", summary.read_text())
             self.assertNotIn("Person Alpha", summary.read_text())
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(Path(tmp) / "output", "mtg001"),
+            )
+
+    def test_retry_preserves_a_summary_with_only_its_label_edited(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{
+                    "start": 5.2,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_00",
+                }],
+            )
+            summary = Path(tmp) / "output" / "mtg001_summary.md"
+            summary.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+
+            real_atomic_write = simple_recorder._atomic_write_text
+
+            def fail_summary_write(path, text, *args, **kwargs):
+                if path == summary and "[Speaker 2] hello there" in text:
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch("simple_recorder._atomic_write_text", side_effect=fail_summary_write):
+                first = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertTrue(_last_json(first.output)["success"])
+            self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
+            summary.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Transcript\n\n[00:05] [Person Delta] hello there\n",
+                encoding="utf-8",
+            )
+
+            retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertIn("[00:05] [Person Delta] hello there", summary.read_text(encoding="utf-8"))
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(Path(tmp) / "output", "mtg001"),
+            )
 
     def test_retry_refuses_reordered_summary_turns_sharing_a_timestamp(self):
         # The manifest retains 5.1 and 5.8, but both are rendered as 00:05.
@@ -1508,6 +1582,19 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                     "original_label": "Speaker 3",
                 },
             ]
+            marker = {
+                "version": 1,
+                "summary_format": "md",
+                "canonical_before_sha256": simple_recorder._transcript_body_hash(
+                    stale_reordered_body,
+                ),
+                "embedded_before_sha256": simple_recorder._transcript_body_hash(
+                    stale_reordered_body,
+                ),
+                "operation_sha256": simple_recorder._summary_sync_operation_hash(
+                    {("mic", "SPEAKER_A")}, "Person Alpha",
+                ),
+            }
 
             with self.assertLogs("src.speaker_suggestions", level="WARNING") as logs:
                 simple_recorder._update_summary_transcript(
@@ -1518,6 +1605,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                     restore_manifest=manifest,
                     restore_target_ids={("mic", "SPEAKER_A")},
                     retry_relabel_to="Person Alpha",
+                    sync_marker=marker,
                 )
 
             self.assertEqual(summary.read_text(encoding="utf-8"), original_summary)
@@ -1560,6 +1648,19 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                     "original_label": "Speaker 3",
                 },
             ]
+            embedded_body = (
+                "[00:05] [Person Beta] beta words\n"
+                "[00:05] [Person Alpha] alpha words"
+            )
+            marker = {
+                "version": 1,
+                "summary_format": "md",
+                "canonical_before_sha256": simple_recorder._transcript_body_hash(embedded_body),
+                "embedded_before_sha256": simple_recorder._transcript_body_hash(embedded_body),
+                "operation_sha256": simple_recorder._summary_sync_operation_hash(
+                    {("mic", "SPEAKER_A")}, "Person Alpha",
+                ),
+            }
 
             with self.assertLogs("src.speaker_suggestions", level="WARNING") as logs:
                 simple_recorder._update_summary_transcript(
@@ -1570,6 +1671,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                     restore_manifest=manifest,
                     restore_target_ids={("mic", "SPEAKER_A")},
                     retry_relabel_to="Person Alpha",
+                    sync_marker=marker,
                 )
 
             self.assertEqual(summary.read_text(encoding="utf-8"), original_summary)

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1336,6 +1336,86 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             )
             self.assertIn("[00:05] [Speaker 2] hello there", summary_text)
 
+    def test_marker_write_failure_rolls_back_marking_and_reports_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{
+                    "start": 5.2,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_00",
+                }],
+            )
+            output_dir = Path(tmp) / "output"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Participants\n\nPerson Alpha\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+
+            transcript_before = transcript.read_text(encoding="utf-8")
+            summary_before = summary.read_text(encoding="utf-8")
+            profiles_before = cfg.get_person_profiles()
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
+            import src.speaker_suggestions as speaker_suggestions
+            real_write = speaker_suggestions.write_sidecar_document
+
+            def fail_only_marker_write(output, stem, document, **kwargs):
+                if "pending_summary_transcript_sync" in document:
+                    raise OSError("simulated marker write failure")
+                return real_write(output, stem, document, **kwargs)
+
+            with mock.patch.object(
+                speaker_suggestions,
+                "write_sidecar_document",
+                side_effect=fail_only_marker_write,
+            ):
+                failed = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertEqual(cfg.get_person_profiles(), profiles_before)
+            self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), sidecar_before)
+            self.assertEqual(transcript.read_text(encoding="utf-8"), transcript_before)
+            self.assertEqual(summary.read_text(encoding="utf-8"), summary_before)
+
+            retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertEqual(cfg.get_person_profiles()[0]["prototypes"], [])
+            sidecar_after = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertTrue(
+                sidecar_after["channels"]["mic"]["clusters"]["SPEAKER_00"][
+                    MULTI_SPEAKER_KEY
+                ]
+            )
+            self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
+            self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
+            self.assertNotIn("## Participants", summary.read_text(encoding="utf-8"))
+
     def test_mark_reconciles_a_completed_marker_before_profile_cleanup(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript = self._seed_with_transcript(

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1393,6 +1393,188 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertNotIn("Person Alpha", transcript.read_text())
             self.assertNotIn("Person Alpha", summary.read_text())
 
+    def test_retry_repairs_summary_after_its_first_write_fails(self):
+        # The first attempt can restore the canonical transcript successfully
+        # but lose the best-effort summary write.  A retry must not use its
+        # zero restored-line count as a reason to leave the stale person name
+        # in the summary's embedded transcript.
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{
+                    "start": 5.2,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_00",
+                }],
+            )
+            summary = Path(tmp) / "output" / "mtg001_summary.md"
+            summary.write_text(
+                "---\ntitle: \"Meeting\"\n---\n\n"
+                "## Summary\n\nText.\n\n"
+                "## Participants\n\nPerson Alpha\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_transcript_write(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary and not failed_once and "[Speaker 2] hello there" in text:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_first_summary_transcript_write,
+            ):
+                first = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertTrue(_last_json(first.output)["success"])
+            self.assertTrue(failed_once)
+            self.assertNotIn("Person Alpha", transcript.read_text())
+            self.assertIn("[00:05] [Person Alpha] hello there", summary.read_text())
+
+            retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+            retry_data = _last_json(retry.output)
+            self.assertTrue(retry_data["success"])
+            self.assertEqual(retry_data["transcript_lines_restored"], 0)
+            self.assertIn("[00:05] [Speaker 2] hello there", summary.read_text())
+            self.assertNotIn("Person Alpha", summary.read_text())
+
+    def test_retry_refuses_reordered_summary_turns_sharing_a_timestamp(self):
+        # The manifest retains 5.1 and 5.8, but both are rendered as 00:05.
+        # If a user reorders those summary lines, their marker and position no
+        # longer prove which one belongs to the target cluster.  Repairing the
+        # apparent stale name would otherwise rewrite the other person's line.
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            transcript_path = Path(tmp) / "transcripts" / "mtg001_transcript.txt"
+            transcript_path.parent.mkdir(parents=True, exist_ok=True)
+            canonical_body = (
+                "[00:05] [Speaker 2] alpha words\n"
+                "[00:05] [Speaker 3] beta words"
+            )
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n" + canonical_body,
+                encoding="utf-8",
+            )
+            summary = output_dir / "mtg001_summary.md"
+            stale_reordered_body = (
+                "[00:05] [Person Beta] beta words\n"
+                "[00:05] [Person Alpha] alpha words"
+            )
+            original_summary = (
+                "## Summary\n\nText.\n\n## Transcript\n\n"
+                f"{stale_reordered_body}\n"
+            )
+            summary.write_text(original_summary, encoding="utf-8")
+            manifest = [
+                {
+                    "start": 5.1,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_A",
+                    "original_label": "Speaker 2",
+                },
+                {
+                    "start": 5.8,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_B",
+                    "original_label": "Speaker 3",
+                },
+            ]
+
+            with self.assertLogs("src.speaker_suggestions", level="WARNING") as logs:
+                simple_recorder._update_summary_transcript(
+                    output_dir,
+                    "mtg001",
+                    transcript_path,
+                    canonical_body,
+                    restore_manifest=manifest,
+                    restore_target_ids={("mic", "SPEAKER_A")},
+                    retry_relabel_to="Person Alpha",
+                )
+
+            self.assertEqual(summary.read_text(encoding="utf-8"), original_summary)
+            self.assertTrue(any("no unique summary marker" in line for line in logs.output))
+
+    def test_retry_refuses_duplicate_summary_marker_when_other_start_is_missing(self):
+        # A missing start is not evidence that the other turn belongs to a
+        # different second.  The stored summary only has [00:05] for both
+        # rows, so the retry cannot prove which reordered row is the target.
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            transcript_path = Path(tmp) / "transcripts" / "mtg001_transcript.txt"
+            transcript_path.parent.mkdir(parents=True, exist_ok=True)
+            canonical_body = (
+                "[00:05] [Speaker 2] alpha words\n"
+                "[00:05] [Speaker 3] beta words"
+            )
+            transcript_path.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n" + canonical_body,
+                encoding="utf-8",
+            )
+            summary = output_dir / "mtg001_summary.md"
+            original_summary = (
+                "## Summary\n\nText.\n\n## Transcript\n\n"
+                "[00:05] [Person Beta] beta words\n"
+                "[00:05] [Person Alpha] alpha words\n"
+            )
+            summary.write_text(original_summary, encoding="utf-8")
+            manifest = [
+                {
+                    "start": 5.1,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_A",
+                    "original_label": "Speaker 2",
+                },
+                {
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_B",
+                    "original_label": "Speaker 3",
+                },
+            ]
+
+            with self.assertLogs("src.speaker_suggestions", level="WARNING") as logs:
+                simple_recorder._update_summary_transcript(
+                    output_dir,
+                    "mtg001",
+                    transcript_path,
+                    canonical_body,
+                    restore_manifest=manifest,
+                    restore_target_ids={("mic", "SPEAKER_A")},
+                    retry_relabel_to="Person Alpha",
+                )
+
+            self.assertEqual(summary.read_text(encoding="utf-8"), original_summary)
+            self.assertTrue(any("no unique summary marker" in line for line in logs.output))
+
     def test_without_a_recorded_original_the_line_says_multiple_speakers(self):
         # Every meeting confirmed before the original label was recorded has
         # nothing to restore. Putting back "You" or "Speaker 3" would invent

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1719,6 +1719,158 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 sidecar_after_retry["channels"]["mic"]["clusters"]["SPEAKER_00"],
             )
 
+    def test_legacy_mark_retry_recovers_a_noncanonical_profile_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            generic_body = "[00:03] [Speaker 2] hello there"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text("## Transcript\n\n" + generic_body + "\n", encoding="utf-8")
+            transcripts_dir = Path(tmp) / "transcripts"
+            transcripts_dir.mkdir(parents=True, exist_ok=True)
+            transcript = transcripts_dir / "mtg001_transcript.txt"
+            transcript.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n" + generic_body,
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "system", "SPEAKER_0", "--new-person", "Alice",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            cfg._config["person_profiles"][0]["display_name"] = "\uff21\uff4c\uff49\uff43\uff45"
+            self.assertTrue(cfg._save())
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_restore(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary and not failed_once:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text", side_effect=fail_first_summary_restore,
+            ):
+                interrupted = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "system", "SPEAKER_0"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(interrupted.exit_code, 0)
+            self.assertTrue(failed_once)
+            self.assertIn("[Multiple speakers] hello there", transcript.read_text(encoding="utf-8"))
+            self.assertIn("[Alice] hello there", summary.read_text(encoding="utf-8"))
+            marker = read_speakers_sidecar(output_dir, "mtg001")[
+                "pending_summary_transcript_sync"
+            ]
+            self.assertIn(
+                simple_recorder._transcript_body_hash("Alice"),
+                marker["legacy_label_sha256s"],
+            )
+
+            retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "system", "SPEAKER_0"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertIn("[Multiple speakers] hello there", summary.read_text(encoding="utf-8"))
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+    def test_legacy_mark_retry_fails_closed_for_unrelated_invalid_profile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            generic_body = "[00:03] [Speaker 2] hello there"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text("## Transcript\n\n" + generic_body + "\n", encoding="utf-8")
+            transcripts_dir = Path(tmp) / "transcripts"
+            transcripts_dir.mkdir(parents=True, exist_ok=True)
+            transcript = transcripts_dir / "mtg001_transcript.txt"
+            transcript.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n" + generic_body,
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "system", "SPEAKER_0", "--new-person", "Alice",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_restore(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary and not failed_once:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text", side_effect=fail_first_summary_restore,
+            ):
+                interrupted = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "system", "SPEAKER_0"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(interrupted.exit_code, 0)
+            self.assertTrue(failed_once)
+            self.assertIn("pending_summary_transcript_sync", read_speakers_sidecar(output_dir, "mtg001"))
+
+            # This profile is unrelated to the meeting and therefore skipped
+            # by the initial profile preflight. The legacy whole-copy retry
+            # still scans it, so an invalid reserved name must be handled by
+            # the CLI error contract rather than escaping as a traceback.
+            cfg._config["person_profiles"].append({
+                "person_id": "unrelated",
+                "display_name": "You",
+                "prototypes": [],
+                "hard_negatives": [],
+            })
+            self.assertTrue(cfg._save())
+            profiles_before = cfg.get_person_profiles()
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
+            transcript_before = transcript.read_text(encoding="utf-8")
+            summary_before = summary.read_text(encoding="utf-8")
+
+            failed = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "system", "SPEAKER_0"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            error = _last_json(failed.output)
+            self.assertFalse(error["success"])
+            self.assertEqual(error["error"], "Invalid person name.")
+            self.assertEqual(cfg.get_person_profiles(), profiles_before)
+            self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), sidecar_before)
+            self.assertEqual(transcript.read_text(encoding="utf-8"), transcript_before)
+            self.assertEqual(summary.read_text(encoding="utf-8"), summary_before)
+
     def test_legacy_mark_retries_after_canonical_write_failure(self):
         with tempfile.TemporaryDirectory() as tmp:
             output_dir = Path(tmp) / "output"
@@ -1938,6 +2090,69 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertNotIn("pending_summary_transcript_sync", read_speakers_sidecar(output_dir, "mtg001"))
             self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
             self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
+
+    def test_single_refuses_an_unfinished_marking_transaction(self):
+        """Clearing a mixed marking cannot bypass its failed summary repair."""
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"}],
+            )
+            output_dir = Path(tmp) / "output"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha", "--relabel-transcript"],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            real_atomic_write = simple_recorder._atomic_write_text
+
+            def fail_summary_restore(path, text, *args, **kwargs):
+                if path == summary and "[Speaker 2] hello there" in text:
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text", side_effect=fail_summary_restore,
+            ):
+                interrupted = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(interrupted.exit_code, 0)
+            sidecar_before_single = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertTrue(
+                sidecar_before_single["channels"]["mic"]["clusters"]["SPEAKER_00"][
+                    MULTI_SPEAKER_KEY
+                ]
+            )
+            self.assertIn("pending_summary_transcript_sync", sidecar_before_single)
+
+            cleared = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00", "--single"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertNotEqual(cleared.exit_code, 0)
+            self.assertFalse(_last_json(cleared.output)["success"])
+            self.assertEqual(
+                read_speakers_sidecar(output_dir, "mtg001"), sidecar_before_single,
+            )
+            self.assertIn("[Person Alpha] hello there", summary.read_text(encoding="utf-8"))
+            self.assertIn("[Speaker 2] hello there", transcript.read_text(encoding="utf-8"))
 
     def test_mark_reports_a_marker_clear_failure_without_success(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1416,6 +1416,174 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
             self.assertNotIn("## Participants", summary.read_text(encoding="utf-8"))
 
+    def test_transcript_read_error_fails_before_marking_or_profile_cleanup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{
+                    "start": 5.2,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_00",
+                }],
+            )
+            output_dir = Path(tmp) / "output"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Participants\n\nPerson Alpha\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            transcript_before = transcript.read_text(encoding="utf-8")
+            summary_before = summary.read_text(encoding="utf-8")
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
+            profiles_before = cfg.get_person_profiles()
+            real_read_text = Path.read_text
+
+            def fail_canonical_read(path, *args, **kwargs):
+                if path == transcript:
+                    raise PermissionError("simulated transcript read denial")
+                return real_read_text(path, *args, **kwargs)
+
+            with mock.patch.object(Path, "read_text", new=fail_canonical_read):
+                failed = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertEqual(cfg.get_person_profiles(), profiles_before)
+            self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), sidecar_before)
+            self.assertEqual(transcript.read_text(encoding="utf-8"), transcript_before)
+            self.assertEqual(summary.read_text(encoding="utf-8"), summary_before)
+            self.assertNotIn("pending_summary_transcript_sync", sidecar_before)
+
+            retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertEqual(cfg.get_person_profiles()[0]["prototypes"], [])
+            sidecar_after_retry = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertTrue(
+                sidecar_after_retry["channels"]["mic"]["clusters"]["SPEAKER_00"][
+                    MULTI_SPEAKER_KEY
+                ]
+            )
+            self.assertNotIn("pending_summary_transcript_sync", sidecar_after_retry)
+            self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
+            self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
+            self.assertNotIn("## Participants", summary.read_text(encoding="utf-8"))
+
+    def test_canonical_transcript_write_failure_keeps_marker_and_retries_mark(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{
+                    "start": 5.2,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_00",
+                }],
+            )
+            output_dir = Path(tmp) / "output"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Participants\n\nPerson Alpha\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            transcript_before = transcript.read_text(encoding="utf-8")
+            summary_before = summary.read_text(encoding="utf-8")
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
+            transcript_tmp = transcript.with_name(transcript.name + ".tmp")
+            real_write_text = Path.write_text
+
+            def fail_canonical_tmp_write(path, text, *args, **kwargs):
+                if path == transcript_tmp:
+                    raise OSError("simulated canonical transcript write failure")
+                return real_write_text(path, text, *args, **kwargs)
+
+            with mock.patch.object(Path, "write_text", new=fail_canonical_tmp_write):
+                failed = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertEqual(cfg.get_person_profiles()[0]["prototypes"], [])
+            sidecar_after_failure = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertTrue(
+                sidecar_after_failure["channels"]["mic"]["clusters"]["SPEAKER_00"][
+                    MULTI_SPEAKER_KEY
+                ]
+            )
+            marker = sidecar_after_failure["pending_summary_transcript_sync"]
+            expected_sidecar = json.loads(json.dumps(sidecar_before))
+            expected_sidecar["pending_summary_transcript_sync"] = marker
+            expected_sidecar["channels"]["mic"]["clusters"]["SPEAKER_00"][
+                MULTI_SPEAKER_KEY
+            ] = True
+            self.assertEqual(sidecar_after_failure, expected_sidecar)
+            self.assertEqual(transcript.read_text(encoding="utf-8"), transcript_before)
+            self.assertEqual(summary.read_text(encoding="utf-8"), summary_before)
+            self.assertIn("Person Alpha", summary_before)
+
+            retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertNotEqual(
+                read_speakers_sidecar(output_dir, "mtg001").get(
+                    "pending_summary_transcript_sync"
+                ),
+                marker,
+            )
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+            self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
+            self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
+            self.assertNotIn("## Participants", summary.read_text(encoding="utf-8"))
+
     def test_mark_reconciles_a_completed_marker_before_profile_cleanup(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript = self._seed_with_transcript(

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1113,6 +1113,51 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 [p["diarization_run_id"] for p in profile["prototypes"]], [run1],
             )
 
+    def test_reserved_you_profile_fails_before_marking_mutation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = self._seed(tmp)
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            person = cfg.create_person_profile("Person Alpha")
+            cfg.add_speaker_prototype(
+                person["person_id"], [1.0, 0.0], recording_type="remote",
+                meeting_id="mtg001", diarization_speaker_id="SPEAKER_0",
+                speech_duration_seconds=60.0, segment_count=10,
+                created_from="user_confirmed", channel="system",
+                diarization_run_id=self._seeded_run_id(tmp),
+            )
+            cfg._config["person_profiles"][0]["display_name"] = "You"
+            self.assertTrue(cfg._save())
+            set_cluster_review_state(
+                output_dir, "mtg001", "system", "SPEAKER_0", REVIEW_STATE_GENERIC,
+            )
+            transcript_dir = Path(tmp) / "transcripts"
+            transcript_dir.mkdir(parents=True, exist_ok=True)
+            transcript = transcript_dir / "mtg001_transcript.txt"
+            transcript.write_text("[00:03] [You] own words", encoding="utf-8")
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Participants\n\nYou\n\n## Transcript\n\n[00:03] [You] own words\n",
+                encoding="utf-8",
+            )
+            profiles_before = cfg.get_person_profiles()
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
+            transcript_before = transcript.read_text(encoding="utf-8")
+            summary_before = summary.read_text(encoding="utf-8")
+
+            failed = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "system", "SPEAKER_0"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertEqual(cfg.get_person_profiles(), profiles_before)
+            self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), sidecar_before)
+            self.assertEqual(transcript.read_text(encoding="utf-8"), transcript_before)
+            self.assertEqual(summary.read_text(encoding="utf-8"), summary_before)
+
     def test_marking_withdraws_this_runs_negatives_and_keeps_an_older_runs(self):
         # The other two removals in the same loop, which the test above never
         # reaches (it stops at a positive removal that matches nothing). A
@@ -1567,6 +1612,194 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
             self.assertNotIn("## Participants", summary.read_text(encoding="utf-8"))
 
+    def test_legacy_mark_restores_transcript_and_summary_and_retries_io_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 30.0,
+                            "segment_count": 5,
+                            "segments": [{"start": 4.0, "end": 6.0}],
+                        },
+                    },
+                },
+            })
+            summary = output_dir / "mtg001_summary.md"
+            generic_body = "[00:05] [Speaker 2] hello there"
+            summary.write_text(
+                "## Summary\n\nText.\n\n## Transcript\n\n" + generic_body + "\n",
+                encoding="utf-8",
+            )
+            transcripts_dir = Path(tmp) / "transcripts"
+            transcripts_dir.mkdir(parents=True, exist_ok=True)
+            transcript = transcripts_dir / "mtg001_transcript.txt"
+            transcript.write_text(
+                "Session: mtg001\n\n" + "=" * 60 + "\n\n" + generic_body,
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            self.assertIn("[Person Alpha] hello there", transcript.read_text())
+            set_cluster_review_state(
+                output_dir,
+                "mtg001",
+                "mic",
+                "SPEAKER_00",
+                REVIEW_STATE_GENERIC,
+            )
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_restore(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary and not failed_once and "[Multiple speakers]" in text:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_first_summary_restore,
+            ):
+                failed = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertTrue(failed_once)
+            self.assertEqual(cfg.get_person_profiles()[0]["prototypes"], [])
+            self.assertIn("[Multiple speakers] hello there", transcript.read_text())
+            self.assertIn("[Person Alpha] hello there", summary.read_text())
+            self.assertNotIn("## Participants", summary.read_text())
+            sidecar_after_failure = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertIn("pending_summary_transcript_sync", sidecar_after_failure)
+            self.assertTrue(
+                sidecar_after_failure["channels"]["mic"]["clusters"]["SPEAKER_00"][
+                    MULTI_SPEAKER_KEY
+                ]
+            )
+            self.assertNotIn(
+                REVIEW_STATE_KEY,
+                sidecar_after_failure["channels"]["mic"]["clusters"]["SPEAKER_00"],
+            )
+
+            retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertIn("[Multiple speakers] hello there", summary.read_text())
+            self.assertNotIn("Person Alpha", summary.read_text())
+            self.assertNotIn("## Participants", summary.read_text())
+            sidecar_after_retry = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertNotIn("pending_summary_transcript_sync", sidecar_after_retry)
+            self.assertNotIn(
+                REVIEW_STATE_KEY,
+                sidecar_after_retry["channels"]["mic"]["clusters"]["SPEAKER_00"],
+            )
+
+    def test_legacy_mark_retries_after_canonical_write_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            write_speakers_sidecar(output_dir, "mtg001", {
+                "mic": {
+                    "recording_type": "in_person",
+                    "clusters": {
+                        "SPEAKER_00": {
+                            "embedding": [1.0, 0.0],
+                            "speech_duration_seconds": 30.0,
+                            "segment_count": 5,
+                            "segments": [{"start": 4.0, "end": 6.0}],
+                        },
+                    },
+                },
+            })
+            generic_body = "[00:05] [Speaker 2] hello there"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Transcript\n\n" + generic_body + "\n",
+                encoding="utf-8",
+            )
+            transcripts_dir = Path(tmp) / "transcripts"
+            transcripts_dir.mkdir(parents=True, exist_ok=True)
+            transcript = transcripts_dir / "mtg001_transcript.txt"
+            transcript.write_text(generic_body, encoding="utf-8")
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            transcript_tmp = transcript.with_name(transcript.name + ".tmp")
+            real_write_text = Path.write_text
+
+            def fail_canonical_tmp_write(path, text, *args, **kwargs):
+                if path == transcript_tmp and "[Multiple speakers]" in text:
+                    raise OSError("simulated canonical transcript write failure")
+                return real_write_text(path, text, *args, **kwargs)
+
+            with mock.patch.object(Path, "write_text", new=fail_canonical_tmp_write):
+                failed = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertEqual(cfg.get_person_profiles()[0]["prototypes"], [])
+            self.assertIn("[Person Alpha] hello there", transcript.read_text())
+            self.assertIn("[Person Alpha] hello there", summary.read_text())
+            self.assertIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
+            retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertIn("[Multiple speakers] hello there", transcript.read_text())
+            self.assertIn("[Multiple speakers] hello there", summary.read_text())
+            self.assertNotIn("Person Alpha", summary.read_text())
+            self.assertNotIn("## Participants", summary.read_text())
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+
     def test_canonical_transcript_write_failure_keeps_marker_and_retries_mark(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript = self._seed_with_transcript(
@@ -1683,6 +1916,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             sidecar = read_speakers_sidecar(output_dir, "mtg001")
             sidecar["pending_summary_transcript_sync"] = {
                 "version": simple_recorder._PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+                "target_ids": [["mic", "SPEAKER_00"]],
                 "summary_format": "md",
                 "canonical_before_sha256": simple_recorder._transcript_body_hash(canonical_body),
                 "embedded_before_sha256": simple_recorder._transcript_body_hash(canonical_body),

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -42,6 +42,7 @@ from src.speaker_suggestions import (
     set_cluster_review_state,
     suggest_speaker,
     suggest_speakers_for_meeting,
+    write_sidecar_document,
     write_speakers_sidecar,
 )
 
@@ -1335,6 +1336,140 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             )
             self.assertIn("[00:05] [Speaker 2] hello there", summary_text)
 
+    def test_mark_reconciles_a_completed_marker_before_profile_cleanup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"}],
+            )
+            output_dir = Path(tmp) / "output"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha", "--relabel-transcript"],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            canonical_body = "[00:05] [Person Alpha] hello there"
+            sidecar = read_speakers_sidecar(output_dir, "mtg001")
+            sidecar["pending_summary_transcript_sync"] = {
+                "version": simple_recorder._PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+                "summary_format": "md",
+                "canonical_before_sha256": simple_recorder._transcript_body_hash(canonical_body),
+                "embedded_before_sha256": simple_recorder._transcript_body_hash(canonical_body),
+                "canonical_after_sha256": simple_recorder._transcript_body_hash(canonical_body),
+                "operation_sha256": simple_recorder._summary_sync_operation_hash(
+                    {("mic", "SPEAKER_01")}, "Person Other",
+                ),
+            }
+            write_sidecar_document(output_dir, "mtg001", sidecar)
+
+            marked = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertTrue(_last_json(marked.output)["success"])
+            self.assertNotIn("pending_summary_transcript_sync", read_speakers_sidecar(output_dir, "mtg001"))
+            self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
+            self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
+
+    def test_mark_reports_a_marker_clear_failure_without_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"}],
+            )
+            output_dir = Path(tmp) / "output"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha", "--relabel-transcript"],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+
+            with mock.patch("simple_recorder._clear_summary_transcript_sync", return_value=False):
+                marked = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(marked.exit_code, 0)
+            self.assertFalse(_last_json(marked.output)["success"])
+            self.assertIn("pending_summary_transcript_sync", read_speakers_sidecar(output_dir, "mtg001"))
+            self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
+            self.assertNotIn("[Person Alpha]", summary.read_text(encoding="utf-8"))
+
+    def test_mark_fails_closed_for_an_ambiguous_pending_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{"start": 5.2, "channel": "mic", "diarization_speaker_id": "SPEAKER_00"}],
+            )
+            output_dir = Path(tmp) / "output"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                ["mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha", "--relabel-transcript"],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            canonical_body = "[00:05] [Person Alpha] hello there"
+            sidecar = read_speakers_sidecar(output_dir, "mtg001")
+            sidecar["pending_summary_transcript_sync"] = {
+                "version": simple_recorder._PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
+                "summary_format": "md",
+                "canonical_before_sha256": simple_recorder._transcript_body_hash(canonical_body),
+                "embedded_before_sha256": simple_recorder._transcript_body_hash(canonical_body),
+                "canonical_after_sha256": simple_recorder._transcript_body_hash("different"),
+                "operation_sha256": simple_recorder._summary_sync_operation_hash(
+                    {("mic", "SPEAKER_01")}, "Person Other",
+                ),
+            }
+            write_sidecar_document(output_dir, "mtg001", sidecar)
+
+            marked = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertNotEqual(marked.exit_code, 0)
+            self.assertFalse(_last_json(marked.output)["success"])
+            self.assertIn("Person Alpha", transcript.read_text(encoding="utf-8"))
+            self.assertIn("Person Alpha", summary.read_text(encoding="utf-8"))
+            self.assertNotIn(
+                MULTI_SPEAKER_KEY,
+                read_speakers_sidecar(output_dir, "mtg001")["channels"]["mic"]["clusters"]["SPEAKER_00"],
+            )
+
     def test_retry_after_sidecar_failure_repairs_transcript_and_participants(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript = self._seed_with_transcript(
@@ -1583,13 +1718,16 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 },
             ]
             marker = {
-                "version": 1,
+                "version": simple_recorder._PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
                 "summary_format": "md",
                 "canonical_before_sha256": simple_recorder._transcript_body_hash(
                     stale_reordered_body,
                 ),
                 "embedded_before_sha256": simple_recorder._transcript_body_hash(
                     stale_reordered_body,
+                ),
+                "canonical_after_sha256": simple_recorder._transcript_body_hash(
+                    canonical_body,
                 ),
                 "operation_sha256": simple_recorder._summary_sync_operation_hash(
                     {("mic", "SPEAKER_A")}, "Person Alpha",
@@ -1653,10 +1791,13 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 "[00:05] [Person Alpha] alpha words"
             )
             marker = {
-                "version": 1,
+                "version": simple_recorder._PENDING_SUMMARY_TRANSCRIPT_SYNC_VERSION,
                 "summary_format": "md",
                 "canonical_before_sha256": simple_recorder._transcript_body_hash(embedded_body),
                 "embedded_before_sha256": simple_recorder._transcript_body_hash(embedded_body),
+                "canonical_after_sha256": simple_recorder._transcript_body_hash(
+                    canonical_body,
+                ),
                 "operation_sha256": simple_recorder._summary_sync_operation_hash(
                     {("mic", "SPEAKER_A")}, "Person Alpha",
                 ),

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1942,6 +1942,113 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 read_speakers_sidecar(Path(tmp) / "output", "mtg001"),
             )
 
+    def test_mark_retry_marker_survives_review_or_participants_followup_failure(self):
+        for failure_stage in ("review_state", "participants"):
+            with self.subTest(failure_stage=failure_stage), tempfile.TemporaryDirectory() as tmp:
+                transcript = self._seed_with_transcript(
+                    tmp,
+                    "[00:05] [Speaker 2] hello there",
+                    [{
+                        "start": 5.2,
+                        "channel": "mic",
+                        "diarization_speaker_id": "SPEAKER_00",
+                    }],
+                )
+                output_dir = Path(tmp) / "output"
+                summary = output_dir / "mtg001_summary.md"
+                summary.write_text(
+                    "## Summary\n\nText.\n\n"
+                    "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                    encoding="utf-8",
+                )
+                cfg = Config(config_path=Path(tmp) / "config.json")
+                confirmed = self._run(
+                    simple_recorder.confirm_speaker,
+                    [
+                        "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                        "--relabel-transcript",
+                    ],
+                    tmp,
+                    cfg=cfg,
+                )
+                self.assertTrue(_last_json(confirmed.output)["success"])
+                set_cluster_review_state(
+                    output_dir,
+                    "mtg001",
+                    "mic",
+                    "SPEAKER_00",
+                    REVIEW_STATE_GENERIC,
+                )
+
+                if failure_stage == "review_state":
+                    failure_patch = mock.patch(
+                        "src.speaker_suggestions.clear_cluster_review_state",
+                        return_value=0,
+                    )
+                else:
+                    real_write_text = Path.write_text
+                    summary_tmp = summary.with_name(summary.name + ".tmp")
+
+                    def fail_participants_write(path, text, *args, **kwargs):
+                        if path == summary_tmp and "## Participants" not in text:
+                            raise OSError("simulated participants write failure")
+                        return real_write_text(path, text, *args, **kwargs)
+
+                    failure_patch = mock.patch.object(
+                        Path,
+                        "write_text",
+                        new=fail_participants_write,
+                    )
+
+                with failure_patch:
+                    failed = self._run(
+                        simple_recorder.mark_speaker_cluster,
+                        ["mtg001", "mic", "SPEAKER_00"],
+                        tmp,
+                        cfg=cfg,
+                    )
+
+                self.assertNotEqual(failed.exit_code, 0)
+                self.assertFalse(_last_json(failed.output)["success"])
+                self.assertEqual(cfg.get_person_profiles()[0]["prototypes"], [])
+                sidecar_after_failure = read_speakers_sidecar(output_dir, "mtg001")
+                self.assertTrue(
+                    sidecar_after_failure["channels"]["mic"]["clusters"]["SPEAKER_00"][
+                        MULTI_SPEAKER_KEY
+                    ]
+                )
+                self.assertIn("pending_summary_transcript_sync", sidecar_after_failure)
+                self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
+                self.assertNotIn(
+                    "[00:05] [Person Alpha] hello there",
+                    summary.read_text(encoding="utf-8"),
+                )
+                if failure_stage == "review_state":
+                    self.assertEqual(
+                        sidecar_after_failure["channels"]["mic"]["clusters"][
+                            "SPEAKER_00"
+                        ][REVIEW_STATE_KEY],
+                        REVIEW_STATE_GENERIC,
+                    )
+                else:
+                    self.assertIn("Person Alpha", summary.read_text(encoding="utf-8"))
+
+                retry = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+                self.assertTrue(_last_json(retry.output)["success"])
+                sidecar_after_retry = read_speakers_sidecar(output_dir, "mtg001")
+                self.assertNotIn("pending_summary_transcript_sync", sidecar_after_retry)
+                self.assertNotIn(
+                    REVIEW_STATE_KEY,
+                    sidecar_after_retry["channels"]["mic"]["clusters"]["SPEAKER_00"],
+                )
+                self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
+
     def test_mark_retry_keeps_marker_when_same_second_turns_make_repair_unsafe(self):
         with tempfile.TemporaryDirectory() as tmp:
             generic_body = (

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1293,6 +1293,14 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                     {"start": 20.0, "channel": "mic", "diarization_speaker_id": "SPEAKER_01"},
                 ],
             )
+            summary = Path(tmp) / "output" / "mtg001_summary.md"
+            summary.write_text(
+                "---\nis_diarised: true\n---\n\n"
+                "## Summary\n\nA two-person meeting.\n\n"
+                "## Transcript\n\n"
+                "[00:05] [Speaker 2] hello there\n\n[00:20] [You] hi back\n",
+                encoding="utf-8",
+            )
             cfg = Config(config_path=Path(tmp) / "config.json")
             cfg.set_identity_matching_enabled(True)
             with mock.patch("src.config.get_config", return_value=cfg), \
@@ -1303,6 +1311,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 ])
             self.assertTrue(_last_json(confirmed.output)["success"])
             self.assertIn("[00:05] [Person Alpha] hello there", transcript.read_text())
+            self.assertIn("[00:05] [Person Alpha] hello there", summary.read_text())
 
             result = self._run(
                 simple_recorder.mark_speaker_cluster,
@@ -1319,6 +1328,12 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 "and the label the line carried before the confirmation comes back",
             )
             self.assertIn("[00:20] [You] hi back", text)  # never this cluster's line
+            summary_text = summary.read_text()
+            self.assertNotIn(
+                "Person Alpha", summary_text,
+                "the withdrawn name must leave the embedded transcript too",
+            )
+            self.assertIn("[00:05] [Speaker 2] hello there", summary_text)
 
     def test_retry_after_sidecar_failure_repairs_transcript_and_participants(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1224,13 +1224,13 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 "a negative earned by a DIFFERENT cluster is not this marking's to delete",
             )
 
-    def _seed_with_transcript(self, tmp, body, manifest):
+    def _seed_with_transcript(self, tmp, body, manifest, *, clusters=None):
         output_dir = Path(tmp) / "output"
         output_dir.mkdir(parents=True, exist_ok=True)
         write_speakers_sidecar(output_dir, "mtg001", {
             "mic": {
                 "recording_type": "in_person",
-                "clusters": {
+                "clusters": clusters or {
                     "SPEAKER_00": {
                         "embedding": [1.0, 0.0], "speech_duration_seconds": 30.0,
                         "segment_count": 5, "segments": [{"start": 4.0, "end": 6.0}],
@@ -1530,7 +1530,7 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
 
     def test_retry_repairs_summary_after_its_first_write_fails(self):
         # The first attempt can restore the canonical transcript successfully
-        # but lose the best-effort summary write.  A retry must not use its
+        # but lose the summary write. A retry must not use its
         # zero restored-line count as a reason to leave the stale person name
         # in the summary's embedded transcript.
         with tempfile.TemporaryDirectory() as tmp:
@@ -1584,7 +1584,8 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                     cfg=cfg,
                 )
 
-            self.assertTrue(_last_json(first.output)["success"])
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertFalse(_last_json(first.output)["success"])
             self.assertTrue(failed_once)
             self.assertNotIn("Person Alpha", transcript.read_text())
             self.assertIn("[00:05] [Person Alpha] hello there", summary.read_text())
@@ -1608,6 +1609,130 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                 "pending_summary_transcript_sync",
                 read_speakers_sidecar(Path(tmp) / "output", "mtg001"),
             )
+
+    def test_mark_retry_keeps_marker_when_same_second_turns_make_repair_unsafe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            generic_body = (
+                "[00:05] [Speaker 2] alpha words\n"
+                "[00:05] [Speaker 3] beta words"
+            )
+            named_body = (
+                "[00:05] [Person Alpha] alpha words\n"
+                "[00:05] [Speaker 3] beta words"
+            )
+            manifest = [
+                {
+                    "start": 5.1,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_00",
+                },
+                {
+                    "start": 5.8,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_01",
+                },
+            ]
+            clusters = {
+                "SPEAKER_00": {
+                    "embedding": [1.0, 0.0],
+                    "speech_duration_seconds": 30.0,
+                    "segment_count": 5,
+                    "segments": [{"start": 4.0, "end": 6.0}],
+                },
+                "SPEAKER_01": {
+                    "embedding": [0.0, 1.0],
+                    "speech_duration_seconds": 25.0,
+                    "segment_count": 4,
+                    "segments": [{"start": 5.5, "end": 7.0}],
+                },
+            }
+            transcript = self._seed_with_transcript(
+                tmp, generic_body, manifest, clusters=clusters,
+            )
+            output_dir = Path(tmp) / "output"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Transcript\n\n" + generic_body + "\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+            self.assertEqual(simple_recorder._saved_transcript_body(transcript), named_body)
+
+            real_atomic_write = simple_recorder._atomic_write_text
+            failed_once = False
+
+            def fail_first_summary_transcript_write(path, text, *args, **kwargs):
+                nonlocal failed_once
+                if path == summary and not failed_once and "[Speaker 2] alpha words" in text:
+                    failed_once = True
+                    raise OSError("simulated summary write failure")
+                return real_atomic_write(path, text, *args, **kwargs)
+
+            with mock.patch(
+                "simple_recorder._atomic_write_text",
+                side_effect=fail_first_summary_transcript_write,
+            ):
+                first = self._run(
+                    simple_recorder.mark_speaker_cluster,
+                    ["mtg001", "mic", "SPEAKER_00"],
+                    tmp,
+                    cfg=cfg,
+                )
+
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertFalse(_last_json(first.output)["success"])
+            self.assertTrue(failed_once)
+            self.assertEqual(simple_recorder._saved_transcript_body(transcript), generic_body)
+            self.assertIn(named_body, summary.read_text(encoding="utf-8"))
+            marker = read_speakers_sidecar(output_dir, "mtg001")[
+                "pending_summary_transcript_sync"
+            ]
+
+            unsafe_retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertNotEqual(unsafe_retry.exit_code, 0)
+            self.assertFalse(_last_json(unsafe_retry.output)["success"])
+            self.assertEqual(simple_recorder._saved_transcript_body(transcript), generic_body)
+            self.assertIn(named_body, summary.read_text(encoding="utf-8"))
+            self.assertEqual(
+                read_speakers_sidecar(output_dir, "mtg001")[
+                    "pending_summary_transcript_sync"
+                ],
+                marker,
+            )
+
+            summary.write_text(
+                "## Transcript\n\n" + generic_body + "\n",
+                encoding="utf-8",
+            )
+            recovered = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertTrue(_last_json(recovered.output)["success"])
+            self.assertNotIn(
+                "pending_summary_transcript_sync",
+                read_speakers_sidecar(output_dir, "mtg001"),
+            )
+            self.assertIn(generic_body, summary.read_text(encoding="utf-8"))
 
     def test_retry_preserves_a_summary_with_only_its_label_edited(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1653,7 +1778,8 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
                     cfg=cfg,
                 )
 
-            self.assertTrue(_last_json(first.output)["success"])
+            self.assertNotEqual(first.exit_code, 0)
+            self.assertFalse(_last_json(first.output)["success"])
             self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
             summary.write_text(
                 "## Summary\n\nText.\n\n"

--- a/tests/test_speaker_multi_marking.py
+++ b/tests/test_speaker_multi_marking.py
@@ -1493,6 +1493,80 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
             self.assertNotIn("## Participants", summary.read_text(encoding="utf-8"))
 
+    def test_missing_transcript_fails_before_marking_and_succeeds_after_restore(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript = self._seed_with_transcript(
+                tmp,
+                "[00:05] [Speaker 2] hello there",
+                [{
+                    "start": 5.2,
+                    "channel": "mic",
+                    "diarization_speaker_id": "SPEAKER_00",
+                }],
+            )
+            output_dir = Path(tmp) / "output"
+            summary = output_dir / "mtg001_summary.md"
+            summary.write_text(
+                "## Summary\n\nText.\n\n"
+                "## Participants\n\nPerson Alpha\n\n"
+                "## Transcript\n\n[00:05] [Speaker 2] hello there\n",
+                encoding="utf-8",
+            )
+            cfg = Config(config_path=Path(tmp) / "config.json")
+            confirmed = self._run(
+                simple_recorder.confirm_speaker,
+                [
+                    "mtg001", "mic", "SPEAKER_00", "--new-person", "Person Alpha",
+                    "--relabel-transcript",
+                ],
+                tmp,
+                cfg=cfg,
+            )
+            self.assertTrue(_last_json(confirmed.output)["success"])
+
+            transcript_before = transcript.read_text(encoding="utf-8")
+            summary_before = summary.read_text(encoding="utf-8")
+            profiles_before = cfg.get_person_profiles()
+            sidecar_before = read_speakers_sidecar(output_dir, "mtg001")
+            transcript.unlink()
+
+            failed = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertNotEqual(failed.exit_code, 0)
+            self.assertFalse(_last_json(failed.output)["success"])
+            self.assertEqual(cfg.get_person_profiles(), profiles_before)
+            self.assertEqual(read_speakers_sidecar(output_dir, "mtg001"), sidecar_before)
+            self.assertFalse(transcript.exists())
+            self.assertEqual(summary.read_text(encoding="utf-8"), summary_before)
+            self.assertIn("Person Alpha", summary_before)
+            self.assertNotIn("pending_summary_transcript_sync", sidecar_before)
+
+            transcript.write_text(transcript_before, encoding="utf-8")
+            retry = self._run(
+                simple_recorder.mark_speaker_cluster,
+                ["mtg001", "mic", "SPEAKER_00"],
+                tmp,
+                cfg=cfg,
+            )
+
+            self.assertTrue(_last_json(retry.output)["success"])
+            self.assertEqual(cfg.get_person_profiles()[0]["prototypes"], [])
+            sidecar_after_retry = read_speakers_sidecar(output_dir, "mtg001")
+            self.assertTrue(
+                sidecar_after_retry["channels"]["mic"]["clusters"]["SPEAKER_00"][
+                    MULTI_SPEAKER_KEY
+                ]
+            )
+            self.assertNotIn("pending_summary_transcript_sync", sidecar_after_retry)
+            self.assertNotIn("Person Alpha", transcript.read_text(encoding="utf-8"))
+            self.assertNotIn("Person Alpha", summary.read_text(encoding="utf-8"))
+            self.assertNotIn("## Participants", summary.read_text(encoding="utf-8"))
+
     def test_canonical_transcript_write_failure_keeps_marker_and_retries_mark(self):
         with tempfile.TemporaryDirectory() as tmp:
             transcript = self._seed_with_transcript(
@@ -1748,9 +1822,19 @@ class MarkSpeakerClusterCliTests(unittest.TestCase):
             self.assertIn("Person Alpha", transcript.read_text())
             self.assertIn("Person Alpha", summary.read_text())
 
-            with mock.patch(
-                "src.speaker_suggestions.write_sidecar_document",
-                side_effect=OSError("disk full"),
+            import src.speaker_suggestions as speaker_suggestions
+            real_write = speaker_suggestions.write_sidecar_document
+
+            def fail_multi_speaker_write(output, stem, document, **kwargs):
+                target = document["channels"]["mic"]["clusters"]["SPEAKER_00"]
+                if target.get(MULTI_SPEAKER_KEY):
+                    raise OSError("disk full")
+                return real_write(output, stem, document, **kwargs)
+
+            with mock.patch.object(
+                speaker_suggestions,
+                "write_sidecar_document",
+                side_effect=fail_multi_speaker_write,
             ):
                 first = self._run(
                     simple_recorder.mark_speaker_cluster,

--- a/tests/test_speaker_schema.py
+++ b/tests/test_speaker_schema.py
@@ -42,6 +42,11 @@ class SpeakerSchemaTests(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     validate_display_name(value)
 
+    def test_display_name_rejects_reserved_self_label(self):
+        for value in ("You", " you ", "Ｙｏｕ"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                validate_display_name(value)
+
     def test_sidecar_path_rejects_a_stem_outside_the_output_directory(self):
         with self.assertRaises(ValueError):
             speakers_sidecar_path(self.temp_dir, "../private")


### PR DESCRIPTION
## Description

Closes #486.

Show generic `Speaker 2`, `Speaker 3`, and `Speaker 4` labels in diarized transcripts while keeping the channel-level `Others` marker implicit.

When a speaker is confirmed or changed, the saved summary transcript is synchronized only if its embedded copy still matches the pre-relabel transcript. Manually corrected or redacted copies remain authoritative. An independent review caught and regression-tested an earlier read-time fallback that could resurface unredacted text; the final implementation does not read the standalone transcript when opening a meeting.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Tested locally with `npm start`
- [x] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

- Python: 1,148 tests passed
- Node/Vitest: 335 + 200 tests passed
- Renderer typecheck and build passed; lint had 0 errors and 37 existing warnings
- T1: 110 passed; the focused speaker-label test was rerun after review
- Model-free T2: 108 passed, 1 model-dependent test skipped because its model is not installed
- Fresh PyInstaller backend bundle built successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows diarized "Speaker N" labels in the transcript panel and keeps embedded summary transcripts current without resurfacing redacted content. Previously generic labels were hidden and a read-time fallback could leak unredacted text; now "Speaker N" is shown, "Others" stays implicit, and meeting detail reads `diarised_text` from the summary only.

- Transcript UI: display "Speaker N" and confirmed names; keep "Others" implicit; "You" unchanged.
- Relabel sync: update the saved transcript on confirm/change/withdraw with `--relabel-transcript`, updating the summary's embedded `diarised_text` only when it still matches the pre-change body; preserve manually edited/redacted copies; prefer JSON over Markdown if both exist.
- Speaker naming: reject any new display name that normalizes to the reserved "You" self-label.
- Retry repair: when a summary write fails, a retry repairs the embedded copy via exact manifest provenance only, refusing when target timestamps are duplicated or ambiguous.
- Tests: E2E and CLI coverage for label rendering, reserved-name rejection, conditional summary syncing, retry repair, redaction preservation, and meeting-detail `diarised_text`.

<sup>Written for commit b039ff9f903294610f4c73d95cc06fe4dd35dca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

