### PR TITLE
feat: ask the live meeting transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you're looking for a hosted desktop recording API, consider checking out [Rec
 - **Recording that coexists** — A compact transcription pill docks beside the app instead of taking over; Stop lands you on the note instantly and you can resume recording into an existing note (it appends and re-generates on demand).
 - **Global record shortcut** — Start or stop recording from anywhere with `⌘⇧R` (`Ctrl+Shift+R` on Windows). Toggle it off in Settings if it clashes with another app. On macOS, power users can additionally bind any key of their own via the `stenoai://record/start` / `record/stop` deep links (Shortcuts app).
 - **In-app note-taking** — Jot notes while you record, or keep a dedicated **My notes** tab that stays editable alongside the AI summary; your notes are folded straight into the summary.
-- **Ask your meetings** — Natural-language Q&A across a single note *or* your entire library via the Chat tab. Pulls from summary, key topics, and the full transcript.
+- **Ask your meetings** — Ask the in-progress live transcript while recording, query a single finished note, or search your library via the Chat tab. Live questions use the same local, cloud, or organisation AI provider configured for summaries.
 - **Multi-language (25 live, 99 total)** — Parakeet covers 25 European languages with live transcription; Whisper handles 99 languages including Chinese, Japanese, Arabic, and Hindi post-stop.
 - **Markdown ownership** — Summaries and transcripts save as clean Markdown you can edit, search, or sync to whatever knowledge base you live in.
 - **Report templates** — Define custom report styles and generate them per meeting; a note can hold multiple reports (the structured summary plus template-driven ones), switchable in the detail view.

--- a/app/e2e-mock-ipc.js
+++ b/app/e2e-mock-ipc.js
@@ -1495,6 +1495,64 @@ function install({ ipcMain }) {
     }
     return originalHandle(channel, fn);
   };
+
+  const originalOn = ipcMain.on.bind(ipcMain);
+  const activeLiveStreams = new Map();
+  ipcMain.on = (channel, listener) => {
+    if (channel === 'query-live-transcript-stream') {
+      return originalOn(channel, (event, queryId, sessionName, question) => {
+        if (process.env.STENOAI_E2E_MOCK_LIVE_STREAM === '1') {
+          const sender = event.sender;
+          if (!queryId || typeof queryId !== 'string') return;
+          if (sender.isDestroyed()) return;
+
+          if (activeLiveStreams.has(queryId)) {
+            for (const t of activeLiveStreams.get(queryId)) clearTimeout(t);
+            activeLiveStreams.delete(queryId);
+          }
+
+          const timers = [];
+          timers.push(
+            setTimeout(() => {
+              if (!sender.isDestroyed()) {
+                sender.send('query-chunk', { queryId, chunk: 'The team agreed to ' });
+              }
+            }, 50),
+          );
+          timers.push(
+            setTimeout(() => {
+              if (!sender.isDestroyed()) {
+                sender.send('query-chunk', { queryId, chunk: 'ship on Friday.' });
+              }
+            }, 150),
+          );
+          timers.push(
+            setTimeout(() => {
+              if (!sender.isDestroyed()) {
+                sender.send('query-done', { queryId, success: true });
+              }
+              activeLiveStreams.delete(queryId);
+            }, 250),
+          );
+          activeLiveStreams.set(queryId, timers);
+          return;
+        }
+        return listener(event, queryId, sessionName, question);
+      });
+    }
+
+    if (channel === 'query-cancel') {
+      return originalOn(channel, (event, queryId) => {
+        if (activeLiveStreams.has(queryId)) {
+          for (const t of activeLiveStreams.get(queryId)) clearTimeout(t);
+          activeLiveStreams.delete(queryId);
+        }
+        return listener(event, queryId);
+      });
+    }
+
+    return originalOn(channel, listener);
+  };
 }
 
 module.exports = { install };

--- a/app/ipc-contract.test.js
+++ b/app/ipc-contract.test.js
@@ -311,3 +311,72 @@ test('the mock sample clip is long enough for a playing state to be observable',
     `the fixture clip is ${match[1]}s; under ~2s the "toggling to stop" assertion races the ended event`,
   );
 });
+
+test('live transcript reads and queries are limited to the trusted app renderer', () => {
+  const getStateIndex = MAIN.indexOf("ipcMain.handle('get-live-transcript-state',");
+  assert.ok(getStateIndex >= 0, 'expected get-live-transcript-state handler in main.js');
+  const getStateBlock = MAIN.slice(getStateIndex, getStateIndex + 500);
+  assert.match(
+    getStateBlock,
+    /event\.sender\s*!==\s*mainWindow\.webContents/,
+    'get-live-transcript-state must verify event.sender === mainWindow.webContents',
+  );
+
+  const queryLiveIndex = MAIN.indexOf("ipcMain.on('query-live-transcript-stream',");
+  assert.ok(queryLiveIndex >= 0, 'expected query-live-transcript-stream handler in main.js');
+  const queryLiveBlock = MAIN.slice(queryLiveIndex, queryLiveIndex + 500);
+  assert.match(
+    queryLiveBlock,
+    /sender\s*!==\s*mainWindow\.webContents/,
+    'query-live-transcript-stream must verify event.sender === mainWindow.webContents',
+  );
+});
+
+test('live queries use the configured provider without putting content or overrides in argv', () => {
+  const queryLiveIndex = MAIN.indexOf("ipcMain.on('query-live-transcript-stream',");
+  const queryLiveBlock = MAIN.slice(queryLiveIndex, queryLiveIndex + 2200);
+  assert.match(
+    queryLiveBlock,
+    /\['query-live-streaming'\]/,
+    'query-live-streaming must use a content-free command argv',
+  );
+  assert.match(
+    queryLiveBlock,
+    /env:\s*\{\s*\.\.\.process\.env,\s*\.\.\.getAiEnv\(\)\s*\}/,
+    'query-live-streaming must inherit the configured provider environment',
+  );
+  assert.doesNotMatch(
+    queryLiveBlock,
+    /--host|--model|-q/,
+    'live query argv must not override provider/model or contain the user question',
+  );
+});
+
+test('live query failures and diagnostics never forward backend or prompt text', () => {
+  const protocolIndex = MAIN.indexOf('function handleLiveQueryProtocolLine(');
+  const cancelIndex = MAIN.indexOf('const pendingQueryCancels = new Map();');
+  assert.ok(protocolIndex >= 0 && cancelIndex > protocolIndex);
+  const liveQueryBlock = MAIN.slice(protocolIndex, cancelIndex);
+  assert.match(liveQueryBlock, /FIXED_LIVE_QUERY_ERRORS\.FAILED/);
+  assert.doesNotMatch(
+    liveQueryBlock,
+    /error:\s*err\.message|error:\s*line\.slice|Process exited with code/,
+    'live query errors must be fixed strings, never raw child-process text',
+  );
+  assert.doesNotMatch(
+    liveQueryBlock,
+    /sendDebugLog|console\.(?:log|warn|error)/,
+    'live query handling must not log transcript, question, or provider output',
+  );
+});
+
+test('live query cancellation is bound to the renderer that started it', () => {
+  const cancelIndex = MAIN.indexOf("ipcMain.on('query-cancel',");
+  assert.ok(cancelIndex >= 0, 'expected query-cancel handler in main.js');
+  const cancelBlock = MAIN.slice(cancelIndex, cancelIndex + 1000);
+  assert.match(
+    cancelBlock,
+    /activeLiveQuery\.sender\s*===\s*sender/,
+    'query-cancel must verify activeLiveQuery.sender === sender',
+  );
+});

--- a/app/live-query-helpers.js
+++ b/app/live-query-helpers.js
@@ -1,0 +1,152 @@
+'use strict';
+
+/**
+ * Pure helpers for live transcript snapshot filtering, formatting, and query validation.
+ *
+ * Privacy & resource guarantees:
+ * - Punctuation-only / filler / empty utterances are rejected via \p{L}|\p{N}.
+ * - Only finalized segments (isFinal === true) are included.
+ * - Speakers are normalized ('You', 'Others', fallback 'Speaker').
+ * - Timestamps are formatted into MM:SS intervals.
+ * - Context snapshot is recent-first capped at 100,000 characters.
+ * - Questions are capped at 2,000 Unicode code units.
+ * - Line buffers and decoded responses are capped at 1 MiB.
+ * - Query timeout is enforced at 300s.
+ * - Error messages are fixed/sanitized and never leak transcript contents.
+ */
+
+const MAX_LIVE_QUERY_QUESTION_CHARS = 2000;
+const MAX_LIVE_TRANSCRIPT_CHARS = 100000;
+const MAX_PROTOCOL_LINE_BYTES = 1024 * 1024;
+const MAX_DECODED_ANSWER_BYTES = 1024 * 1024;
+const LIVE_QUERY_TIMEOUT_MS = 300000;
+
+const FIXED_LIVE_QUERY_ERRORS = Object.freeze({
+  UNAUTHORIZED: 'Unauthorized renderer',
+  INVALID_QUERY_ID: 'Invalid query id',
+  INVALID_SESSION: 'Invalid live session',
+  NO_ACTIVE_TRANSCRIPT: 'No active live transcript for this session',
+  EMPTY_TRANSCRIPT: 'Live transcript is empty',
+  QUESTION_REQUIRED: 'Question is required',
+  QUESTION_TOO_LONG: 'Question exceeds maximum length of 2000 characters',
+  QUERY_ALREADY_ACTIVE: 'Query already active',
+  TIMEOUT: 'Query timed out',
+  LINE_LIMIT_EXCEEDED: 'Protocol line limit exceeded',
+  FAILED: 'Live query failed',
+  RESPONSE_LIMIT_EXCEEDED: 'Response limit exceeded',
+  STREAM_CLOSED: 'Stream closed prematurely',
+});
+
+function formatLiveQueryTimestamp(value) {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds)) return '??:??';
+  const whole = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(whole / 60);
+  const secs = whole % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+}
+
+function isMeaningfulLiveQueryText(text) {
+  return /[\p{L}\p{N}]/u.test(String(text || ''));
+}
+
+function formatSingleLiveSegment(segment) {
+  const speaker = segment.speaker === 'Others' || segment.speaker === 'You'
+    ? segment.speaker
+    : 'Speaker';
+  const start = formatLiveQueryTimestamp(segment.start);
+  const end = formatLiveQueryTimestamp(segment.end);
+  return `[${start} - ${end}] ${speaker}: ${String(segment.text).trim()}`;
+}
+
+function formatLiveTranscriptSegments(segments, { maxChars = MAX_LIVE_TRANSCRIPT_CHARS } = {}) {
+  if (!Array.isArray(segments)) return '';
+  const valid = segments.filter(
+    (segment) => segment && segment.isFinal && isMeaningfulLiveQueryText(segment.text),
+  );
+  if (valid.length === 0) return '';
+
+  const cap = typeof maxChars === 'number' && maxChars > 0 ? maxChars : MAX_LIVE_TRANSCRIPT_CHARS;
+
+  // Build recent-first: iterate backwards from newest to oldest
+  const selectedLines = [];
+  let currentLen = 0;
+
+  for (let i = valid.length - 1; i >= 0; i--) {
+    const line = formatSingleLiveSegment(valid[i]);
+    const addedLen = line.length + (selectedLines.length > 0 ? 1 : 0);
+
+    if (currentLen + addedLen <= cap) {
+      selectedLines.unshift(line);
+      currentLen += addedLen;
+    } else {
+      if (selectedLines.length === 0) {
+        // Single segment exceeds cap: take the tail of this segment
+        selectedLines.push(line.slice(-cap));
+      }
+      break;
+    }
+  }
+
+  return selectedLines.join('\n').trim();
+}
+
+function validateLiveQueryInputs({ queryId, sessionName, question } = {}) {
+  if (typeof queryId !== 'string' || !queryId.trim() || queryId.length > 256) {
+    return { valid: false, error: FIXED_LIVE_QUERY_ERRORS.INVALID_QUERY_ID };
+  }
+  if (typeof sessionName !== 'string' || !sessionName.trim() || sessionName.length > 256) {
+    return { valid: false, error: FIXED_LIVE_QUERY_ERRORS.INVALID_SESSION };
+  }
+  if (typeof question !== 'string' || !question.trim()) {
+    return { valid: false, error: FIXED_LIVE_QUERY_ERRORS.QUESTION_REQUIRED };
+  }
+  if (question.length > MAX_LIVE_QUERY_QUESTION_CHARS) {
+    return { valid: false, error: FIXED_LIVE_QUERY_ERRORS.QUESTION_TOO_LONG };
+  }
+  return { valid: true };
+}
+
+function buildLiveTranscriptQuerySnapshot({
+  sessionName,
+  activeSessionName,
+  systemAudioRecordingActive,
+  liveTranscriptState,
+  maxChars = MAX_LIVE_TRANSCRIPT_CHARS,
+} = {}) {
+  if (typeof sessionName !== 'string' || !sessionName.trim() || sessionName.length > 256) {
+    return { error: FIXED_LIVE_QUERY_ERRORS.INVALID_SESSION };
+  }
+  if (
+    !systemAudioRecordingActive
+    || activeSessionName !== sessionName
+    || !liveTranscriptState
+    || liveTranscriptState.sessionName !== sessionName
+  ) {
+    return { error: FIXED_LIVE_QUERY_ERRORS.NO_ACTIVE_TRANSCRIPT };
+  }
+
+  const allSegments = [
+    ...(liveTranscriptState.priorSegments || []),
+    ...(liveTranscriptState.segments || []),
+  ];
+
+  const transcript = formatLiveTranscriptSegments(allSegments, { maxChars });
+  if (!transcript) return { error: FIXED_LIVE_QUERY_ERRORS.EMPTY_TRANSCRIPT };
+  return { transcript };
+}
+
+module.exports = {
+  MAX_LIVE_QUERY_QUESTION_CHARS,
+  MAX_LIVE_TRANSCRIPT_CHARS,
+  MAX_PROTOCOL_LINE_BYTES,
+  MAX_DECODED_ANSWER_BYTES,
+  LIVE_QUERY_TIMEOUT_MS,
+  FIXED_LIVE_QUERY_ERRORS,
+  formatLiveQueryTimestamp,
+  isMeaningfulLiveQueryText,
+  formatSingleLiveSegment,
+  formatLiveTranscriptSegments,
+  validateLiveQueryInputs,
+  buildLiveTranscriptQuerySnapshot,
+};

