### PR TITLE
fix: let interrupted Parakeet downloads resume

### DIFF
--- a/src/parakeet_models.py
+++ b/src/parakeet_models.py
@@ -39,6 +39,20 @@ SUPPORTED_PARAKEET_MODELS: dict[str, dict] = {
     },
 }
 
+_REQUIRED_SNAPSHOT_FILES: dict[str, tuple[str, ...]] = {
+    "mlx-community/parakeet-tdt-0.6b-v3": (
+        "config.json",
+        "model.safetensors",
+    ),
+    "istupakov/parakeet-tdt-0.6b-v3-onnx": (
+        "config.json",
+        "encoder-model.int8.onnx",
+        "decoder_joint-model.int8.onnx",
+        "vocab.txt",
+    ),
+}
+
+
 
 def _hf_cache_dir_for(model_id: str) -> Path:
     """HuggingFace hub cache directory for a given repo id.
@@ -70,24 +84,40 @@ def _hf_cache_dir_for(model_id: str) -> Path:
 
 
 def is_installed(model_id: str = DEFAULT_MODEL_ID) -> bool:
-    """Return True iff the model has at least one downloaded snapshot on disk.
+    """Return True iff a complete runtime snapshot is present on disk.
 
-    Checks the HuggingFace cache directly so we don't import parakeet-mlx
-    (and trigger model loading) just to answer the question — Settings polls
-    this on tab load and the import cost would visibly stall the UI.
+    HuggingFace creates the snapshot directory and config symlink before a
+    large weight download finishes. Treating any non-empty snapshot as
+    installed makes the next backend process force ``HF_HUB_OFFLINE=1``, so it
+    can neither resume the partial download nor load the missing weights.
+    Require every file the selected runtime opens instead.
 
-    MUST stay free of any ``huggingface_hub`` import: ``maybe_enable_offline``
-    sets ``HF_HUB_OFFLINE`` and relies on the hub being import-deferred until
-    ``_load_model`` runs. Importing the hub here would snapshot the env too
-    early and silently defeat offline mode.
+    This stays free of ``huggingface_hub`` imports because
+    ``maybe_enable_offline`` must set its environment before the hub is first
+    imported.
     """
-    cache_dir = _hf_cache_dir_for(model_id)
-    snapshots = cache_dir / "snapshots"
+    required_files = _REQUIRED_SNAPSHOT_FILES.get(model_id)
+    if required_files is None:
+        return False
+
+    snapshots = _hf_cache_dir_for(model_id) / "snapshots"
     if not snapshots.is_dir():
         return False
-    for snap in snapshots.iterdir():
-        if snap.is_dir() and any(snap.iterdir()):
-            return True
+    try:
+        for snapshot in snapshots.iterdir():
+            if not snapshot.is_dir():
+                continue
+            try:
+                if all(
+                    (snapshot / name).is_file()
+                    and (snapshot / name).stat().st_size > 0
+                    for name in required_files
+                ):
+                    return True
+            except OSError:
+                continue
+    except OSError:
+        return False
     return False
 
 
@@ -101,13 +131,9 @@ def maybe_enable_offline(model_id: str = DEFAULT_MODEL_ID) -> bool:
     of ``_load_model``, immediately before importing parakeet-mlx / onnx-asr,
     which is the latest-safe and only symmetric point.
 
-    Gated on ``is_installed`` so a first-ever run (model absent) is left
-    online and ``download`` proceeds normally — offline-loading a
-    just-downloaded model is correct. Edge case: ``is_installed`` only checks
-    that a snapshot dir is non-empty, so a corrupt/partial snapshot would read
-    as installed and offline mode would then block a repair re-fetch. Low
-    probability and accepted — the existing code already trusts
-    ``is_installed``.
+    Gated on ``is_installed`` so a first-ever or interrupted download is left
+    online and can finish. Once every runtime-required file is present, loading
+    switches to fully offline resolution.
 
     ``setdefault`` so an operator who explicitly exported ``HF_HUB_OFFLINE=0``
     for debugging isn't overridden.

--- a/tests/test_parakeet_models.py
+++ b/tests/test_parakeet_models.py
@@ -1,8 +1,83 @@
 import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch
 
 from src import parakeet_models