--- a/app/live-query-helpers.test.js
+++ b/app/live-query-helpers.test.js
@@ -1,0 +1,300 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  MAX_LIVE_QUERY_QUESTION_CHARS,
+  MAX_LIVE_TRANSCRIPT_CHARS,
+  MAX_PROTOCOL_LINE_BYTES,
+  MAX_DECODED_ANSWER_BYTES,
+  LIVE_QUERY_TIMEOUT_MS,
+  FIXED_LIVE_QUERY_ERRORS,
+  formatLiveQueryTimestamp,
+  isMeaningfulLiveQueryText,
+  formatLiveTranscriptSegments,
+  validateLiveQueryInputs,
+  buildLiveTranscriptQuerySnapshot,
+} = require('./live-query-helpers');
+
+test('constants match required protocol and resource limits', () => {
+  assert.strictEqual(MAX_LIVE_QUERY_QUESTION_CHARS, 2000);
+  assert.strictEqual(MAX_LIVE_TRANSCRIPT_CHARS, 100000);
+  assert.strictEqual(MAX_PROTOCOL_LINE_BYTES, 1024 * 1024);
+  assert.strictEqual(MAX_DECODED_ANSWER_BYTES, 1024 * 1024);
+  assert.strictEqual(LIVE_QUERY_TIMEOUT_MS, 300000);
+  assert.strictEqual(FIXED_LIVE_QUERY_ERRORS.FAILED, 'Live query failed');
+});
+
+test('formatLiveQueryTimestamp formats seconds into MM:SS', () => {
+  assert.strictEqual(formatLiveQueryTimestamp(0), '00:00');
+  assert.strictEqual(formatLiveQueryTimestamp(5), '00:05');
+  assert.strictEqual(formatLiveQueryTimestamp(65), '01:05');
+  assert.strictEqual(formatLiveQueryTimestamp(125.8), '02:05');
+  assert.strictEqual(formatLiveQueryTimestamp(3600), '60:00');
+  assert.strictEqual(formatLiveQueryTimestamp('45'), '00:45');
+});
+
+test('formatLiveQueryTimestamp handles non-finite and negative inputs safely', () => {
+  assert.strictEqual(formatLiveQueryTimestamp(-10), '00:00');
+  assert.strictEqual(formatLiveQueryTimestamp(NaN), '??:??');
+  assert.strictEqual(formatLiveQueryTimestamp(Infinity), '??:??');
+  assert.strictEqual(formatLiveQueryTimestamp(null), '00:00'); // Number(null) is 0
+  assert.strictEqual(formatLiveQueryTimestamp(undefined), '??:??');
+  assert.strictEqual(formatLiveQueryTimestamp('invalid'), '??:??');
+});
+
+test('isMeaningfulLiveQueryText accepts linguistic and numeric content across scripts', () => {
+  // Latin / English
+  assert.strictEqual(isMeaningfulLiveQueryText('Hello world'), true);
+  assert.strictEqual(isMeaningfulLiveQueryText('OK'), true);
+  assert.strictEqual(isMeaningfulLiveQueryText('123'), true);
+  assert.strictEqual(isMeaningfulLiveQueryText('Q4 roadmap'), true);
+
+  // Traditional Chinese / CJK
+  assert.strictEqual(isMeaningfulLiveQueryText('你好'), true);
+  assert.strictEqual(isMeaningfulLiveQueryText('這是繁體中文即時轉錄測試'), true);
+  assert.strictEqual(isMeaningfulLiveQueryText('會議紀錄'), true);
+  assert.strictEqual(isMeaningfulLiveQueryText('日本語テスト'), true);
+  assert.strictEqual(isMeaningfulLiveQueryText('한국어'), true);
+
+  // Accented and unicode letters
+  assert.strictEqual(isMeaningfulLiveQueryText('résumé'), true);
+  assert.strictEqual(isMeaningfulLiveQueryText('Café'), true);
+});
+
+test('isMeaningfulLiveQueryText rejects punctuation-only and whitespace-only utterances', () => {
+  // Punctuation-only snapshots that must be rejected
+  assert.strictEqual(isMeaningfulLiveQueryText('...'), false);
+  assert.strictEqual(isMeaningfulLiveQueryText('???'), false);
+  assert.strictEqual(isMeaningfulLiveQueryText('!'), false);
+  assert.strictEqual(isMeaningfulLiveQueryText('... ??? !'), false);
+  assert.strictEqual(isMeaningfulLiveQueryText('——'), false);
+  assert.strictEqual(isMeaningfulLiveQueryText('……'), false);
+  assert.strictEqual(isMeaningfulLiveQueryText('，。、；：'), false);
+  assert.strictEqual(isMeaningfulLiveQueryText('【】（）'), false);
+
+  // Whitespace and empty
+  assert.strictEqual(isMeaningfulLiveQueryText(''), false);
+  assert.strictEqual(isMeaningfulLiveQueryText('   '), false);
+  assert.strictEqual(isMeaningfulLiveQueryText('\t\n  '), false);
+  assert.strictEqual(isMeaningfulLiveQueryText(null), false);
+  assert.strictEqual(isMeaningfulLiveQueryText(undefined), false);
+});
+
+test('formatLiveTranscriptSegments filters non-final, empty, and punctuation-only segments', () => {
+  const segments = [
+    { start: 0, end: 3, speaker: 'You', text: 'Hello everyone', isFinal: true },
+    { start: 3, end: 5, speaker: 'Others', text: '...', isFinal: true }, // punctuation-only -> rejected
+    { start: 5, end: 8, speaker: 'Others', text: 'Good morning!', isFinal: true },
+    { start: 8, end: 10, speaker: 'You', text: 'interim unfinalized chunk', isFinal: false }, // not final -> rejected
+    null,
+    undefined,
+    { start: 10, end: 14, speaker: 'CustomSpeaker', text: '會議開始進行討論', isFinal: true }, // unknown speaker -> normalized to Speaker
+  ];
+
+  const formatted = formatLiveTranscriptSegments(segments);
+  const lines = formatted.split('\n');
+
+  assert.strictEqual(lines.length, 3);
+  assert.strictEqual(lines[0], '[00:00 - 00:03] You: Hello everyone');
+  assert.strictEqual(lines[1], '[00:05 - 00:08] Others: Good morning!');
+  assert.strictEqual(lines[2], '[00:10 - 00:14] Speaker: 會議開始進行討論');
+});
+
+test('formatLiveTranscriptSegments returns empty string for non-array or empty inputs', () => {
+  assert.strictEqual(formatLiveTranscriptSegments([]), '');
+  assert.strictEqual(formatLiveTranscriptSegments(null), '');
+  assert.strictEqual(formatLiveTranscriptSegments(undefined), '');
+  assert.strictEqual(formatLiveTranscriptSegments('not an array'), '');
+});
+
+test('formatLiveTranscriptSegments caps transcript to maxChars favoring most recent segments', () => {
+  const segments = [
+    { start: 0, end: 10, speaker: 'You', text: 'First segment early in meeting', isFinal: true },
+    { start: 10, end: 20, speaker: 'Others', text: 'Second segment middle of meeting', isFinal: true },
+    { start: 20, end: 30, speaker: 'You', text: 'Third segment latest discussion topic', isFinal: true },
+  ];
+
+  // When cap fits all segments
+  const full = formatLiveTranscriptSegments(segments, { maxChars: 1000 });
+  assert.ok(full.includes('First segment'));
+  assert.ok(full.includes('Second segment'));
+  assert.ok(full.includes('Third segment'));
+
+  // When cap only fits the most recent segments (e.g. last 2 segments)
+  const line3 = '[00:20 - 00:30] You: Third segment latest discussion topic';
+  const line2 = '[00:10 - 00:20] Others: Second segment middle of meeting';
+  const capTwo = line3.length + 1 + line2.length;
+  const recentTwo = formatLiveTranscriptSegments(segments, { maxChars: capTwo });
+  assert.strictEqual(recentTwo, `${line2}\n${line3}`);
+  assert.strictEqual(recentTwo.includes('First segment'), false);
+
+  // When cap only fits the last segment
+  const capOne = line3.length;
+  const recentOne = formatLiveTranscriptSegments(segments, { maxChars: capOne });
+  assert.strictEqual(recentOne, line3);
+  assert.strictEqual(recentOne.includes('Second segment'), false);
+
+  // When a single segment exceeds maxChars, take the tail slice bounded to maxChars
+  const truncated = formatLiveTranscriptSegments(segments, { maxChars: 20 });
+  assert.strictEqual(truncated.length, 20);
+  assert.strictEqual(truncated, line3.slice(-20));
+});
+
+test('validateLiveQueryInputs validates queryId, sessionName, and question length', () => {
+  // Valid input
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({
+      queryId: 'q-12345',
+      sessionName: 'session-20260824',
+      question: 'What was decided about the budget?',
+    }),
+    { valid: true },
+  );
+
+  // Invalid queryId
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: '', sessionName: 's1', question: 'Q' }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.INVALID_QUERY_ID },
+  );
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: null, sessionName: 's1', question: 'Q' }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.INVALID_QUERY_ID },
+  );
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: 'a'.repeat(300), sessionName: 's1', question: 'Q' }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.INVALID_QUERY_ID },
+  );
+
+  // Invalid sessionName
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: 'q1', sessionName: '', question: 'Q' }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.INVALID_SESSION },
+  );
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: 'q1', sessionName: '   ', question: 'Q' }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.INVALID_SESSION },
+  );
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: 'q1', sessionName: 'b'.repeat(300), question: 'Q' }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.INVALID_SESSION },
+  );
+
+  // Invalid question
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: 'q1', sessionName: 's1', question: '' }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.QUESTION_REQUIRED },
+  );
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: 'q1', sessionName: 's1', question: '   ' }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.QUESTION_REQUIRED },
+  );
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: 'q1', sessionName: 's1', question: null }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.QUESTION_REQUIRED },
+  );
+  assert.deepStrictEqual(
+    validateLiveQueryInputs({ queryId: 'q1', sessionName: 's1', question: 'x'.repeat(2001) }),
+    { valid: false, error: FIXED_LIVE_QUERY_ERRORS.QUESTION_TOO_LONG },
+  );
+});
+
+test('buildLiveTranscriptQuerySnapshot validates session match and active recording state', () => {
+  const validState = {
+    sessionName: 'session-20260824-1',
+    priorSegments: [],
+    segments: [
+      { start: 0, end: 4, speaker: 'You', text: 'Discussing the release plan', isFinal: true },
+    ],
+  };
+
+  // Missing or invalid sessionName
+  assert.deepStrictEqual(
+    buildLiveTranscriptQuerySnapshot({ sessionName: '' }),
+    { error: FIXED_LIVE_QUERY_ERRORS.INVALID_SESSION },
+  );
+  assert.deepStrictEqual(
+    buildLiveTranscriptQuerySnapshot({ sessionName: null }),
+    { error: FIXED_LIVE_QUERY_ERRORS.INVALID_SESSION },
+  );
+
+  // Recording inactive
+  assert.deepStrictEqual(
+    buildLiveTranscriptQuerySnapshot({
+      sessionName: 'session-20260824-1',
+      activeSessionName: 'session-20260824-1',
+      systemAudioRecordingActive: false,
+      liveTranscriptState: validState,
+    }),
+    { error: FIXED_LIVE_QUERY_ERRORS.NO_ACTIVE_TRANSCRIPT },
+  );
+
+  // Session mismatch with active recording session
+  assert.deepStrictEqual(
+    buildLiveTranscriptQuerySnapshot({
+      sessionName: 'session-20260824-1',
+      activeSessionName: 'session-other',
+      systemAudioRecordingActive: true,
+      liveTranscriptState: validState,
+    }),
+    { error: FIXED_LIVE_QUERY_ERRORS.NO_ACTIVE_TRANSCRIPT },
+  );
+
+  // Session mismatch with live transcript state
+  assert.deepStrictEqual(
+    buildLiveTranscriptQuerySnapshot({
+      sessionName: 'session-20260824-1',
+      activeSessionName: 'session-20260824-1',
+      systemAudioRecordingActive: true,
+      liveTranscriptState: { ...validState, sessionName: 'session-other' },
+    }),
+    { error: FIXED_LIVE_QUERY_ERRORS.NO_ACTIVE_TRANSCRIPT },
+  );
+});
+
+test('buildLiveTranscriptQuerySnapshot returns error when live transcript has only punctuation or non-final segments', () => {
+  const punctuationOnlyState = {
+    sessionName: 'session-zh',
+    priorSegments: [
+      { start: 0, end: 2, speaker: 'You', text: '...', isFinal: true },
+    ],
+    segments: [
+      { start: 2, end: 4, speaker: 'Others', text: '??? !!!', isFinal: true },
+      { start: 4, end: 6, speaker: 'You', text: 'unfinalized text', isFinal: false },
+    ],
+  };
+
+  const result = buildLiveTranscriptQuerySnapshot({
+    sessionName: 'session-zh',
+    activeSessionName: 'session-zh',
+    systemAudioRecordingActive: true,
+    liveTranscriptState: punctuationOnlyState,
+  });
+
+  assert.deepStrictEqual(result, { error: FIXED_LIVE_QUERY_ERRORS.EMPTY_TRANSCRIPT });
+});
+
+test('buildLiveTranscriptQuerySnapshot concatenates priorSegments and current segments into clean transcript', () => {
+  const fullState = {
+    sessionName: 'session-zh',
+    priorSegments: [
+      { start: 0, end: 5, speaker: 'You', text: '我們現在開始會議', isFinal: true },
+    ],
+    segments: [
+      { start: 5, end: 12, speaker: 'Others', text: '好的，確認收到', isFinal: true },
+    ],
+  };
+
+  const result = buildLiveTranscriptQuerySnapshot({
+    sessionName: 'session-zh',
+    activeSessionName: 'session-zh',
+    systemAudioRecordingActive: true,
+    liveTranscriptState: fullState,
+  });
+
+  assert.strictEqual(result.error, undefined);
+  assert.strictEqual(
+    result.transcript,
+    '[00:00 - 00:05] You: 我們現在開始會議\n[00:05 - 00:12] Others: 好的，確認收到',
+  );
+});