+
+
+class IsInstalledTests(unittest.TestCase):
+    def setUp(self):
+        self._cache = TemporaryDirectory()
+        self._saved_hf_hub_cache = os.environ.get("HF_HUB_CACHE")
+        os.environ["HF_HUB_CACHE"] = self._cache.name
+
+    def tearDown(self):
+        if self._saved_hf_hub_cache is None:
+            os.environ.pop("HF_HUB_CACHE", None)
+        else:
+            os.environ["HF_HUB_CACHE"] = self._saved_hf_hub_cache
+        self._cache.cleanup()
+
+    def _snapshot(self, model_id: str) -> Path:
+        snapshot = (
+            parakeet_models._hf_cache_dir_for(model_id)
+            / "snapshots"
+            / "test-revision"
+        )
+        snapshot.mkdir(parents=True)
+        return snapshot
+
+    @staticmethod
+    def _write(snapshot: Path, *names: str) -> None:
+        for name in names:
+            (snapshot / name).write_bytes(b"present")
+
+    def test_mlx_snapshot_requires_nonempty_weights(self):
+        model_id = "mlx-community/parakeet-tdt-0.6b-v3"
+        snapshot = self._snapshot(model_id)
+        self._write(snapshot, "config.json")
+
+        self.assertFalse(parakeet_models.is_installed(model_id))
+        (snapshot / "model.safetensors").write_bytes(b"")
+        self.assertFalse(parakeet_models.is_installed(model_id))
+        self._write(snapshot, "model.safetensors")
+        self.assertTrue(parakeet_models.is_installed(model_id))
+
+    def test_onnx_snapshot_requires_every_runtime_file(self):
+        model_id = "istupakov/parakeet-tdt-0.6b-v3-onnx"
+        snapshot = self._snapshot(model_id)
+        self._write(
+            snapshot,
+            "config.json",
+            "encoder-model.int8.onnx",
+            "decoder_joint-model.int8.onnx",
+        )
+
+        self.assertFalse(parakeet_models.is_installed(model_id))
+        self._write(snapshot, "vocab.txt")
+        self.assertTrue(parakeet_models.is_installed(model_id))
+
+    def test_unknown_model_never_forces_offline_mode(self):
+        model_id = "example/future-model"
+        snapshot = self._snapshot(model_id)
+        self._write(snapshot, "config.json", "weights.bin")
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HF_HUB_OFFLINE", None)
+            os.environ.pop("TRANSFORMERS_OFFLINE", None)
+            self.assertFalse(parakeet_models.is_installed(model_id))
+            self.assertFalse(parakeet_models.maybe_enable_offline(model_id))
+            self.assertNotIn("HF_HUB_OFFLINE", os.environ)
+            self.assertNotIn("TRANSFORMERS_OFFLINE", os.environ)
+
+    def test_unreadable_snapshots_directory_is_not_installed(self):
+        model_id = "mlx-community/parakeet-tdt-0.6b-v3"
+        self._snapshot(model_id)
+
+        with patch.object(Path, "iterdir", side_effect=PermissionError):
+            self.assertFalse(parakeet_models.is_installed(model_id))
 
 
 class MaybeEnableOfflineTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

Hugging Face creates a snapshot directory and `config.json` link before a large Parakeet weight download finishes. Steno treated any non-empty snapshot as installed, so the next backend process enabled `HF_HUB_OFFLINE=1` and could neither resume the interrupted download nor load the missing weights. The resulting error was a misleading local `config.json` path failure.

## Change

- Require every runtime file before a Parakeet snapshot counts as installed.
- Cover the MLX repository (`config.json`, `model.safetensors`) and ONNX int8 repository (`config.json`, encoder, decoder/joint, vocabulary).
- Leave unknown/future repositories online rather than risking a false complete state.
- Add regression coverage for partial, empty, complete, unreadable, and unknown-model cache states.

## Verification

- `python -m unittest tests.test_parakeet_models` — 11 passed
- `git diff --check upstream/main` — clean

## Scope

This PR changes only model-cache completeness detection. It does not change the selected transcription engine, model identifiers, network endpoint, or UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let interrupted Parakeet downloads resume by requiring a complete runtime snapshot before enabling offline mode. Previously any non-empty Hugging Face snapshot counted as installed and forced `HF_HUB_OFFLINE=1`, blocking resume and causing misleading `config.json` path errors.

- Define `_REQUIRED_SNAPSHOT_FILES`:
  - `mlx-community/parakeet-tdt-0.6b-v3`: `config.json`, `model.safetensors`
  - `istupakov/parakeet-tdt-0.6b-v3-onnx`: `config.json`, `encoder-model.int8.onnx`, `decoder_joint-model.int8.onnx`, `vocab.txt`
- Make `is_installed` succeed only when all required files exist and are non-empty; unknown repos and unreadable cache dirs return False. Stays free of `huggingface_hub` imports.
- Keep `maybe_enable_offline` online for first-time or interrupted downloads; switch offline only after a complete snapshot. Respects a pre-set `HF_HUB_OFFLINE`.
- Add tests for partial MLX/ONNX snapshots, complete snapshots, unknown models (no offline), and unreadable snapshot directories.

<sup>Written for commit 049bad0a8828b7585c0671ebd9d83b92a0e2bb62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