--- a/app/main.js
+++ b/app/main.js
@@ -69,6 +69,14 @@ const { sweepOrphanedLiveSnapshots } = require('./live-snapshot-sweep');
 const { userNotesFilePath } = require('./notes-file');
 const { buildNoteReadyNotificationOptions, buildTranscriptReadyBody } = require('./notification-copy');
 const { makeLineReader } = require('./backend-stream');
+const {
+  MAX_PROTOCOL_LINE_BYTES,
+  MAX_DECODED_ANSWER_BYTES,
+  LIVE_QUERY_TIMEOUT_MS,
+  FIXED_LIVE_QUERY_ERRORS,
+  validateLiveQueryInputs,
+  buildLiveTranscriptQuerySnapshot,
+} = require('./live-query-helpers');
 // Pure deep-link (stenoai://) parsing/sanitizing lives in ./shortcut-url
 // (unit-tested). The stateful side — window creation, IPC dispatch,
 // notifications — stays here and calls parseShortcutUrl().
@@ -3447,7 +3455,275 @@ ipcMain.handle('query-transcript', async (event, summaryFile, question) => {
   }
 });
 
+
 const activeQueryProcs = new Map();
+let activeLiveQuery = null;
+
+function safeSendQueryPayload(sender, channel, payload) {
+  try {
+    if (sender && !sender.isDestroyed()) sender.send(channel, payload);
+  } catch (_) { /* renderer gone — nothing to notify */ }
+}
+
+function handleLiveQueryProtocolLine(line, queryId, sender, proc, state, cleanup) {
+  if (state.done) return;
+
+  if (line.startsWith('CHAT_CHUNK:')) {
+    try {
+      const chunk = Buffer.from(line.slice('CHAT_CHUNK:'.length), 'base64').toString('utf-8');
+      state.totalDecodedBytes += Buffer.byteLength(chunk, 'utf-8');
+      if (state.totalDecodedBytes > MAX_DECODED_ANSWER_BYTES) {
+        state.done = true;
+        try { proc.kill(); } catch (_) {}
+        safeSendQueryPayload(sender, 'query-done', {
+          queryId,
+          success: false,
+          error: FIXED_LIVE_QUERY_ERRORS.RESPONSE_LIMIT_EXCEEDED,
+        });
+        cleanup();
+        return;
+      }
+      safeSendQueryPayload(sender, 'query-chunk', { queryId, chunk });
+      if (sender.isDestroyed()) {
+        state.done = true;
+        try { proc.kill(); } catch (_) {}
+        cleanup();
+      }
+    } catch (_) { /* ignore malformed chunks */ }
+    return;
+  }
+  if (line === 'CHAT_STREAM_COMPLETE') {
+    if (!state.done) {
+      state.done = true;
+      safeSendQueryPayload(sender, 'query-done', { queryId, success: true });
+      cleanup();
+    }
+    return;
+  }
+  if (line.startsWith('CHAT_STREAM_ERROR:')) {
+    if (!state.done) {
+      state.done = true;
+      safeSendQueryPayload(sender, 'query-done', {
+        queryId,
+        success: false,
+        error: FIXED_LIVE_QUERY_ERRORS.FAILED,
+      });
+      cleanup();
+    }
+  }
+}
+
+ipcMain.on('query-live-transcript-stream', (event, queryId, sessionName, question) => {
+  const sender = event?.sender;
+  const responseQueryId =
+    typeof queryId === 'string' && queryId.length <= 256 ? queryId : '';
+  const done = (payload) =>
+    safeSendQueryPayload(sender, 'query-done', { queryId: responseQueryId, ...payload });
+
+  // Gate to trusted mainWindow.webContents
+  if (!mainWindow || mainWindow.isDestroyed() || !sender || sender !== mainWindow.webContents) {
+    done({ success: false, error: FIXED_LIVE_QUERY_ERRORS.UNAUTHORIZED });
+    return;
+  }
+
+  // Validate inputs
+  const validation = validateLiveQueryInputs({ queryId, sessionName, question });
+  if (!validation.valid) {
+    done({ success: false, error: validation.error });
+    return;
+  }
+
+  // Enforce one active live query per trusted sender / global live path
+  if (activeLiveQuery !== null) {
+    done({ success: false, error: FIXED_LIVE_QUERY_ERRORS.QUERY_ALREADY_ACTIVE });
+    return;
+  }
+
+  const snapshot = buildLiveTranscriptQuerySnapshot({
+    sessionName,
+    activeSessionName: currentRecordingSessionName,
+    systemAudioRecordingActive,
+    liveTranscriptState,
+  });
+  if (snapshot.error) {
+    done({ success: false, error: snapshot.error });
+    return;
+  }
+  if (sender.isDestroyed()) return;
+
+  let proc;
+  try {
+    proc = require('child_process').spawn(
+      getBackendPath(),
+      ['query-live-streaming'],
+      {
+        env: { ...process.env, ...getAiEnv() },
+        cwd: getBackendCwd(),
+        windowsHide: true,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
+  } catch {
+    done({ success: false, error: FIXED_LIVE_QUERY_ERRORS.FAILED });
+    return;
+  }
+
+  const state = { done: false, totalDecodedBytes: 0 };
+  let killTimer = null;
+
+  const cleanup = () => {
+    if (killTimer) {
+      clearTimeout(killTimer);
+      killTimer = null;
+    }
+    try {
+      if (!sender.isDestroyed()) sender.removeListener('destroyed', onSenderDestroyed);
+    } catch (_) {}
+    if (activeLiveQuery && activeLiveQuery.queryId === queryId) {
+      activeLiveQuery = null;
+    }
+  };
+
+  const onSenderDestroyed = () => {
+    if (activeLiveQuery && activeLiveQuery.queryId === queryId) {
+      state.done = true;
+      try { proc.kill(); } catch (_) {}
+      cleanup();
+    }
+  };
+  sender.once('destroyed', onSenderDestroyed);
+
+  if (sender.isDestroyed()) {
+    state.done = true;
+    try { proc.kill(); } catch (_) {}
+    cleanup();
+    return;
+  }
+
+  killTimer = setTimeout(() => {
+    if (!state.done) {
+      state.done = true;
+      try { proc.kill('SIGKILL'); } catch (_) {}
+      safeSendQueryPayload(sender, 'query-done', {
+        queryId,
+        success: false,
+        error: FIXED_LIVE_QUERY_ERRORS.TIMEOUT,
+      });
+      cleanup();
+    }
+  }, LIVE_QUERY_TIMEOUT_MS);
+
+  activeLiveQuery = {
+    queryId,
+    sender,
+    proc,
+    state,
+    killTimer,
+    cleanup,
+  };
+
+  let buf = '';
+
+  proc.stdout.on('data', (data) => {
+    if (state.done) return;
+    buf += data.toString();
+    if (Buffer.byteLength(buf, 'utf-8') > MAX_PROTOCOL_LINE_BYTES && !buf.includes('\n')) {
+      state.done = true;
+      try { proc.kill(); } catch (_) {}
+      safeSendQueryPayload(sender, 'query-done', {
+        queryId,
+        success: false,
+        error: FIXED_LIVE_QUERY_ERRORS.LINE_LIMIT_EXCEEDED,
+      });
+      cleanup();
+      return;
+    }
+
+    const lines = buf.split(/\r?\n/);
+    buf = lines.pop();
+    for (const line of lines) {
+      if (state.done) break;
+      if (Buffer.byteLength(line, 'utf-8') > MAX_PROTOCOL_LINE_BYTES) {
+        state.done = true;
+        try { proc.kill(); } catch (_) {}
+        safeSendQueryPayload(sender, 'query-done', {
+          queryId,
+          success: false,
+          error: FIXED_LIVE_QUERY_ERRORS.LINE_LIMIT_EXCEEDED,
+        });
+        cleanup();
+        return;
+      }
+      handleLiveQueryProtocolLine(line, queryId, sender, proc, state, cleanup);
+    }
+  });
+
+  proc.stderr.on('data', () => {
+    // Backend stderr can contain prompt/transcript context; never log it.
+  });
+
+  proc.stdin.on('error', (err) => {
+    if (err && err.code === 'EPIPE') return;
+    if (!state.done) {
+      state.done = true;
+      try { proc.kill(); } catch (_) {}
+      safeSendQueryPayload(sender, 'query-done', {
+        queryId,
+        success: false,
+        error: FIXED_LIVE_QUERY_ERRORS.FAILED,
+      });
+      cleanup();
+    }
+  });
+
+  try {
+    const payload = JSON.stringify({
+      transcript: snapshot.transcript,
+      question,
+    });
+    proc.stdin.end(payload, 'utf-8');
+  } catch {
+    if (!state.done) {
+      state.done = true;
+      try { proc.kill(); } catch (_) {}
+      safeSendQueryPayload(sender, 'query-done', {
+        queryId,
+        success: false,
+        error: FIXED_LIVE_QUERY_ERRORS.FAILED,
+      });
+      cleanup();
+    }
+  }
+
+  proc.on('close', (code) => {
+    if (!state.done) {
+      const remainder = buf.trim();
+      if (remainder) {
+        handleLiveQueryProtocolLine(remainder, queryId, sender, proc, state, cleanup);
+      }
+    }
+    if (!state.done) {
+      state.done = true;
+      const error = code === 0
+        ? FIXED_LIVE_QUERY_ERRORS.STREAM_CLOSED
+        : FIXED_LIVE_QUERY_ERRORS.FAILED;
+      safeSendQueryPayload(sender, 'query-done', { queryId, success: false, error });
+    }
+    cleanup();
+  });
+
+  proc.on('error', () => {
+    if (!state.done) {
+      state.done = true;
+      safeSendQueryPayload(sender, 'query-done', {
+        queryId,
+        success: false,
+        error: FIXED_LIVE_QUERY_ERRORS.FAILED,
+      });
+    }
+    cleanup();
+  });
+});
 
 // Cancellation intent for streaming queries that are still in their pre-spawn
 // async window. query-transcript-stream now `await`s validateMeetingFilePath
@@ -3459,7 +3735,24 @@ const activeQueryProcs = new Map();
 // that flag on every exit path so it never spawns-then-orphans a proc.
 const pendingQueryCancels = new Map();
 
-ipcMain.on('query-cancel', (_event, queryId) => {
+ipcMain.on('query-cancel', (event, queryId) => {
+  const sender = event?.sender;
+
+  // Live query path: owner-bound cancellation
+  if (activeLiveQuery && activeLiveQuery.queryId === queryId) {
+    if (activeLiveQuery.sender === sender) {
+      console.log(`[LIVE-QUERY] Cancelling queryId=${queryId}`);
+      activeLiveQuery.state.done = true;
+      if (activeLiveQuery.killTimer) clearTimeout(activeLiveQuery.killTimer);
+      try { activeLiveQuery.proc.kill(); } catch (_) {}
+      activeLiveQuery.cleanup();
+      activeLiveQuery = null;
+    } else {
+      console.warn(`[LIVE-QUERY] Rejected cancel for queryId=${queryId} from unauthorized sender`);
+    }
+    return;
+  }
+
   const proc = activeQueryProcs.get(queryId);
   if (proc) {
     console.log(`[QUERY] Cancelling queryId=${queryId}`);
@@ -3486,7 +3779,7 @@ ipcMain.on('query-cancel', (_event, queryId) => {
 });
 
 ipcMain.on('query-transcript-stream', async (event, queryId, summaryFile, question) => {
-  console.log(`[QUERY] IPC received: question="${question.substring(0, 50)}" file="${summaryFile}"`);
+  console.log(`[QUERY] IPC received: questionLen=${String(question || '').length} file="${summaryFile}"`);
   sendDebugLog(`🤖 Streaming query (${String(question || '').length} chars)`);
   const env = { ...process.env, ...getAiEnv() };
 
@@ -3640,9 +3933,8 @@ ipcMain.on('query-transcript-stream', async (event, queryId, summaryFile, questi
     }
   });
 
-  proc.stderr.on('data', (data) => {
-    const msg = data.toString().trim();
-    if (msg) console.log(`[QUERY stderr] ${msg.substring(0, 200)}`);
+  proc.stderr.on('data', () => {
+    // Backend stderr can include prompt/transcript context; never log it.
   });
 
   proc.on('close', (code) => {
@@ -3650,7 +3942,7 @@ ipcMain.on('query-transcript-stream', async (event, queryId, summaryFile, questi
     if (!event.sender.isDestroyed()) {
       event.sender.removeListener('destroyed', onSenderDestroyed);
     }
-    console.log(`[QUERY] Process closed, code=${code}, chunks=${chunkCount}, bufRemainder=${buf.length > 0 ? JSON.stringify(buf.substring(0, 100)) : 'empty'}`);
+    console.log(`[QUERY] Process closed, code=${code}, chunks=${chunkCount}, bufRemainderBytes=${Buffer.byteLength(buf)}`);
     if (buf.trim() === 'CHAT_STREAM_COMPLETE' || buf.trim() === 'STREAM_COMPLETE') {
       console.log(`[QUERY] STREAM_COMPLETE was in buf remainder — sending done now`);
       if (!event.sender.isDestroyed()) event.sender.send('query-done', { queryId, success: true });
@@ -4760,7 +5052,13 @@ ipcMain.on('live-transcribe-stop', () => {
 // and back during recording) to backfill segments before subscribing to
 // `live-transcript-chunk` for the tail. Returns an empty array when no
 // recording is active.
-ipcMain.handle('get-live-transcript-state', async () => {
+ipcMain.handle('get-live-transcript-state', async (event) => {
+  if (!mainWindow || mainWindow.isDestroyed() || !event || event.sender !== mainWindow.webContents) {
+    return {
+      success: false,
+      error: FIXED_LIVE_QUERY_ERRORS.UNAUTHORIZED,
+    };
+  }
   return {
     success: true,
     sessionName: liveTranscriptState.sessionName,

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js person-sample-ipc.test.js speaker-ipc.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js settings-ipc.test.js regen-title-busy-guard.test.js update-idle-gate.test.js update-os-gate.test.js update-error-copy.test.js notification-copy.test.js obsidian-sync.test.js e2e-window-visibility.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js live-query-helpers.test.js ipc-contract.test.js person-sample-ipc.test.js speaker-ipc.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js settings-ipc.test.js regen-title-busy-guard.test.js update-idle-gate.test.js update-os-gate.test.js update-error-copy.test.js notification-copy.test.js obsidian-sync.test.js e2e-window-visibility.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",

--- a/app/preload.js
+++ b/app/preload.js
@@ -179,6 +179,7 @@ const stenoai = {
   query: {
     ask: (file, q) => invoke('query-transcript', file, q),
     askStream: (id, file, q) => send('query-transcript-stream', id, file, q),
+    askLiveStream: (id, sessionName, q) => send('query-live-transcript-stream', id, sessionName, q),
     chatGlobalStream: (id, q, folderId) => send('chat-global-stream', id, q, folderId ?? null),
     cancel: (id) => send('query-cancel', id),
   },

--- a/app/renderer/src/components/AskBar.tsx
+++ b/app/renderer/src/components/AskBar.tsx
@@ -1,26 +1,11 @@
 import * as React from 'react';
-import {
-  ArrowUp,
-  Check,
-  ChevronDown,
-  ChevronUp,
-  Copy,
-  Square,
-  X,
-} from 'lucide-react';
+import { ArrowUp, Check, ChevronDown, ChevronUp, Copy, Square, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { renderMarkdown } from '@/lib/markdown';
-import { useAskBar } from '@/lib/askBarContext';
-import {
-  useChatSessions,
-  type ChatMessage,
-  type ChatSession,
-} from '@/hooks/useChatSessions';
-import { useGlobalStreaming } from '@/hooks/useStreamingQuery';
-import {
-  OrgTranscriptPanelContent,
-  TranscriptPanelContent,
-} from '@/components/TranscriptPanel';
+import { useAskBar, type ActiveOrgMeeting } from '@/lib/askBarContext';
+import { useChatSessions, type ChatMessage, type ChatSession } from '@/hooks/useChatSessions';
+import { useGlobalStreaming, type StreamResult } from '@/hooks/useStreamingQuery';
+import { OrgTranscriptPanelContent, TranscriptPanelContent } from '@/components/TranscriptPanel';
 import { useMeeting } from '@/hooks/useMeetings';
 import { useRecording } from '@/hooks/useRecording';
 import { buildTranscriptBundle } from '@/lib/transcriptBundle';
@@ -30,8 +15,13 @@ import { buildTranscriptBundle } from '@/lib/transcriptBundle';
 // ---------------------------------------------------------------------------
 
 export function TranscriptBar() {
-  const { activeSummaryFile, activeMeetingName, activeOrgMeeting, transcriptOpen, setTranscriptOpen } =
-    useAskBar();
+  const {
+    activeSummaryFile,
+    activeMeetingName,
+    activeOrgMeeting,
+    transcriptOpen,
+    setTranscriptOpen,
+  } = useAskBar();
   const meeting = useMeeting(activeSummaryFile ?? undefined);
   const recording = useRecording();
   const [copied, setCopied] = React.useState(false);
@@ -93,7 +83,13 @@ export function TranscriptBar() {
     >
       <div className="mv-transcript-head">
         <span className="mv-transcript-wave mv-transcript-wave-static" aria-hidden="true">
-          <span /><span /><span /><span /><span /><span /><span />
+          <span />
+          <span />
+          <span />
+          <span />
+          <span />
+          <span />
+          <span />
         </span>
         <span className="mv-transcript-label">Transcript</span>
         <button
@@ -115,7 +111,14 @@ export function TranscriptBar() {
           <ChevronUp size={13} style={{ color: 'var(--fg-2)', flexShrink: 0 }} />
         </button>
       </div>
-      <div style={{ height: 260, display: 'flex', flexDirection: 'column', borderTop: '1px solid var(--border-subtle)' }}>
+      <div
+        style={{
+          height: 260,
+          display: 'flex',
+          flexDirection: 'column',
+          borderTop: '1px solid var(--border-subtle)',
+        }}
+      >
         {activeOrgMeeting ? (
           <OrgTranscriptPanelContent transcript={orgTranscript} />
         ) : (
@@ -186,7 +189,13 @@ export function TranscriptToggle() {
         aria-hidden="true"
         style={{ width: 16, height: 13 }}
       >
-        <span /><span /><span /><span /><span /><span /><span />
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
       </span>
       {/* Expand indicator (Granola-style) — points up to reveal the transcript,
           flips down when it's open. */}
@@ -203,11 +212,13 @@ export function TranscriptToggle() {
 }
 
 /**
- * The floating chat composer. `disabled` renders it visible-but-inert while a
- * recording is active (chat needs the processed note, so the input carries a
- * "Chat available after recording" hint instead of a dead field) — and unlike
- * the idle state it renders even with no active meeting, so the recording
- * pill always has the bar beside it.
+ * The floating chat composer. `disabled` renders it visible-but-inert only
+ * for genuinely unsupported cases (no caller-override path). While a recording
+ * is active or paused the composer stays enabled and routes to the live
+ * transcript stream instead of the processed-note backend, so chat is usable
+ * throughout the meeting (input reads "Ask about the live transcript…"). It
+ * renders with no active meeting while recording so the transcription pill
+ * always has the bar beside it.
  */
 export function AskBar({ disabled = false }: { disabled?: boolean }) {
   const {
@@ -217,12 +228,74 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
     transcriptOpen,
     setTranscriptOpen,
   } = useAskBar();
-  // For shared notes, persist sessions under a synthetic summaryFile key so
-  // they don't collide with local meetings. Same useChatSessions plumbing.
-  const sessionKey = activeOrgMeeting
-    ? `org:${activeOrgMeeting.id}`
-    : activeSummaryFile;
-  const sessionLabel = activeOrgMeeting?.title ?? activeMeetingName;
+
+  // Detect active recording so we can enable the bar and route to the live
+  // stream rather than the processed-note backend. We read recording state
+  // directly here — PrimaryDock passes disabled={recordingActive} for layout
+  // reasons (pill coexistence doc comment) but the input itself should be live.
+  const recording = useRecording();
+  const isRecording = recording.status === 'recording' || recording.status === 'paused';
+  const liveSessionName = recording.sessionName ?? undefined;
+
+  // Session key for live recording: stable synthetic key that won't collide
+  // with saved notes (summaryFile paths) or org notes (org:id).
+  const sessionKey =
+    isRecording && liveSessionName
+      ? `live:${liveSessionName}`
+      : activeOrgMeeting
+        ? `org:${activeOrgMeeting.id}`
+        : activeSummaryFile;
+  const sessionLabel = isRecording
+    ? (liveSessionName ?? 'Live recording')
+    : (activeOrgMeeting?.title ?? activeMeetingName);
+
+  // Hidden when there is nothing to chat about — recording provides its own
+  // context so a live session is always actionable.
+  const hidden = !activeSummaryFile && !activeOrgMeeting && !isRecording;
+  if (hidden) return null;
+
+  return (
+    <AskBarComposer
+      key={sessionKey ?? 'idle'}
+      sessionKey={sessionKey}
+      sessionLabel={sessionLabel}
+      activeMeetingName={activeMeetingName}
+      activeSummaryFile={activeSummaryFile}
+      activeOrgMeeting={activeOrgMeeting}
+      isRecording={isRecording}
+      liveSessionName={liveSessionName}
+      disabled={disabled}
+      transcriptOpen={transcriptOpen}
+      setTranscriptOpen={setTranscriptOpen}
+    />
+  );
+}
+
+interface AskBarComposerProps {
+  sessionKey: string | null;
+  sessionLabel: string | null;
+  activeMeetingName: string | null;
+  activeSummaryFile: string | null;
+  activeOrgMeeting: ActiveOrgMeeting | null;
+  isRecording: boolean;
+  liveSessionName: string | undefined;
+  disabled: boolean;
+  transcriptOpen: boolean;
+  setTranscriptOpen: (open: boolean) => void;
+}
+
+function AskBarComposer({
+  sessionKey,
+  sessionLabel,
+  activeMeetingName,
+  activeSummaryFile,
+  activeOrgMeeting,
+  isRecording,
+  liveSessionName,
+  disabled,
+  transcriptOpen,
+  setTranscriptOpen,
+}: AskBarComposerProps) {
   const chat = useChatSessions(sessionKey, sessionLabel);
   const streaming = useGlobalStreaming();
 
@@ -230,6 +303,7 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
   const [sessionMenuOpen, setSessionMenuOpen] = React.useState(false);
   const [input, setInput] = React.useState('');
   const [activeStreamId, setActiveStreamId] = React.useState<string | null>(null);
+  const activeStreamIdRef = React.useRef<string | null>(null);
   const pendingPersistRef = React.useRef<string | null>(null);
   const scrollRef = React.useRef<HTMLDivElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -239,32 +313,30 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
   const isStreaming = activeStream?.status === 'streaming';
   const session = chat.activeSession;
   const hasMessages = (session?.messages.length ?? 0) > 0;
-  const hidden = !activeSummaryFile && !activeOrgMeeting;
-  const canSend = input.trim().length > 0 && !isStreaming && !disabled;
 
-  const cancelStreamRef = React.useRef(streaming.cancelStream);
-  cancelStreamRef.current = streaming.cancelStream;
+  // canSend: during recording the disabled prop is irrelevant (live chat is
+  // always available); otherwise honour the caller's disabled flag.
+  const canSend = input.trim().length > 0 && !isStreaming && (isRecording || !disabled);
 
+  // Clean up any in-flight stream on unmount (e.g. when sessionKey changes or component unmounts)
+  const cancelStream = streaming.cancelStream;
   React.useEffect(() => {
-    setExpanded(false);
-    setSessionMenuOpen(false);
-    setTranscriptOpen(false);
-    setActiveStreamId((prev) => {
-      if (prev) {
-        cancelStreamRef.current(prev);
-        pendingPersistRef.current = null;
+    return () => {
+      const inFlightId = activeStreamIdRef.current;
+      if (inFlightId) {
+        cancelStream(inFlightId);
+        activeStreamIdRef.current = null;
       }
-      return null;
-    });
-  }, [activeSummaryFile, activeOrgMeeting?.id, setTranscriptOpen]);
+      setTranscriptOpen(false);
+    };
+  }, [cancelStream, setTranscriptOpen]);
 
-  // Recording started: close a saved-meeting transcript panel that was
-  // already open. The whole bar goes inert (the toggle below is hidden while
-  // disabled), and leaving the 72-band panel up would let it overlap the
-  // expanded LiveTranscriptBar — the one stacking the dock can't resolve.
+  // Recording started: close the saved-meeting transcript panel because it
+  // would overlap the LiveTranscriptBar. Live recording keeps this composer
+  // active, so only non-recording disabled states close it.
   React.useEffect(() => {
-    if (disabled) setTranscriptOpen(false);
-  }, [disabled, setTranscriptOpen]);
+    if (disabled && !isRecording) setTranscriptOpen(false);
+  }, [disabled, isRecording, setTranscriptOpen]);
 
   React.useEffect(() => {
     if (!expanded && !transcriptOpen) return;
@@ -291,25 +363,25 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
     scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [session?.messages.length, activeStream?.text, expanded]);
 
-  React.useEffect(() => {
-    if (!activeStreamId) return;
-    const stream = streaming.streams[activeStreamId];
-    if (!stream) return;
-    const sessionId = pendingPersistRef.current;
-    if (!sessionId) return;
-    if (stream.status === 'streaming') return;
-
+  const handleStreamComplete = (
+    streamId: string,
+    targetSessionId: string,
+    result: StreamResult
+  ) => {
     const content =
-      stream.text.trim() ||
-      (stream.status === 'error'
-        ? `Error: ${stream.error ?? 'query failed'}`
-        : '(empty response)');
+      result.text.trim() ||
+      (result.status === 'error' ? `Error: ${result.error ?? 'query failed'}` : '(empty response)');
     const message: ChatMessage = { role: 'assistant', content, ts: Date.now() };
-    void chat.appendMessage(sessionId, message);
-    pendingPersistRef.current = null;
-    streaming.clearStream(activeStreamId);
-    setActiveStreamId(null);
-  }, [activeStreamId, streaming, chat]);
+    void chat.appendMessage(targetSessionId, message);
+    if (pendingPersistRef.current === targetSessionId) {
+      pendingPersistRef.current = null;
+    }
+    streaming.clearStream(streamId);
+    if (activeStreamIdRef.current === streamId) {
+      activeStreamIdRef.current = null;
+    }
+    setActiveStreamId((current) => (current === streamId ? null : current));
+  };
 
   // Re-entrancy guard. submitPrompt awaits createSession/appendMessage; rapid
   // suggestion-chip clicks (or Enter) before those resolve would otherwise
@@ -318,8 +390,10 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
 
   const submitPrompt = async (raw: string) => {
     const q = raw.trim();
-    if (!q || isStreaming || disabled) return;
-    if (!activeSummaryFile && !activeOrgMeeting) return;
+    // During recording: not disabled; no summaryFile needed — use live route.
+    if (!q || isStreaming) return;
+    if (!isRecording && disabled) return;
+    if (!isRecording && !activeSummaryFile && !activeOrgMeeting) return;
     if (submittingRef.current) return;
     submittingRef.current = true;
 
@@ -334,9 +408,16 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
       setInput('');
 
       let streamId: string;
-      if (activeOrgMeeting) {
-        // Org route — system prompt is built from the shared note's body so
-        // the model has the same context the user sees on screen.
+      const targetSessionId = sessionId;
+      const onComplete = (result: StreamResult) => {
+        handleStreamComplete(streamId, targetSessionId, result);
+      };
+
+      if (isRecording && liveSessionName) {
+        // Live route — question sent against the in-progress recording.
+        streamId = streaming.startLiveStream(liveSessionName, q, { onComplete });
+      } else if (activeOrgMeeting) {
+        // Org route — system prompt built from the shared note's body.
         const system =
           `You answer questions about a single shared meeting note titled "${activeOrgMeeting.title}". ` +
           `Be concise and cite content from the note when relevant.\n\n--- NOTE ---\n${activeOrgMeeting.body}`;
@@ -344,11 +425,12 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
           role: m.role,
           content: m.content,
         }));
-        streamId = streaming.startOrgNoteStream(system, q, history);
+        streamId = streaming.startOrgNoteStream(system, q, history, { onComplete });
       } else {
-        streamId = streaming.startStream(activeSummaryFile!, q);
+        streamId = streaming.startStream(activeSummaryFile!, q, { onComplete });
       }
-      pendingPersistRef.current = sessionId;
+      pendingPersistRef.current = targetSessionId;
+      activeStreamIdRef.current = streamId;
       setActiveStreamId(streamId);
 
       setExpanded(true);
@@ -362,7 +444,24 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
 
   const stop = () => {
     if (!activeStreamId) return;
-    streaming.cancelStream(activeStreamId);
+    const streamId = activeStreamId;
+    const stream = streaming.streams[streamId];
+    streaming.cancelStream(streamId);
+
+    const sessionId = pendingPersistRef.current;
+    if (sessionId && stream) {
+      const content =
+        stream.text.trim() ||
+        (stream.status === 'error'
+          ? `Error: ${stream.error ?? 'query failed'}`
+          : '(empty response)');
+      const message: ChatMessage = { role: 'assistant', content, ts: Date.now() };
+      void chat.appendMessage(sessionId, message);
+      pendingPersistRef.current = null;
+    }
+    streaming.clearStream(streamId);
+    activeStreamIdRef.current = null;
+    setActiveStreamId(null);
   };
 
   const onPickSession = (id: string) => {
@@ -381,7 +480,6 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
     setExpanded(true);
   };
 
-
   const handleInputFocus = () => {
     setExpanded(true);
     if (transcriptOpen) setTranscriptOpen(false);
@@ -392,17 +490,15 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
     setSessionMenuOpen(false);
   };
 
-  // Idle with no meeting in context: nothing to chat about, render nothing.
-  // Disabled (recording active) is the exception — the bar stays visible as
-  // an inert shell so the transcription pill has the composer beside it and
-  // the user can see chat will return after processing.
-  if (hidden && !disabled) return null;
-
-  const showChatPanel = !disabled && expanded && (hasMessages || isStreaming);
+  const showChatPanel = (isRecording || !disabled) && expanded && (hasMessages || isStreaming);
 
   return (
-    <div ref={containerRef} data-ask-bar className="flex w-full flex-col gap-2.5" style={{ pointerEvents: 'auto' }}>
-
+    <div
+      ref={containerRef}
+      data-ask-bar
+      className="flex w-full flex-col gap-2.5"
+      style={{ pointerEvents: 'auto' }}
+    >
       {/* Chat message panel */}
       {showChatPanel && (
         <div className="mv-transcript open" style={{ maxHeight: 360 }}>
@@ -420,6 +516,7 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
           />
           <div
             ref={scrollRef}
+            data-testid="chat-messages"
             className="scrollbar-clean overflow-y-auto px-4 py-3"
             style={{ maxHeight: 300 }}
           >
@@ -433,11 +530,8 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
       )}
 
       {/* Suggestion chips — appear when ask bar is focused with empty conversation */}
-      {!disabled && expanded && !hasMessages && !isStreaming && (
-        <div
-          className="mv-chat flex flex-wrap items-center gap-2"
-          style={{ padding: '10px 14px' }}
-        >
+      {!isRecording && !disabled && expanded && !hasMessages && !isStreaming && (
+        <div className="mv-chat flex flex-wrap items-center gap-2" style={{ padding: '10px 14px' }}>
           {SUGGESTION_CHIPS.map((chip) => (
             <button
               key={chip.label}
@@ -455,7 +549,10 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
       {/* Chat composer */}
       <form
         className="mv-chat"
-        onSubmit={(e) => { e.preventDefault(); void submit(); }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          void submit();
+        }}
       >
         {/* Transcript toggle lives as a standalone circular button LEFT of the
             Ask bar (see TranscriptToggle, rendered by PrimaryDock) — Granola-
@@ -466,7 +563,7 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
           ref={inputRef}
           className="mv-chat-input"
           value={input}
-          disabled={disabled}
+          disabled={disabled && !isRecording}
           onChange={(e) => setInput(e.target.value)}
           onFocus={handleInputFocus}
           onKeyDown={(e) => {
@@ -481,23 +578,20 @@ export function AskBar({ disabled = false }: { disabled?: boolean }) {
             }
           }}
           placeholder={
-            disabled
-              ? 'Chat available after recording'
-              : hasMessages
-                ? 'Continue chat…'
-                : 'Ask anything about this meeting…'
+            isRecording
+              ? 'Ask about the live transcript…'
+              : disabled
+                ? 'Chat available after recording'
+                : hasMessages
+                  ? 'Continue chat…'
+                  : 'Ask anything about this meeting…'
           }
           aria-label="Ask about this meeting"
         />
 
         {/* Send / stop */}
         {isStreaming ? (
-          <button
-            type="button"
-            className="mv-chat-send active"
-            onClick={stop}
-            aria-label="Stop"
-          >
+          <button type="button" className="mv-chat-send active" onClick={stop} aria-label="Stop">
             <Square size={12} />
           </button>
         ) : (
@@ -545,14 +639,17 @@ function ChatHeader({
   onCollapse,
 }: ChatHeaderProps) {
   return (
-    <div className="relative flex flex-shrink-0 items-center justify-between border-b px-3 py-2" style={{ borderColor: 'var(--border-subtle)' }}>
+    <div
+      className="relative flex flex-shrink-0 items-center justify-between border-b px-3 py-2"
+      style={{ borderColor: 'var(--border-subtle)' }}
+    >
       <div className="relative">
         <button
           type="button"
           onClick={onOpenSessions}
           className={cn(
             'flex items-center gap-1.5 rounded-md px-2 py-1 text-sm font-semibold transition-colors hover:bg-muted',
-            sessionMenuOpen && 'bg-muted',
+            sessionMenuOpen && 'bg-muted'
           )}
           style={{ color: 'var(--fg-1)' }}
         >
@@ -560,7 +657,10 @@ function ChatHeader({
             {session?.name ?? (meetingName ? `Ask about ${meetingName}` : 'Ask AI')}
           </span>
           <ChevronDown
-            className={cn('size-3.5 flex-shrink-0 transition-transform duration-150', sessionMenuOpen && 'rotate-180')}
+            className={cn(
+              'size-3.5 flex-shrink-0 transition-transform duration-150',
+              sessionMenuOpen && 'rotate-180'
+            )}
             style={{ color: 'var(--fg-2)' }}
           />
         </button>
@@ -618,7 +718,9 @@ function SessionDropdown({ sessions, activeId, onPick, onDelete }: SessionDropdo
       style={{ background: 'var(--surface-raised)', borderColor: 'var(--border-subtle)' }}
     >
       {sessions.length === 0 ? (
-        <p className="px-3 py-2 text-xs" style={{ color: 'var(--fg-muted)' }}>No saved chats yet.</p>
+        <p className="px-3 py-2 text-xs" style={{ color: 'var(--fg-muted)' }}>
+          No saved chats yet.
+        </p>
       ) : (
         sessions.map((s) => {
           const isActive = s.id === activeId;
@@ -627,7 +729,7 @@ function SessionDropdown({ sessions, activeId, onPick, onDelete }: SessionDropdo
               key={s.id}
               className={cn(
                 'group flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm transition-colors hover:bg-muted',
-                isActive && 'bg-muted font-medium',
+                isActive && 'bg-muted font-medium'
               )}
             >
               <button
@@ -676,7 +778,10 @@ function MessageList({ messages, liveText, streaming }: MessageListProps) {
           {liveText ? (
             <div className="max-w-[90%] text-sm leading-[1.7]" style={{ color: 'var(--fg-1)' }}>
               {renderMarkdown(liveText)}
-              <span className="ml-0.5 inline-block h-3.5 w-0.5 animate-pulse align-text-bottom" style={{ background: 'var(--fg-2)' }} />
+              <span
+                className="ml-0.5 inline-block h-3.5 w-0.5 animate-pulse align-text-bottom"
+                style={{ background: 'var(--fg-2)' }}
+              />
             </div>
           ) : (
             <div className="flex items-center gap-1.5 py-1" style={{ color: 'var(--fg-muted)' }}>

--- a/app/renderer/src/hooks/useStreamingQuery.ts
+++ b/app/renderer/src/hooks/useStreamingQuery.ts
@@ -11,6 +11,18 @@ export interface StreamState {
   error: string | null;
 }
 
+export interface StreamResult {
+  text: string;
+  status: 'done' | 'error';
+  error: string | null;
+}
+
+export interface StreamOptions {
+  onChunk?: (chunk: string) => void;
+  onDone?: () => void;
+  onError?: (err: Error) => void;
+  onComplete?: (result: StreamResult) => void;
+}
 function newId() {
   return `q-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -33,43 +45,53 @@ export function useStreamingQuery() {
     activeRef.current.delete(id);
   };
 
-  const startStream = React.useCallback((file: string, question: string): string => {
-    const id = newId();
-    setStreams((prev) => ({
-      ...prev,
-      [id]: { text: '', status: 'streaming', error: null },
-    }));
-    activeRef.current.add(id);
+  const startStream = React.useCallback(
+    (file: string, question: string, options?: StreamOptions): string => {
+      const id = newId();
+      setStreams((prev) => ({
+        ...prev,
+        [id]: { text: '', status: 'streaming', error: null },
+      }));
+      activeRef.current.add(id);
 
-    const off = ipc().subscribeQueryStream(id, {
-      onChunk: (chunk) => {
-        setStreams((prev) => {
-          const current = prev[id];
-          if (!current) return prev;
-          return { ...prev, [id]: { ...current, text: current.text + chunk } };
-        });
-      },
-      onDone: () => {
-        setStreams((prev) => {
-          const current = prev[id];
-          if (!current) return prev;
-          return { ...prev, [id]: { ...current, status: 'done' } };
-        });
-        detachStream(id);
-      },
-      onError: (err) => {
-        setStreams((prev) => {
-          const current = prev[id];
-          if (!current) return prev;
-          return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
-        });
-        detachStream(id);
-      },
-    });
-    unsubsRef.current.set(id, off);
-    ipc().query.askStream(id, file, question);
-    return id;
-  }, []);
+      let accumulatedText = '';
+      const off = ipc().subscribeQueryStream(id, {
+        onChunk: (chunk) => {
+          accumulatedText += chunk;
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, text: current.text + chunk } };
+          });
+          options?.onChunk?.(chunk);
+        },
+        onDone: () => {
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, status: 'done' } };
+          });
+          detachStream(id);
+          options?.onDone?.();
+          options?.onComplete?.({ text: accumulatedText, status: 'done', error: null });
+        },
+        onError: (err) => {
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
+          });
+          detachStream(id);
+          options?.onError?.(err);
+          options?.onComplete?.({ text: accumulatedText, status: 'error', error: err.message });
+        },
+      });
+      unsubsRef.current.set(id, off);
+      ipc().query.askStream(id, file, question);
+      return id;
+    },
+    []
+  );
 
   // Cross-note variant of startStream — same wire shape, no summaryFile.
   // Used by the Chat tab to ask questions across every meeting summary,
@@ -79,123 +101,197 @@ export function useStreamingQuery() {
   // For org scope, we asynchronously build the corpus then dispatch through
   // ipc().org.chatStream — chunks land on the same query-chunk channel as
   // local chat so the renderer doesn't need a parallel subscription.
-  const startGlobalStream = React.useCallback((
-    question: string,
-    folderId?: string | null,
-    orgHistory?: Array<{ role: 'user' | 'assistant'; content: string }>,
-  ): string => {
-    const id = newId();
-    setStreams((prev) => ({
-      ...prev,
-      [id]: { text: '', status: 'streaming', error: null },
-    }));
-    activeRef.current.add(id);
+  const startGlobalStream = React.useCallback(
+    (
+      question: string,
+      folderId?: string | null,
+      orgHistory?: Array<{ role: 'user' | 'assistant'; content: string }>,
+      options?: StreamOptions
+    ): string => {
+      const id = newId();
+      setStreams((prev) => ({
+        ...prev,
+        [id]: { text: '', status: 'streaming', error: null },
+      }));
+      activeRef.current.add(id);
 
-    const off = ipc().subscribeQueryStream(id, {
-      onChunk: (chunk) => {
-        setStreams((prev) => {
-          const current = prev[id];
-          if (!current) return prev;
-          return { ...prev, [id]: { ...current, text: current.text + chunk } };
-        });
-      },
-      onDone: () => {
-        setStreams((prev) => {
-          const current = prev[id];
-          if (!current) return prev;
-          return { ...prev, [id]: { ...current, status: 'done' } };
-        });
-        detachStream(id);
-      },
-      onError: (err) => {
-        setStreams((prev) => {
-          const current = prev[id];
-          if (!current) return prev;
-          return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
-        });
-        detachStream(id);
-      },
-    });
-    unsubsRef.current.set(id, off);
-
-    if (folderId === ORG_SHARED_SCOPE) {
-      // Build the corpus + dispatch through the org adapter. The fetch is
-      // async; the user can cancel before payload-build completes, so we
-      // re-check activeRef before firing the actual stream to avoid kicking
-      // off a request the renderer no longer cares about.
-      void (async () => {
-        try {
-          const payload = await buildOrgChatPayload(orgHistory ?? [], question);
-          if (!activeRef.current.has(id)) return; // cancelled while building
-          ipc().org.chatStream(id, payload);
-        } catch (e) {
-          if (!activeRef.current.has(id)) return; // cancelled while building
+      let accumulatedText = '';
+      const off = ipc().subscribeQueryStream(id, {
+        onChunk: (chunk) => {
+          accumulatedText += chunk;
           setStreams((prev) => {
             const current = prev[id];
             if (!current) return prev;
-            return {
-              ...prev,
-              [id]: { ...current, status: 'error', error: (e as Error).message },
-            };
+            return { ...prev, [id]: { ...current, text: current.text + chunk } };
+          });
+          options?.onChunk?.(chunk);
+        },
+        onDone: () => {
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, status: 'done' } };
           });
           detachStream(id);
-        }
-      })();
-    } else {
-      ipc().query.chatGlobalStream(id, question, folderId ?? null);
-    }
-    return id;
-  }, []);
+          options?.onDone?.();
+          options?.onComplete?.({ text: accumulatedText, status: 'done', error: null });
+        },
+        onError: (err) => {
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
+          });
+          detachStream(id);
+          options?.onError?.(err);
+          options?.onComplete?.({ text: accumulatedText, status: 'error', error: err.message });
+        },
+      });
+      unsubsRef.current.set(id, off);
+
+      if (folderId === ORG_SHARED_SCOPE) {
+        // Build the corpus + dispatch through the org adapter. The fetch is
+        // async; the user can cancel before payload-build completes, so we
+        // re-check activeRef before firing the actual stream to avoid kicking
+        // off a request the renderer no longer cares about.
+        void (async () => {
+          try {
+            const payload = await buildOrgChatPayload(orgHistory ?? [], question);
+            if (!activeRef.current.has(id)) return; // cancelled while building
+            ipc().org.chatStream(id, payload);
+          } catch (e) {
+            if (!activeRef.current.has(id)) return; // cancelled while building
+            setStreams((prev) => {
+              const current = prev[id];
+              if (!current) return prev;
+              return {
+                ...prev,
+                [id]: { ...current, status: 'error', error: (e as Error).message },
+              };
+            });
+            detachStream(id);
+            const err = e as Error;
+            options?.onError?.(err);
+            options?.onComplete?.({ text: accumulatedText, status: 'error', error: err.message });
+          }
+        })();
+      } else {
+        ipc().query.chatGlobalStream(id, question, folderId ?? null);
+      }
+      return id;
+    },
+    []
+  );
 
   /** Stream a question against a single shared note's body, via the org
    *  adapter. Mirrors startStream's API but takes the note's system prompt
    *  directly instead of a local file path. */
-  const startOrgNoteStream = React.useCallback((
-    system: string,
-    question: string,
-    history?: Array<{ role: 'user' | 'assistant'; content: string }>,
-  ): string => {
-    const id = newId();
-    setStreams((prev) => ({
-      ...prev,
-      [id]: { text: '', status: 'streaming', error: null },
-    }));
-    activeRef.current.add(id);
+  const startOrgNoteStream = React.useCallback(
+    (
+      system: string,
+      question: string,
+      history?: Array<{ role: 'user' | 'assistant'; content: string }>,
+      options?: StreamOptions
+    ): string => {
+      const id = newId();
+      setStreams((prev) => ({
+        ...prev,
+        [id]: { text: '', status: 'streaming', error: null },
+      }));
+      activeRef.current.add(id);
 
-    const off = ipc().subscribeQueryStream(id, {
-      onChunk: (chunk) => {
-        setStreams((prev) => {
-          const current = prev[id];
-          if (!current) return prev;
-          return { ...prev, [id]: { ...current, text: current.text + chunk } };
-        });
-      },
-      onDone: () => {
-        setStreams((prev) => {
-          const current = prev[id];
-          if (!current) return prev;
-          return { ...prev, [id]: { ...current, status: 'done' } };
-        });
-        detachStream(id);
-      },
-      onError: (err) => {
-        setStreams((prev) => {
-          const current = prev[id];
-          if (!current) return prev;
-          return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
-        });
-        detachStream(id);
-      },
-    });
-    unsubsRef.current.set(id, off);
+      let accumulatedText = '';
+      const off = ipc().subscribeQueryStream(id, {
+        onChunk: (chunk) => {
+          accumulatedText += chunk;
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, text: current.text + chunk } };
+          });
+          options?.onChunk?.(chunk);
+        },
+        onDone: () => {
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, status: 'done' } };
+          });
+          detachStream(id);
+          options?.onDone?.();
+          options?.onComplete?.({ text: accumulatedText, status: 'done', error: null });
+        },
+        onError: (err) => {
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
+          });
+          detachStream(id);
+          options?.onError?.(err);
+          options?.onComplete?.({ text: accumulatedText, status: 'error', error: err.message });
+        },
+      });
+      unsubsRef.current.set(id, off);
 
-    const messages = [
-      ...(history ?? []),
-      { role: 'user' as const, content: question },
-    ];
-    ipc().org.chatStream(id, { system, messages });
-    return id;
-  }, []);
+      const messages = [...(history ?? []), { role: 'user' as const, content: question }];
+      ipc().org.chatStream(id, { system, messages });
+      return id;
+    },
+    []
+  );
+
+  /** Stream a question against the live (in-progress) recording transcript.
+   *  Routes to ipc().query.askLiveStream; main uses the same configured
+   *  provider and model as summaries. Chunks land on the standard query
+   *  stream channels so the existing subscription drives the UI. */
+  const startLiveStream = React.useCallback(
+    (sessionName: string, question: string, options?: StreamOptions): string => {
+      const id = newId();
+      setStreams((prev) => ({
+        ...prev,
+        [id]: { text: '', status: 'streaming', error: null },
+      }));
+      activeRef.current.add(id);
+
+      let accumulatedText = '';
+      const off = ipc().subscribeQueryStream(id, {
+        onChunk: (chunk) => {
+          accumulatedText += chunk;
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, text: current.text + chunk } };
+          });
+          options?.onChunk?.(chunk);
+        },
+        onDone: () => {
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, status: 'done' } };
+          });
+          detachStream(id);
+          options?.onDone?.();
+          options?.onComplete?.({ text: accumulatedText, status: 'done', error: null });
+        },
+        onError: (err) => {
+          setStreams((prev) => {
+            const current = prev[id];
+            if (!current) return prev;
+            return { ...prev, [id]: { ...current, status: 'error', error: err.message } };
+          });
+          detachStream(id);
+          options?.onError?.(err);
+          options?.onComplete?.({ text: accumulatedText, status: 'error', error: err.message });
+        },
+      });
+      unsubsRef.current.set(id, off);
+      ipc().query.askLiveStream(id, sessionName, question);
+      return id;
+    },
+    []
+  );
 
   const cancelStream = React.useCallback((id: string) => {
     const off = unsubsRef.current.get(id);
@@ -219,17 +315,19 @@ export function useStreamingQuery() {
   }, []);
 
   React.useEffect(() => {
+    const subscriptions = unsubsRef.current;
+    const activeStreams = activeRef.current;
     return () => {
-      for (const off of unsubsRef.current.values()) off();
-      unsubsRef.current.clear();
-      for (const id of activeRef.current) {
+      for (const off of subscriptions.values()) off();
+      subscriptions.clear();
+      for (const id of activeStreams) {
         try {
           ipc().query.cancel(id);
         } catch {
           // bridge may already be torn down
         }
       }
-      activeRef.current.clear();
+      activeStreams.clear();
     };
   }, []);
 
@@ -238,6 +336,7 @@ export function useStreamingQuery() {
     startStream,
     startGlobalStream,
     startOrgNoteStream,
+    startLiveStream,
     cancelStream,
     clearStream,
   };

--- a/app/renderer/src/lib/ipc.ts
+++ b/app/renderer/src/lib/ipc.ts
@@ -1134,6 +1134,7 @@ export interface StenoaiBridge {
   query: {
     ask: RequestFn<[file: string, q: string], QueryResponse>;
     askStream: SendFn<[id: string, file: string, q: string]>;
+    askLiveStream: SendFn<[id: string, sessionName: string, q: string]>;
     chatGlobalStream: SendFn<[id: string, q: string, folderId?: string | null]>;
     cancel: SendFn<[id: string]>;
   };

--- a/e2e/specs/live-meeting-chat.t1.spec.ts
+++ b/e2e/specs/live-meeting-chat.t1.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "../fixtures/electron";
+import type { Page } from "@playwright/test";
+
+/**
+ * T1 — renderer-only, mock IPC. The Ask bar stays enabled while recording,
+ * routes submissions to the live transcript stream, renders streamed chunks,
+ * and exposes cancellation. app/e2e-mock-ipc.js supplies the stateful stream;
+ * no backend or model runs.
+ */
+
+const PILL_ENV = {
+  STENOAI_E2E_MOCK_PARAKEET_INSTALLED: "1",
+  STENOAI_E2E_MOCK_LIVE_STREAM: "1",
+};
+const MESSAGES_TESTID = '[data-testid="chat-messages"]';
+// Start a recording in the BACKGROUND (as a hotkey/tray/auto trigger does) so the
+// Ask bar stays put with the composer enabled. Mirrors pill-dock.t1.
+async function startInBackground(page: Page, name = "Epsilon Planning") {
+  await page.evaluate((sessionName) => window.stenoai.recording.start(sessionName), name);
+  await expect(page.getByTestId("transcription-pill")).toBeVisible();
+}
+
+const LIVE_PLACEHOLDER = "Ask about the live transcript…";
+const OLD_DISABLED_HINT = "Chat available after recording";
+
+test("recording enables the composer with the live placeholder (not the disabled hint)", async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({
+    mockIpc: true,
+    env: { ...PILL_ENV, STENOAI_E2E_SEED_MEETING: "1" },
+  });
+
+  // On a meeting, idle: the composer is enabled with the normal hint.
+  await page.evaluate(() => {
+    window.location.hash = "#/meetings/epsilon_summary.json";
+  });
+  await expect(
+    page.getByPlaceholder("Ask anything about this meeting…"),
+  ).toBeVisible();
+
+  // Start recording in the background — the Ask bar stays (disabled={recordingActive}
+  // is only a layout signal on PrimaryDock); AskBar itself reads recording status.
+  await startInBackground(page);
+  // The recording coexists — home did not navigate to /recording.
+  const hash = await page.evaluate(() => window.location.hash);
+  expect(hash).not.toContain("/recording");
+
+  // The composer is ENABLED now, with the live-transcript placeholder.
+  const liveInput = page.getByPlaceholder(LIVE_PLACEHOLDER);
+  await expect(liveInput).toBeVisible();
+  await expect(liveInput).toBeEnabled();
+
+  // The old disabled hint must NOT be present anywhere.
+  await expect(page.getByPlaceholder(OLD_DISABLED_HINT)).toHaveCount(0);
+
+  // Stopped recording on the meeting view returns to the meeting placeholder.
+  await page.evaluate(() => window.stenoai.recording.stop());
+  await expect(
+    page.getByPlaceholder("Ask anything about this meeting…"),
+  ).toBeVisible();
+  await expect(page.getByPlaceholder(OLD_DISABLED_HINT)).toHaveCount(0);
+});
+
+test("live stream: submit routes to the live transcript and streamed answer renders", async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({ mockIpc: true, env: PILL_ENV });
+
+  await startInBackground(page);
+
+  const question = "What decision did the team reach on shipping Friday?";
+
+  // Type the question into the live-enabled composer and submit (Enter).
+  const input = page.getByPlaceholder(LIVE_PLACEHOLDER);
+  await input.click();
+  await input.fill(question);
+  await page.keyboard.press("Enter");
+
+  // The stream is live: the composer now shows the Stop affordance.
+  const stopButton = page.getByRole("button", { name: "Stop", exact: true });
+  await expect(stopButton).toBeVisible();
+  // The streamed answer appears alongside the user's question.
+  const body = () =>
+    page.locator(MESSAGES_TESTID).evaluate((el) => el.textContent ?? "");
+  await expect.poll(body, { timeout: 10_000 }).toContain(question);
+  await expect.poll(body, { timeout: 10_000 }).toContain("ship on Friday");
+});
+
+test("live stream: the stop/cancel button cancels an in-flight answer", async ({
+  launchApp,
+}) => {
+  const { page } = await launchApp({ mockIpc: true, env: PILL_ENV });
+
+  await startInBackground(page);
+
+  const input = page.getByPlaceholder(LIVE_PLACEHOLDER);
+  await input.click();
+  await input.fill("What were the next steps?");
+  await page.keyboard.press("Enter");
+
+  // Stream active → stop button.
+  const stopButton = page.getByRole("button", { name: "Stop", exact: true });
+  await expect(stopButton).toBeVisible();
+
+  // Click stop → cancels the stream. The composer returns to the Send affordance.
+  await stopButton.click();
+  await expect(
+    page.getByRole("button", { name: "Send", exact: true }),
+  ).toBeVisible();
+
+  // Re-type and submit: a new in-flight stream exposes Stop again, proving the
+  // cancel returned the bar to a reusable (not stuck-disabled) state.
+  await input.fill("Any risks?");
+  await page.keyboard.press("Enter");
+  await expect(stopButton).toBeVisible();
+});

--- a/e2e/specs/pill-dock.t1.spec.ts
+++ b/e2e/specs/pill-dock.t1.spec.ts
@@ -6,8 +6,8 @@ import type { Page } from '@playwright/test';
  * BACKGROUND start (hotkey/tray/auto) does not navigate — it docks the compact
  * Granola-style pill (components/LiveDock.tsx: wave + elapsed +
  * expand chevron + stop glyph) docks LEFT of the Ask bar in the primary
- * bottom-dock row (components/PrimaryDock.tsx), the Ask bar renders
- * visible-but-disabled, and (Parakeet) the pill expands into the
+ * bottom-dock row (components/PrimaryDock.tsx), the Ask bar stays enabled for
+ * live-transcript questions, and (Parakeet) the pill expands into the
  * LiveTranscriptBar panel.
  *
  * There is NO manual pause anywhere — stop ends the segment ("stop is the
@@ -37,7 +37,7 @@ async function startInBackground(page: Page) {
   return pill;
 }
 
-test('recording coexists: pill docks next to a disabled Ask bar, expands, stops to processing', async ({
+test('recording coexists: pill docks next to an enabled live Ask bar, expands, stops to processing', async ({
   launchApp,
 }) => {
   const { page } = await launchApp({ mockIpc: true, env: PILL_ENV });
@@ -50,11 +50,11 @@ test('recording coexists: pill docks next to a disabled Ask bar, expands, stops 
   expect(hash).not.toContain('/meetings/processing');
 
   // Adjacent row: pill + Ask bar share the primary dock row, and the Ask bar
-  // is visible but disabled with the recording hint.
+  // is visible and enabled with the live transcript placeholder.
   await expect(page.getByTestId('primary-dock-row')).toBeVisible();
-  const askInput = page.getByPlaceholder('Chat available after recording');
+  const askInput = page.getByPlaceholder('Ask about the live transcript…');
   await expect(askInput).toBeVisible();
-  await expect(askInput).toBeDisabled();
+  await expect(askInput).toBeEnabled();
 
   // Compact pill = wave + elapsed + expand + stop glyph. NO pause control —
   // stop is the new pause.
@@ -67,13 +67,13 @@ test('recording coexists: pill docks next to a disabled Ask bar, expands, stops 
   await expect(page.getByTestId('generate-notes-dock-button')).toHaveCount(0);
   await expect(page.locator('[data-transcript-bar]')).toHaveCount(0);
 
-  // Chrome routes (settings): the pill docks ALONE — no disabled composer
+  // Chrome routes (settings): the pill docks ALONE — no live composer
   // floating over the Settings page.
   await page.evaluate(() => {
     window.location.hash = '#/settings';
   });
   await expect(page.getByTestId('transcription-pill')).toBeVisible();
-  await expect(page.getByPlaceholder('Chat available after recording')).toHaveCount(0);
+  await expect(page.getByPlaceholder('Ask about the live transcript…')).toHaveCount(0);
 
   // Processing route: recording wins the slot (back-to-back notes) — the
   // pill + Stop stay reachable instead of being displaced by ProcessingDock.
@@ -205,11 +205,11 @@ test('continue-recording: the transcript panel footer offers Resume (Granola-sty
   await expect(resume).toBeVisible();
 
   // Resume starts a recording that appends to this note: the pill takes over
-  // and the Ask bar goes inert.
+  // and the Ask bar switches to the live transcript.
   await resume.click();
   await expect(page.getByTestId('transcription-pill')).toBeVisible();
   await expect(page.getByTestId('resume-recording-button')).toHaveCount(0);
-  await expect(page.getByPlaceholder('Chat available after recording')).toBeDisabled();
+  await expect(page.getByPlaceholder('Ask about the live transcript…')).toBeEnabled();
 });
 
 test('stale note (continued): floating CTA reads Generate notes', async ({ launchApp }) => {

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4028,6 +4028,128 @@ def query_streaming(transcript_file, question):
     except Exception as e:
         print(f"CHAT_STREAM_ERROR:{e}", flush=True)
 
+MAX_LIVE_QUERY_STDIN_BYTES = 1024 * 1024  # 1 MiB
+MAX_LIVE_QUERY_TRANSCRIPT_CHARS = 100_000
+MAX_LIVE_QUERY_QUESTION_CHARS = 2_000
+MAX_LIVE_QUERY_ANSWER_BYTES = 1024 * 1024  # 1 MiB
+
+
+@cli.command(name='query-live-streaming')
+@click.pass_context
+def query_live_streaming(ctx):
+    """Answer a question from the finalized live transcript.
+
+    Reads bounded JSON ``{"transcript": "...", "question": "..."}`` from
+    stdin and uses the same persisted provider and model as meeting summaries.
+    Streams ``CHAT_CHUNK:<base64>`` lines, then ``CHAT_STREAM_COMPLETE`` (or a
+    fixed ``CHAT_STREAM_ERROR`` on failure). Transcript and question content
+    never enters argv, logs, or error text.
+    """
+    import sys
+    import json
+    import base64
+    # This subprocess emits a machine protocol only. Provider/config diagnostics
+    # stay suppressed so no transcript or question content can reach stderr.
+    previous_logging_disable = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    ctx.call_on_close(lambda: logging.disable(previous_logging_disable))
+
+    try:
+        input_stream = getattr(sys.stdin, "buffer", sys.stdin)
+        raw_payload = input_stream.read(MAX_LIVE_QUERY_STDIN_BYTES + 1)
+        if isinstance(raw_payload, str):
+            raw_payload = raw_payload.encode("utf-8")
+    except Exception:
+        raw_payload = b""
+
+    if not raw_payload or not raw_payload.strip():
+        print(
+            "CHAT_STREAM_ERROR:Empty live transcript (nothing to query)",
+            flush=True,
+        )
+        sys.exit(1)
+
+    if len(raw_payload) > MAX_LIVE_QUERY_STDIN_BYTES:
+        print(
+            "CHAT_STREAM_ERROR:Live query payload exceeds maximum length",
+            flush=True,
+        )
+        sys.exit(1)
+
+    try:
+        data = json.loads(raw_payload)
+    except Exception:
+        print(
+            "CHAT_STREAM_ERROR:Invalid live query payload",
+            flush=True,
+        )
+        sys.exit(1)
+
+    if not isinstance(data, dict):
+        print(
+            "CHAT_STREAM_ERROR:Invalid live query payload",
+            flush=True,
+        )
+        sys.exit(1)
+
+    transcript = data.get("transcript")
+    question = data.get("question")
+
+    if not isinstance(transcript, str) or not transcript.strip():
+        print(
+            "CHAT_STREAM_ERROR:Empty live transcript (nothing to query)",
+            flush=True,
+        )
+        sys.exit(1)
+
+    if not isinstance(question, str) or not question.strip():
+        print(
+            "CHAT_STREAM_ERROR:Empty live query question",
+            flush=True,
+        )
+        sys.exit(1)
+
+    if len(transcript) > MAX_LIVE_QUERY_TRANSCRIPT_CHARS:
+        print(
+            "CHAT_STREAM_ERROR:Live transcript exceeds maximum length",
+            flush=True,
+        )
+        sys.exit(1)
+
+    if len(question) > MAX_LIVE_QUERY_QUESTION_CHARS:
+        print(
+            "CHAT_STREAM_ERROR:Live query question exceeds maximum length",
+            flush=True,
+        )
+        sys.exit(1)
+
+    from src.config import get_config
+
+    # Reuse the same language resolution the query prompt uses so the live
+    # answer respects the user's language pin / detection like every other path.
+    language = resolve_output_language(
+        get_config().get_language(), None, transcript.strip()
+    )
+
+    try:
+        summarizer = OllamaSummarizer()
+        total_answer_bytes = 0
+        for chunk in summarizer.query_transcript_streaming_strict(
+            transcript.strip(), question.strip(), language=language
+        ):
+            if not isinstance(chunk, str):
+                raise TypeError("Live query provider returned a non-text chunk")
+            chunk_bytes = chunk.encode('utf-8')
+            total_answer_bytes += len(chunk_bytes)
+            if total_answer_bytes > MAX_LIVE_QUERY_ANSWER_BYTES:
+                raise ValueError("Live query answer exceeded size limit")
+            encoded = base64.b64encode(chunk_bytes).decode('ascii')
+            sys.stdout.write(f"CHAT_CHUNK:{encoded}\n")
+            sys.stdout.flush()
+        print("CHAT_STREAM_COMPLETE", flush=True)
+    except Exception:
+        print("CHAT_STREAM_ERROR:Live query failed", flush=True)
+        sys.exit(1)
 
 def _chat_corpus_char_budget(ai_provider: str, model: str) -> int:
     """Char budget for the cross-note chat corpus, sized to the active model.

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1812,8 +1812,78 @@ QUESTION: {question}
 
 ANSWER:"""
 
-    def query_transcript_streaming(self, transcript: str, question: str, language: str = "en"):
-        """Generator that yields text chunks from the LLM for a transcript query."""
+    def query_transcript_streaming_strict(
+        self,
+        transcript: str,
+        question: str,
+        language: str = "en",
+    ):
+        """Yield query chunks while propagating provider and protocol errors."""
+        if not transcript or transcript.strip() == "":
+            raise ValueError("No transcript available to query.")
+        if not question or question.strip() == "":
+            raise ValueError("Please provide a question.")
+
+        prompt = self._build_query_prompt(transcript, question, language)
+
+        if self.ai_provider == "adapter":
+            # Interactive query — user is waiting at the AskBar. Fail fast on
+            # a stalled connection rather than using the summary-grade ceiling.
+            yield from self._adapter_stream(prompt, timeout_seconds=300)
+            return
+
+        if self.ai_provider == "cloud":
+            if self.cloud_provider == "anthropic":
+                with self.anthropic_client.messages.stream(
+                    model=self.model_name,
+                    max_tokens=2048,
+                    messages=[{"role": "user", "content": prompt}],
+                ) as stream:
+                    yield from stream.text_stream
+            elif self.cloud_provider == "bedrock":
+                # Bedrock streaming needs an eventstream parser; match the
+                # existing query path by yielding one bounded-time response.
+                text = self._bedrock_chat(prompt, timeout_seconds=300)
+                if text:
+                    yield text
+            else:
+                response = self.cloud_client.chat.completions.create(
+                    model=self.model_name,
+                    messages=[{"role": "user", "content": prompt}],
+                    stream=True,
+                )
+                for chunk in response:
+                    # Some providers emit usage-only chunks with no choices.
+                    if not chunk.choices:
+                        continue
+                    content = chunk.choices[0].delta.content
+                    if content:
+                        yield content
+            return
+
+        if self.ai_provider == "remote":
+            self.client = ollama.Client(host=self.remote_url)
+        else:
+            self._ensure_ollama_ready()
+            self.client = ollama.Client()
+        stream = self.client.chat(
+            model=self.model_name,
+            messages=[{"role": "user", "content": prompt}],
+            stream=True,
+            options=self._ollama_options(),
+        )
+        for chunk in stream:
+            content = chunk["message"]["content"]
+            if content:
+                yield content
+
+    def query_transcript_streaming(
+        self,
+        transcript: str,
+        question: str,
+        language: str = "en",
+    ):
+        """Yield query chunks and preserve the legacy inline error response."""
         if not transcript or transcript.strip() == "":
             yield "No transcript available to query."
             return
@@ -1821,62 +1891,12 @@ ANSWER:"""
             yield "Please provide a question."
             return
 
-        prompt = self._build_query_prompt(transcript, question, language)
-
         try:
-            if self.ai_provider == "adapter":
-                # Interactive query — user is waiting at the AskBar. Fail
-                # fast on a stalled connection rather than letting it hang
-                # for the summarisation-grade ceiling.
-                yield from self._adapter_stream(prompt, timeout_seconds=300)
-                return
-            if self.ai_provider == "cloud":
-                if self.cloud_provider == "anthropic":
-                    with self.anthropic_client.messages.stream(
-                        model=self.model_name,
-                        max_tokens=2048,
-                        messages=[{"role": "user", "content": prompt}],
-                    ) as stream:
-                        for text in stream.text_stream:
-                            yield text
-                elif self.cloud_provider == "bedrock":
-                    # Same eventstream parsing tradeoff as summarize_streaming
-                    # — fall back to non-streaming Converse and emit the full
-                    # answer in one yield. Interactive query so we keep the
-                    # 300 s ceiling that the OpenAI/Anthropic paths use.
-                    text = self._bedrock_chat(prompt, timeout_seconds=300)
-                    if text:
-                        yield text
-                else:
-                    response = self.cloud_client.chat.completions.create(
-                        model=self.model_name,
-                        messages=[{"role": "user", "content": prompt}],
-                        stream=True,
-                    )
-                    for chunk in response:
-                        # Some providers emit chunk variants with empty choices
-                        # (e.g. usage-only chunks); skip those instead of crashing.
-                        if not chunk.choices:
-                            continue
-                        content = chunk.choices[0].delta.content
-                        if content:
-                            yield content
-            else:
-                if self.ai_provider == "remote":
-                    self.client = ollama.Client(host=self.remote_url)
-                else:
-                    self._ensure_ollama_ready()
-                    self.client = ollama.Client()
-                stream = self.client.chat(
-                    model=self.model_name,
-                    messages=[{"role": "user", "content": prompt}],
-                    stream=True,
-                    options=self._ollama_options(),
-                )
-                for chunk in stream:
-                    content = chunk['message']['content']
-                    if content:
-                        yield content
+            yield from self.query_transcript_streaming_strict(
+                transcript,
+                question,
+                language=language,
+            )
         except Exception as e:
             logger.error(f"Streaming query failed: {e}")
             yield f"\n[Error: {e}]"

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1804,10 +1804,11 @@ TITLE:"""
             query_lang_instruction = ""
         return f"""Answer the following question based on the meeting content below (summary, key topics, and transcript).
 Be concise and direct. If the answer requires inference from what was discussed, that's fine.
-Only say you don't know if the topic truly wasn't discussed at all.{query_lang_instruction}
+If the transcript below contains no speech, reply that there is no meeting content yet.{query_lang_instruction}
 
 QUESTION: {question}
 
+TRANSCRIPT:
 {transcript}
 
 ANSWER:"""

--- a/tests/test_live_query.py
+++ b/tests/test_live_query.py
@@ -1,0 +1,360 @@
+"""Tests for the provider-neutral live AskBar query backend."""
+
+import base64
+import json
+import logging
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from click.testing import CliRunner
+
+_TEST_USER_DATA = tempfile.TemporaryDirectory()
+os.environ.setdefault("STENOAI_USER_DATA_DIR", _TEST_USER_DATA.name)
+
+# Backend imports must happen after the user-data override above.
+import simple_recorder  # noqa: E402
+from simple_recorder import query_live_streaming  # noqa: E402
+from src.summarizer import OllamaSummarizer  # noqa: E402
+
+
+class _Config:
+    def get_language(self):
+        return "auto"
+
+
+class LiveQueryCliTests(unittest.TestCase):
+    def _run(
+        self,
+        *,
+        raw_input=None,
+        transcript="The team decided to ship on Friday.",
+        question="What did we decide?",
+        args=None,
+        chunks=("They will ", "ship on Friday."),
+        stream_error=None,
+    ):
+        if raw_input is None:
+            raw_input = json.dumps(
+                {"transcript": transcript, "question": question}
+            )
+
+        summarizer = mock.MagicMock()
+        if stream_error is None:
+            summarizer.query_transcript_streaming_strict.return_value = iter(chunks)
+        else:
+            summarizer.query_transcript_streaming_strict.side_effect = stream_error
+
+        with (
+            mock.patch.object(
+                simple_recorder,
+                "OllamaSummarizer",
+                return_value=summarizer,
+            ) as summarizer_class,
+            mock.patch("src.config.get_config", return_value=_Config()),
+            mock.patch.object(
+                simple_recorder,
+                "resolve_output_language",
+                return_value="en",
+            ),
+        ):
+            result = CliRunner().invoke(
+                query_live_streaming,
+                args or [],
+                input=raw_input,
+            )
+
+        return result, summarizer_class, summarizer
+
+    def test_is_registered_on_the_cli(self):
+        self.assertIn("query-live-streaming", simple_recorder.cli.commands)
+
+    def test_provider_and_model_override_options_are_not_accepted(self):
+        for args in (
+            ["-q", "What did we decide?"],
+            ["--host", "http://127.0.0.1:11443"],
+            ["--model", "some-model"],
+        ):
+            with self.subTest(args=args):
+                result, summarizer_class, _ = self._run(args=args)
+                self.assertNotEqual(result.exit_code, 0)
+                self.assertIn("No such option", result.output)
+                summarizer_class.assert_not_called()
+
+    def test_uses_configured_summarizer_and_strict_stream_with_zero_overrides(self):
+        transcript = "  The team voted to release on Friday.  "
+        question = "  When is the release?  "
+        chunks = ("Friday ", "afternoon.")
+
+        result, summarizer_class, summarizer = self._run(
+            transcript=transcript,
+            question=question,
+            chunks=chunks,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        summarizer_class.assert_called_once_with()
+        summarizer.query_transcript_streaming_strict.assert_called_once_with(
+            transcript.strip(),
+            question.strip(),
+            language="en",
+        )
+
+        lines = result.output.splitlines()
+        encoded_chunks = [
+            line.removeprefix("CHAT_CHUNK:")
+            for line in lines
+            if line.startswith("CHAT_CHUNK:")
+        ]
+        self.assertEqual(
+            [base64.b64decode(value).decode("utf-8") for value in encoded_chunks],
+            list(chunks),
+        )
+        self.assertEqual(lines[-1], "CHAT_STREAM_COMPLETE")
+
+    def test_invalid_payloads_fail_before_constructing_a_summarizer(self):
+        cases = (
+            ("", "Empty live transcript"),
+            ("  \n", "Empty live transcript"),
+            ("{not-json}", "Invalid live query payload"),
+            (json.dumps(["not", "an", "object"]), "Invalid live query payload"),
+            (
+                json.dumps({"transcript": "  ", "question": "valid"}),
+                "Empty live transcript",
+            ),
+            (
+                json.dumps({"transcript": "valid", "question": "  "}),
+                "Empty live query question",
+            ),
+        )
+        for raw_input, expected in cases:
+            with self.subTest(expected=expected):
+                result, summarizer_class, _ = self._run(raw_input=raw_input)
+                self.assertNotEqual(result.exit_code, 0)
+                self.assertIn(f"CHAT_STREAM_ERROR:{expected}", result.output)
+                self.assertNotIn("CHAT_STREAM_COMPLETE", result.output)
+                summarizer_class.assert_not_called()
+
+    def test_transcript_and_question_character_limits(self):
+        cases = (
+            (
+                {"transcript": "A" * 100_001, "question": "Q"},
+                "Live transcript exceeds maximum length",
+            ),
+            (
+                {"transcript": "A", "question": "Q" * 2_001},
+                "Live query question exceeds maximum length",
+            ),
+        )
+        for payload, expected in cases:
+            with self.subTest(expected=expected):
+                result, summarizer_class, _ = self._run(
+                    raw_input=json.dumps(payload)
+                )
+                self.assertNotEqual(result.exit_code, 0)
+                self.assertIn(f"CHAT_STREAM_ERROR:{expected}", result.output)
+                summarizer_class.assert_not_called()
+
+    def test_stdin_limit_is_measured_in_utf8_bytes(self):
+        raw_input = json.dumps(
+            {
+                "transcript": "valid",
+                "question": "Q",
+                "padding": "界" * 350_000,
+            },
+            ensure_ascii=False,
+        )
+        self.assertGreater(
+            len(raw_input.encode("utf-8")),
+            simple_recorder.MAX_LIVE_QUERY_STDIN_BYTES,
+        )
+
+        result, summarizer_class, _ = self._run(raw_input=raw_input)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn(
+            "CHAT_STREAM_ERROR:Live query payload exceeds maximum length",
+            result.output,
+        )
+        summarizer_class.assert_not_called()
+
+    def test_provider_failure_emits_only_fixed_error_and_restores_logging(self):
+        transcript = "SECRET_TRANSCRIPT the budget was cut"
+        question = "SECRET_QUESTION by how much?"
+        provider_error = RuntimeError(
+            "SECRET_PROVIDER_ERROR containing prompt and endpoint details"
+        )
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+
+        handler = _Capture()
+        root = logging.getLogger()
+        root.addHandler(handler)
+        previous_disable = logging.root.manager.disable
+        try:
+            result, summarizer_class, summarizer = self._run(
+                transcript=transcript,
+                question=question,
+                stream_error=provider_error,
+            )
+        finally:
+            root.removeHandler(handler)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.output.strip(),
+            "CHAT_STREAM_ERROR:Live query failed",
+        )
+        self.assertNotIn("CHAT_STREAM_COMPLETE", result.output)
+        self.assertNotIn("SECRET_", result.output)
+        self.assertEqual(records, [])
+        self.assertEqual(logging.root.manager.disable, previous_disable)
+        summarizer_class.assert_called_once_with()
+        summarizer.query_transcript_streaming_strict.assert_called_once()
+
+    def test_answer_exceeding_one_mib_fails_without_completion(self):
+        chunks = ("X" * (512 * 1024), "Y" * (512 * 1024 + 1))
+
+        result, _, _ = self._run(chunks=chunks)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("CHAT_CHUNK:", result.output)
+        self.assertIn("CHAT_STREAM_ERROR:Live query failed", result.output)
+        self.assertNotIn("CHAT_STREAM_COMPLETE", result.output)
+
+    def test_non_text_provider_chunk_fails_closed(self):
+        result, _, _ = self._run(chunks=("valid", b"not text"))
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("CHAT_STREAM_ERROR:Live query failed", result.output)
+        self.assertNotIn("CHAT_STREAM_COMPLETE", result.output)
+
+
+class StrictQueryStreamingTests(unittest.TestCase):
+    def test_strict_stream_propagates_provider_errors(self):
+        summarizer = object.__new__(OllamaSummarizer)
+        summarizer.ollama_process = None
+        summarizer.ai_provider = "adapter"
+        summarizer._build_query_prompt = mock.MagicMock(return_value="prompt")
+        summarizer._adapter_stream = mock.MagicMock(
+            side_effect=RuntimeError("provider unavailable")
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "provider unavailable"):
+            list(
+                summarizer.query_transcript_streaming_strict(
+                    "transcript",
+                    "question",
+                )
+            )
+        summarizer._adapter_stream.assert_called_once_with(
+            "prompt",
+            timeout_seconds=300,
+        )
+
+    def test_strict_stream_uses_configured_local_or_remote_ollama(self):
+        for provider in ("local", "remote"):
+            with self.subTest(provider=provider):
+                summarizer = object.__new__(OllamaSummarizer)
+                summarizer.ollama_process = None
+                summarizer.ai_provider = provider
+                summarizer.model_name = "configured-model"
+                summarizer.remote_url = "https://configured.example"
+                summarizer._build_query_prompt = mock.MagicMock(
+                    return_value="prompt"
+                )
+                summarizer._ensure_ollama_ready = mock.MagicMock()
+                summarizer._ollama_options = mock.MagicMock(
+                    return_value={"num_ctx": 8192}
+                )
+                fake_ollama = mock.MagicMock()
+                client = mock.MagicMock()
+                client.chat.return_value = iter(
+                    [{"message": {"content": "configured answer"}}]
+                )
+                fake_ollama.Client.return_value = client
+
+                with mock.patch("src.summarizer.ollama", fake_ollama):
+                    chunks = list(
+                        summarizer.query_transcript_streaming_strict(
+                            "transcript",
+                            "question",
+                        )
+                    )
+
+                self.assertEqual(chunks, ["configured answer"])
+                expected_client_args = (
+                    {"host": "https://configured.example"}
+                    if provider == "remote"
+                    else {}
+                )
+                fake_ollama.Client.assert_called_once_with(**expected_client_args)
+                if provider == "remote":
+                    summarizer._ensure_ollama_ready.assert_not_called()
+                else:
+                    summarizer._ensure_ollama_ready.assert_called_once_with()
+                client.chat.assert_called_once_with(
+                    model="configured-model",
+                    messages=[{"role": "user", "content": "prompt"}],
+                    stream=True,
+                    options={"num_ctx": 8192},
+                )
+
+    def test_strict_stream_uses_configured_openai_compatible_provider(self):
+        summarizer = object.__new__(OllamaSummarizer)
+        summarizer.ollama_process = None
+        summarizer.ai_provider = "cloud"
+        summarizer.cloud_provider = "openai"
+        summarizer.model_name = "configured-cloud-model"
+        summarizer._build_query_prompt = mock.MagicMock(return_value="prompt")
+        summarizer.cloud_client = mock.MagicMock()
+        summarizer.cloud_client.chat.completions.create.return_value = [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="cloud answer")
+                    )
+                ]
+            ),
+            SimpleNamespace(choices=[]),
+        ]
+
+        chunks = list(
+            summarizer.query_transcript_streaming_strict(
+                "transcript",
+                "question",
+            )
+        )
+
+        self.assertEqual(chunks, ["cloud answer"])
+        summarizer.cloud_client.chat.completions.create.assert_called_once_with(
+            model="configured-cloud-model",
+            messages=[{"role": "user", "content": "prompt"}],
+            stream=True,
+        )
+
+    def test_legacy_stream_keeps_inline_error_contract(self):
+        summarizer = object.__new__(OllamaSummarizer)
+        summarizer.ollama_process = None
+        summarizer.query_transcript_streaming_strict = mock.MagicMock(
+            side_effect=RuntimeError("provider unavailable")
+        )
+
+        with self.assertLogs("src.summarizer", level="ERROR"):
+            chunks = list(
+                summarizer.query_transcript_streaming(
+                    "transcript",
+                    "question",
+                )
+            )
+
+        self.assertEqual(chunks, ["\n[Error: provider unavailable]"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Lets users ask questions while a recording is still in progress:

- enables the Ask bar during recording and streams answers against finalized live-transcript segments
- uses the same persisted provider and model as summaries (local or remote Ollama, OpenAI-compatible, Anthropic, Bedrock, or the organisation adapter); there is no feature-specific host or model override
- keeps transcript and question content off argv and logs by sending one bounded JSON payload over stdin
- limits questions to 2,000 characters, recent transcript context to 100,000 characters, stdin/protocol/answer buffers to 1 MiB, and requests to 300 seconds
- gates transcript access to the trusted renderer, allows one live query at a time, binds cancellation to its owner, and maps child/provider failures to fixed UI errors
- retains the existing finished-note and global-chat flows

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [ ] Tested locally with `npm start`
- [x] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

Verified on macOS:

- `vp run test:unit` — 350 Node tests and 200 Vitest tests passed
- `vp run typecheck:renderer` — passed
- `vp run build:renderer` — passed
- ESLint on the three changed renderer files — passed with no warnings
- `python -m unittest tests.test_live_query -v` — 13 passed, covering configured local, remote, OpenAI-compatible, and adapter paths plus limits and fixed-error privacy
- `python -m unittest tests.test_summarizer_stream_errors tests.test_summarizer_logging_privacy -v` — 14 passed
- `playwright test ... live-meeting-chat.t1.spec.ts` — 3 passed
- `playwright test ... pill-dock.t1.spec.ts` — 7 T1 tests passed; the unrelated model-backed T2 match was skipped

## Additional Notes

Live queries follow the user's existing AI-provider choice. A local provider keeps the query local; when a cloud or organisation provider is configured, the bounded live transcript snapshot is sent to that provider just as meeting summaries are.

No recording, transcript, question, provider response, file name, or raw provider error is added to telemetry or logs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users ask questions while a recording is in progress by streaming answers from finalized live-transcript segments. Previously the Ask bar was disabled during recording; now it stays enabled, streams against a bounded transcript snapshot, supports cancel, and keeps content private.

- Backend/IPC
  - Adds `query-live-transcript-stream` and gates live transcript state and queries to the trusted renderer (main window only).
  - Allows one live query at a time; binds cancellation to the query owner; maps provider/child failures to fixed UI errors; no transcript/question/response content enters telemetry or logs.
  - Introduces `query-live-streaming` in `simple_recorder.py`: reads one bounded JSON payload over stdin, streams base64 chunks, enforces limits (question 2,000 chars; transcript 100,000 chars; line/answer buffers 1 MiB; 300s timeout), and uses the persisted provider/model (local Ollama, OpenAI-compatible, Anthropic, Bedrock, or organisation adapter).

- Renderer/tests
  - Keeps the Ask bar enabled during recording; updates `AskBar` and `useStreamingQuery` to handle live streaming and cancel; adds `askLiveStream` to the preload bridge.
  - Retains finished-note and global-chat flows unchanged.
  - Adds unit and e2e coverage: `live-query-helpers.test.js`, `tests/test_live_query.py`, new `live-meeting-chat.t1.spec.ts`, and updates `pill-dock.t1.spec.ts`.

<sup>Written for commit c9c7fbe289302778544b155dda3acf8817224b53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

