### PR TITLE
feat(macOS): default summaries to Apple SystemLanguageModel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,27 @@ back to channel labels when the cache is unavailable. The cache lives below
 the Steno user-data directory and therefore honors `STENOAI_USER_DATA_DIR` in
 tests; `STENOAI_DIARIZE_MODEL_DIR` is the lower-level sidecar override.
 
+### Apple System Language Model (macOS only)
+On-device summarization uses `bin/steno-apple-lm`, a Swift sidecar
+(`apple-lm-sidecar/`) wrapping `FoundationModels.SystemLanguageModel.default`.
+The OS serves Advanced when the Mac has it and otherwise 3B Core; there is no
+`init(variant:)`. Python talks to the sidecar via `src.apple_lm` (`status` /
+`complete` / `stream`); prompts go on stdin, and errors are fixed strings.
+Build it before `pyinstaller` when the macOS 26+ SDK is present:
+
+```
+scripts/build-apple-lm-sidecar.sh   # outputs bin/steno-apple-lm
+```
+
+`stenoai.spec` bundles the binary only when it exists and only on Darwin. A
+build host without the SDK omits it and the app keeps Ollama
+`gemma4:e2b-it-qat`. Official `macos-14` release runners cannot compile
+FoundationModels; a real sidecar in the notarized DMG needs a macOS 26+
+build image. Tests isolate with `STENOAI_DISABLE_APPLE_LM=1`; a fake binary
+can be injected via `STENOAI_APPLE_LM_BIN`. Windows/Linux never resolve the
+sidecar.
+
+
 ### End-to-end tests (Playwright)
 The e2e suite drives the **real Electron app** (real window, real clicks) to catch
 full-app regressions like the org-provider reset before they reach users. It lives

--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ Have questions or suggestions? [Join our Discord](https://discord.gg/DZ6vcQnxxu)
 - `Parakeet TDT v3` (572 MB): Highest quality, supports live transcription, 25 European languages (English, Spanish, French, German, Italian, Portuguese, Dutch, Russian, Polish, Czech, and 15 others). Apple Silicon only via MLX. **(default on fresh installs)**
 - `Whisper Large V3 Turbo` (1.6 GB): Best-accuracy Whisper engine for the languages Parakeet can't speak (Chinese, Japanese, Korean, Arabic, Hindi, and 94 others). Post-stop only.
 
-**Summarization Models** (Ollama):
-- `gemma4:e2b-it-qat` (4.3GB): Lightest Gemma 4, quantization-aware, with a real 128K context **(default)**
+**Summarization Models:**
+- `Apple Intelligence (SystemLanguageModel)`: Built-in on-device System Language Model — Advanced wherever available, automatically falling back to 3B Core. **(default on macOS when available)**
+- `gemma4:e2b-it-qat` (4.3GB): Lightest Gemma 4 via Ollama, quantization-aware, with a real 128K context **(default fallback / non-Apple)**
 - `gemma4:e4b-it-qat` (6.1GB): Quantization-aware E4B — higher quality than E2B at a modest footprint
 - `qwen3.5:9b` (6.6GB): Excellent at structured output and action items
 - `gemma4:12b-it-qat` (7.2GB): Gemma 4 (quantization-aware) with a 256K context — best for long meetings
 - `gpt-oss:20b` (14GB): OpenAI open-weight model with reasoning capabilities
-
 ## Future Roadmap
 
 ### Enhanced Features

--- a/app/analytics-helpers.js
+++ b/app/analytics-helpers.js
@@ -301,7 +301,8 @@ function captureSanitizedException(posthogClient, err, distinctId) {
 // User-entered model names, fine-tuned ids, local paths, and self-pulled tags
 // can carry customer/project names, so they collapse to the fixed "custom".
 const ANALYTICS_MODEL_ALLOWLIST = new Set([
-  // Curated local registry (SUPPORTED_MODELS in src/config.py) + MLX tags
+  // Curated local registry (SUPPORTED_MODELS in src/config.py) + Apple + MLX tags
+  'apple:system',
   'gemma4:e2b-it-qat',
   'gemma4:e4b-it-qat',
   'gemma4:12b-it-qat',

--- a/app/analytics-helpers.test.js
+++ b/app/analytics-helpers.test.js
@@ -471,6 +471,7 @@ test('sanitizeModelForAnalytics keeps known public model ids but collapses custo
   // deliberate literal duplicate of ANALYTICS_MODEL_ALLOWLIST so that an
   // accidental removal or typo in the allowlist fails here.
   const curatedPublicIds = [
+    'apple:system',
     'gemma4:e2b-it-qat',
     'gemma4:e4b-it-qat',
     'gemma4:12b-it-qat',

--- a/app/main.js
+++ b/app/main.js
@@ -7299,6 +7299,48 @@ ipcMain.handle('setup-ollama-and-model', async () => {
       sendDebugLog(`Could not read AI provider, proceeding with local setup: ${e.message}`);
     }
 
+    // Check if Apple Intelligence or an already-installed model is available
+    let pullTarget = DEFAULT_AI_MODEL;
+    try {
+      const resolvedRaw = await runPythonScript('simple_recorder.py', ['resolve-setup-model'], true);
+      const resolved = JSON.parse(resolvedRaw.trim());
+      if (resolved && resolved.pull_target) {
+        pullTarget = resolved.pull_target;
+      }
+      if (resolved && resolved.installed) {
+        if (resolved.installed === 'apple:system') {
+          sendDebugLog('Using Apple Intelligence for on-device summaries');
+          try {
+            const setRaw = await runPythonScript('simple_recorder.py', ['set-model', 'apple:system'], true);
+            const jsonLine = setRaw.trim().split('\n').reverse().find((l) => l.trim().startsWith('{'));
+            const setRes = jsonLine ? JSON.parse(jsonLine) : null;
+            if (!setRes || setRes.success !== true) {
+              return { success: false, error: (setRes && setRes.error) || 'Failed to save Apple Intelligence as the selected model.' };
+            }
+          } catch (e) {
+            return { success: false, error: `Failed to save Apple Intelligence as the selected model: ${e.message}` };
+          }
+          trackEvent('setup_completed', { step: 'apple_intelligence' });
+          return { success: true, message: 'Using Apple Intelligence' };
+        }
+        sendDebugLog(`Found already-installed model "${resolved.installed}" — skipping download`);
+        try {
+          const setRaw = await runPythonScript('simple_recorder.py', ['set-model', resolved.installed], true);
+          const jsonLine = setRaw.trim().split('\n').reverse().find((l) => l.trim().startsWith('{'));
+          const setRes = jsonLine ? JSON.parse(jsonLine) : null;
+          if (!setRes || setRes.success !== true) {
+            return { success: false, error: (setRes && setRes.error) || 'Failed to save the selected model.' };
+          }
+        } catch (e) {
+          return { success: false, error: `Failed to save the selected model: ${e.message}` };
+        }
+        trackEvent('setup_completed', { step: 'ollama_existing_model' });
+        return { success: true, message: `Using already-installed model ${resolved.installed}` };
+      }
+    } catch (e) {
+      sendDebugLog(`Could not check for installed models: ${e.message}`);
+    }
+
     // Check macOS version — bundled Ollama requires macOS 14 (Sonoma) or later.
     // os.release() reports the kernel version, which is Darwin on mac but the
     // Windows NT build on Windows; gate the version check to darwin so a non-mac
@@ -7403,44 +7445,7 @@ ipcMain.handle('setup-ollama-and-model', async () => {
       sendDebugLog('Warning: Ollama may not be fully ready, attempting pull anyway...');
     }
 
-    // #123: don't re-download the default if the connected Ollama already has a
-    // supported model. The backend matches installed models against the supported
-    // registry (single source of truth in config.py); on a hit we set it active
-    // and skip the pull entirely, so the default Local path needs no network for
-    // anyone with a usable Ollama already set up. Best-effort: any failure here
-    // falls through to the normal download below.
-    let pullTarget = DEFAULT_AI_MODEL;
-    try {
-      const resolvedRaw = await runPythonScript('simple_recorder.py', ['resolve-setup-model'], true);
-      const resolved = JSON.parse(resolvedRaw.trim());
-      if (resolved && resolved.pull_target) {
-        pullTarget = resolved.pull_target;
-      }
-      if (resolved && resolved.installed) {
-        sendDebugLog(`Found already-installed model "${resolved.installed}" — skipping download`);
-        // Persist it as the active model, and only report success once that
-        // write actually succeeded. set-model now exits non-zero on a
-        // config-write failure (runPythonScript rejects) AND prints
-        // success:false, so we check both: swallowing the failure here would
-        // have setup claim success with no active model saved.
-        try {
-          const setRaw = await runPythonScript('simple_recorder.py', ['set-model', resolved.installed], true);
-          // set-model prints a human line before the JSON, so grab the last
-          // JSON-looking line rather than parsing the whole stdout.
-          const jsonLine = setRaw.trim().split('\n').reverse().find((l) => l.trim().startsWith('{'));
-          const setRes = jsonLine ? JSON.parse(jsonLine) : null;
-          if (!setRes || setRes.success !== true) {
-            return { success: false, error: (setRes && setRes.error) || 'Failed to save the selected model.' };
-          }
-        } catch (e) {
-          return { success: false, error: `Failed to save the selected model: ${e.message}` };
-        }
-        trackEvent('setup_completed', { step: 'ollama_existing_model' });
-        return { success: true, message: `Using already-installed model ${resolved.installed}` };
-      }
-    } catch (e) {
-      sendDebugLog(`Could not check for installed models, proceeding to download: ${e.message}`);
-    }
+    // If no model is installed yet, download the pullTarget model
 
     sendDebugLog('Downloading AI model (this may take several minutes)...');
     sendDebugLog(`POST http://127.0.0.1:11434/api/pull {name: "${pullTarget}"}`);

--- a/app/renderer/src/lib/chat.ts
+++ b/app/renderer/src/lib/chat.ts
@@ -59,6 +59,7 @@ export function formatActiveModel(p: ActiveModelFields | undefined): string {
       return 'Organisation';
     case 'local':
     default:
+      if (p.model === 'apple:system') return 'Apple Intelligence';
       return p.model ? `Ollama · ${p.model}` : 'Ollama';
   }
 }

--- a/apple-lm-sidecar/main.swift
+++ b/apple-lm-sidecar/main.swift
@@ -1,0 +1,140 @@
+import Foundation
+import FoundationModels
+
+@main
+struct StenoAppleLM {
+    static func main() async {
+        let command = CommandLine.arguments.dropFirst().first ?? "status"
+        do {
+            switch command {
+            case "status":
+                try printStatus()
+            case "complete":
+                try await printComplete()
+            case "stream":
+                try await printStream()
+            default:
+                FileHandle.standardError.write(Data("usage: steno-apple-lm status | complete | stream\n".utf8))
+                exit(2)
+            }
+        } catch {
+            emitError()
+            exit(1)
+        }
+    }
+}
+
+private func readStdinPrompt() -> String {
+    let data = FileHandle.standardInput.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8) ?? ""
+}
+
+private func printJSON(_ object: [String: Any]) throws {
+    let data = try JSONSerialization.data(withJSONObject: object, options: [])
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+private func emitError() {
+    // Fixed keys only — never echo the prompt or model output.
+    try? printJSON(["error": "apple_lm_failed"])
+}
+
+private func printStatus() throws {
+    guard #available(macOS 26.0, *) else {
+        try printJSON(["available": false, "reason": "unsupported_os"])
+        return
+    }
+    let model = SystemLanguageModel.default
+    switch model.availability {
+    case .available:
+        var payload: [String: Any] = ["available": true]
+        if #available(macOS 27.0, *) {
+            let variant = model.variant
+            if variant == .coreAdvanced3 {
+                payload["variant"] = "coreAdvanced3"
+            } else if variant == .core3 {
+                payload["variant"] = "core3"
+            } else {
+                payload["variant"] = "unknown"
+            }
+            payload["display_name"] = variant.displayName
+        } else {
+            payload["variant"] = "core3"
+            payload["display_name"] = "Apple Intelligence"
+        }
+        try printJSON(payload)
+    case .unavailable(let reason):
+        try printJSON([
+            "available": false,
+            "reason": unavailableReasonName(reason),
+        ])
+    }
+}
+
+@available(macOS 26.0, *)
+private func unavailableReasonName(
+    _ reason: SystemLanguageModel.Availability.UnavailableReason
+) -> String {
+    switch reason {
+    case .deviceNotEligible:
+        return "deviceNotEligible"
+    case .appleIntelligenceNotEnabled:
+        return "appleIntelligenceNotEnabled"
+    case .modelNotReady:
+        return "modelNotReady"
+    @unknown default:
+        return "unavailable"
+    }
+}
+
+private func printComplete() async throws {
+    guard #available(macOS 26.0, *) else {
+        try printJSON(["error": "apple_lm_failed", "reason": "unsupported_os"])
+        exit(1)
+    }
+    let model = SystemLanguageModel.default
+    guard model.isAvailable else {
+        try printJSON(["error": "apple_lm_failed", "reason": "unavailable"])
+        exit(1)
+    }
+    let session = LanguageModelSession(model: model)
+    let response = try await session.respond(to: readStdinPrompt())
+    try printJSON(["text": response.content])
+}
+
+private func printStream() async throws {
+    guard #available(macOS 26.0, *) else {
+        try printJSON(["error": "apple_lm_failed", "reason": "unsupported_os"])
+        exit(1)
+    }
+    let model = SystemLanguageModel.default
+    guard model.isAvailable else {
+        try printJSON(["error": "apple_lm_failed", "reason": "unavailable"])
+        exit(1)
+    }
+    let session = LanguageModelSession(model: model)
+    var previous = ""
+    let stream = session.streamResponse(to: readStdinPrompt())
+    for try await snapshot in stream {
+        let current = stringContent(snapshot.content)
+        let delta: String
+        if current.hasPrefix(previous) {
+            delta = String(current.dropFirst(previous.count))
+        } else {
+            delta = current
+        }
+        previous = current
+        if !delta.isEmpty {
+            try printJSON(["delta": delta])
+        }
+    }
+    try printJSON(["done": true])
+}
+
+private func stringContent(_ value: some Any) -> String {
+    if let text = value as? String {
+        return text
+    }
+    return String(describing: value)
+}

--- a/docs/models/summarization-models.mdx
+++ b/docs/models/summarization-models.mdx
@@ -9,16 +9,14 @@ After transcription, Steno passes the transcript to a language model to generate
 
 | Model | Size | Notes |
 |-------|------|-------|
-| `gemma4:e2b-it-qat` | ~4.3GB (~6.5GB on Apple Silicon) | Default. Fast, 128K context. |
+| `apple:system` (Apple Intelligence) | Built-in | Default on macOS when available. Uses SystemLanguageModel Advanced with automatic 3B Core fallback. |
+| `gemma4:e2b-it-qat` | ~4.3GB (~6.5GB on Apple Silicon) | Default Ollama fallback. Fast, 128K context. |
 | `gemma4:e4b-it-qat` | ~6.1GB (~8.8GB on Apple Silicon) | Higher quality, modest footprint. |
 | `qwen3.5:9b` | ~6.6GB | Strong at structured output and action items. |
 | `gemma4:12b-it-qat` | ~7.2GB (~7.7GB on Apple Silicon) | 256K context, best for long meetings. |
 | `gpt-oss:20b` | ~14GB | Highest quality, reasoning. |
 
-On Apple Silicon, the three Gemma 4 models are automatically pulled as MLX/NVFP4 builds instead of the base GGUF -- a meaningful speed win, at a larger download size (shown above).
-
-`gemma4:e2b-it-qat` (Gemma 4 E2B) is the default and handles most meetings well. `llama3.2:3b` is still available for existing users pinned to it, but is deprecated in favor of the Gemma 4 lineup and hidden from the default model picker. Larger models produce better-structured, more detailed notes; the trade-off is processing time and disk space.
-
+On Apple Silicon with Apple Intelligence available, Steno uses the built-in `SystemLanguageModel` (preferring Advanced and falling back to 3B Core). Otherwise, local summarization runs via Ollama with `gemma4:e2b-it-qat` as the default.
 ## How to change models
 
 1. Open **Settings → AI**

--- a/e2e/fixtures/electron.ts
+++ b/e2e/fixtures/electron.ts
@@ -67,6 +67,9 @@ export const test = base.extend<Fixtures>({
         // A specific focus/visibility test can override this with "0".
         STENOAI_E2E_HEADLESS: '1',
         STENOAI_USER_DATA_DIR: userDataDir,
+        // Model-free E2E defaults to deterministic Ollama fixtures unless a spec
+        // explicitly tests Apple LM integration via opts.env.
+        STENOAI_DISABLE_APPLE_LM: '1',
         ...(opts.mockIpc ? { STENOAI_E2E_MOCK_IPC: '1' } : {}),
         ...(opts.env ?? {}),
       };
@@ -81,6 +84,7 @@ export const test = base.extend<Fixtures>({
           app = await electron.launch({
             args: [
               '.',
+              ...(process.env.ELECTRON_EXTRA_LAUNCH_ARGS ? process.env.ELECTRON_EXTRA_LAUNCH_ARGS.split(' ') : []),
               ...(opts.fakeAudio
                 ? ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream']
                 : []),

--- a/e2e/specs/apple-lm-default.t2.spec.ts
+++ b/e2e/specs/apple-lm-default.t2.spec.ts
@@ -1,0 +1,119 @@
+import { chmodSync, mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { test, expect } from '../fixtures/electron';
+import { realUserDataDir, fileSig } from '../fixtures/real-user-data';
+import { readUserConfig } from '../fixtures/user-config';
+
+/**
+ * T2 — Apple System Language Model (Advanced / 3B Core) default resolution.
+ *
+ * Model-free: uses a lightweight mock script pointed to via STENOAI_APPLE_LM_BIN
+ * with STENOAI_DISABLE_APPLE_LM: '0'. Verifies that on Darwin, when Apple LM is
+ * reported available, a fresh launch defaults to `apple:system`, surfaces it via
+ * the preload bridge, lists it in supported_models, and persists to disk.
+ */
+
+type ListResult = {
+  success: boolean;
+  current_model?: string;
+  supported_models?: Record<string, { installed?: boolean; name?: string; description?: string }>;
+};
+
+type CurrentModel = { success: boolean; model?: string };
+
+type StenoWindow = Window & {
+  stenoai: {
+    models: {
+      list: () => Promise<ListResult>;
+      getCurrent: () => Promise<CurrentModel>;
+      set: (name: string) => Promise<{ success?: boolean }>;
+    };
+    ai: {
+      getProvider: () => Promise<{ success: boolean; model?: string; ai_provider?: string }>;
+    };
+  };
+};
+
+test('fresh install defaults to apple:system when Apple Intelligence is available', async ({
+  launchApp,
+  userDataDir,
+}) => {
+  test.skip(process.platform !== 'darwin', 'Apple SystemLanguageModel is macOS-only');
+
+  const realDirBefore = fileSig(realUserDataDir());
+  const fixtureDir = mkdtempSync(path.join(tmpdir(), 'stenoai-apple-lm-'));
+  const mockScript = path.join(fixtureDir, 'mock-steno-apple-lm.sh');
+
+  writeFileSync(
+    mockScript,
+    [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      'cmd="${1:-status}"',
+      'case "$cmd" in',
+      '  status)',
+      '    echo \'{"available":true,"variant":"coreAdvanced3","display_name":"Apple Intelligence"}\'',
+      '    ;;',
+      '  complete)',
+      '    echo \'{"text":"Mocked response"}\'',
+      '    ;;',
+      '  stream)',
+      '    echo \'{"delta":"Mocked"}\'',
+      '    echo \'{"done":true}\'',
+      '    ;;',
+      '  *)',
+      '    echo \'{"error":"unknown_command"}\'',
+      '    exit 1',
+      '    ;;',
+      'esac',
+    ].join('\n'),
+  );
+  chmodSync(mockScript, 0o755);
+
+  const { page } = await launchApp({
+    env: {
+      STENOAI_DISABLE_APPLE_LM: '0',
+      STENOAI_APPLE_LM_BIN: mockScript,
+    },
+  });
+
+  // Preload get-current-model returns apple:system
+  const current = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.models.getCurrent(),
+  );
+  expect(current.success).toBe(true);
+  expect(current.model).toBe('apple:system');
+
+  // getProvider also returns model: apple:system
+  const provider = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.ai.getProvider(),
+  );
+  expect(provider.success).toBe(true);
+  expect(provider.model).toBe('apple:system');
+
+  // On-disk config reflects apple:system with auto source
+  await expect
+    .poll(() => readUserConfig(userDataDir).model)
+    .toBe('apple:system');
+  expect(readUserConfig(userDataDir).summary_model_source).toBe('auto');
+
+  // models.list includes apple:system as installed
+  const listed = await page.evaluate(() =>
+    (window as StenoWindow).stenoai.models.list(),
+  );
+  expect(listed.success).toBe(true);
+  expect(listed.supported_models?.['apple:system']?.installed).toBe(true);
+  expect(listed.supported_models?.['apple:system']?.description).toContain('Advanced');
+
+  // Explicit user switch to another model updates config and sets source to user
+  await page.evaluate(() =>
+    (window as StenoWindow).stenoai.models.set('gemma4:e2b-it-qat'),
+  );
+  await expect
+    .poll(() => readUserConfig(userDataDir).model)
+    .toBe('gemma4:e2b-it-qat');
+  expect(readUserConfig(userDataDir).summary_model_source).toBe('user');
+
+  expect(fileSig(realUserDataDir())).toBe(realDirBefore);
+});

--- a/scripts/build-apple-lm-sidecar.sh
+++ b/scripts/build-apple-lm-sidecar.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build the Darwin-only SystemLanguageModel helper.
+#
+# Usage: scripts/build-apple-lm-sidecar.sh [arch]
+#   arch defaults to host arch (arm64 / x86_64).
+#
+# FoundationModels.framework ships with the macOS 26+ SDK. Prefer Xcode-beta
+# when present so Variant inspection (macOS 27) is available.
+set -euo pipefail
+
+ARCH="${1:-$(uname -m)}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/apple-lm-sidecar/main.swift"
+OUT="$ROOT/bin/steno-apple-lm"
+
+if [[ ! -f "$SRC" ]]; then
+    echo "missing sidecar source: $SRC" >&2
+    exit 1
+fi
+
+if [[ -d /Applications/Xcode-beta.app ]]; then
+    export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+fi
+
+mkdir -p "$ROOT/bin"
+
+TMP_OUT="${OUT}.tmp.$$"
+trap 'rm -f "$TMP_OUT"' EXIT
+
+xcrun swiftc \
+    -O \
+    -parse-as-library \
+    -target "${ARCH}-apple-macos26.0" \
+    -framework FoundationModels \
+    "$SRC" \
+    -o "$TMP_OUT"
+
+test -x "$TMP_OUT"
+codesign --sign - "$TMP_OUT" 2>/dev/null || true
+mv -f "$TMP_OUT" "$OUT"
+trap - EXIT
+file "$OUT"

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -64,6 +64,11 @@ if [ "$(uname -s)" = "Darwin" ]; then
         exit 1
     fi
     echo ""
+    echo "Building Apple LM sidecar (needs macOS 26+ SDK)..."
+    if ! "$SCRIPT_DIR/build-apple-lm-sidecar.sh" "$(uname -m)"; then
+        echo "Warning: Apple LM sidecar was not built at bin/steno-apple-lm." >&2
+        echo "Summaries will use Ollama until a host with the macOS 26+ SDK produces that binary." >&2
+    fi
 fi
 
 python3 -m PyInstaller stenoai.spec --noconfirm

--- a/simple_recorder.py
+++ b/simple_recorder.py
@@ -4500,15 +4500,22 @@ def setup_check(as_json):
     else:
         checks.append(("⚠️ whisper-model", "will download on first use (~500MB)"))
 
-    # Check if LLM model is downloaded (check ~/.ollama/models/)
-    ollama_models_path = Path.home() / ".ollama" / "models" / "manifests" / "registry.ollama.ai" / "library"
-    if ollama_models_path.exists() and any(ollama_models_path.iterdir()):
-        model_names = [d.name for d in ollama_models_path.iterdir() if d.is_dir()]
-        checks.append(("✅ llm-model", ", ".join(model_names[:2])))
+    # Check if LLM model is available (Apple System Language Model or ~/.ollama/models/)
+    from src.apple_lm import apple_lm_available, apple_lm_status
+    if sys.platform == "darwin" and apple_lm_available():
+        status = apple_lm_status()
+        variant = status.get("variant") or "available"
+        checks.append(("✅ llm-model", f"Apple System Language Model ({variant})"))
     else:
-        checks.append(("❌ llm-model", "no model installed - needed for summaries"))
-
-    # Derive a structured, machine-readable view of the checks. This is the
+        try:
+            ollama_models_path = Path.home() / ".ollama" / "models" / "manifests" / "registry.ollama.ai" / "library"
+            if ollama_models_path.exists() and any(ollama_models_path.iterdir()):
+                model_names = [d.name for d in ollama_models_path.iterdir() if d.is_dir()]
+                checks.append(("✅ llm-model", ", ".join(model_names[:2])))
+            else:
+                checks.append(("❌ llm-model", "no model installed - needed for summaries"))
+        except Exception:
+            checks.append(("❌ llm-model", "no model installed - needed for summaries"))
     # single source of truth for each check's (name, status, detail) and for the
     # overall verdict; both the JSON output and the human summary below read from
     # it, so the pass/fail logic is never duplicated. Status is decoded from the
@@ -4671,6 +4678,20 @@ def list_models():
                     # "Select" re-offered.
                     if info['mlx_installed']:
                         info['installed'] = True
+        from src.apple_lm import (
+            APPLE_SYSTEM_MODEL,
+            apple_lm_available,
+            apple_system_model_info,
+            is_apple_system_model,
+        )
+        if provider == "local" and (apple_lm_available() or is_apple_system_model(current_model)):
+            is_def = (current_model == APPLE_SYSTEM_MODEL)
+            apple_info = {
+                **apple_system_model_info(is_default=is_def),
+                "installed": apple_lm_available(),
+                "gguf_installed": False,
+            }
+            models = {APPLE_SYSTEM_MODEL: apple_info, **models}
         result = {
             "current_model": current_model,
             "supported_models": models,
@@ -8190,11 +8211,15 @@ def download_whisper_model():
 @cli.command()
 @click.argument('model_name')
 def check_model(model_name):
-    """Check if a model is installed in Ollama (uses HTTP API)."""
+    """Check if a model is installed in Ollama or available in Apple Intelligence."""
+    from src.apple_lm import is_apple_system_model, apple_lm_available
+    if is_apple_system_model(model_name):
+        print(json.dumps({"installed": apple_lm_available(), "model": model_name}))
+        return
+
     from src.config import get_config
     config = get_config()
     provider = config.get_ai_provider()
-
     if provider == "remote":
         remote_url = config.get_remote_ollama_url()
         if not remote_url:
@@ -8228,6 +8253,14 @@ def check_model(model_name):
 @click.argument('model_name')
 def pull_model(model_name):
     """Download an Ollama model (uses HTTP API)."""
+    from src.apple_lm import is_apple_system_model, apple_lm_available
+    if is_apple_system_model(model_name):
+        if apple_lm_available():
+            print(json.dumps({"success": True, "model": model_name}))
+        else:
+            print(json.dumps({"success": False, "error": "Apple Intelligence is not available on this system"}))
+        return
+
     from src.ollama_manager import start_ollama_server
     start_ollama_server()
     try:
@@ -8266,14 +8299,16 @@ def pull_model(model_name):
 @cli.command(name='verify-model')
 @click.argument('model_name')
 def verify_model(model_name):
-    """Smoke-test a just-pulled model with a 1-token chat call (uses HTTP API).
+    """Smoke-test a model with a 1-token chat call."""
+    from src.apple_lm import is_apple_system_model, complete
+    if is_apple_system_model(model_name):
+        try:
+            complete("hi", timeout=10)
+            print(json.dumps({"success": True, "error": None}))
+        except Exception as e:
+            print(json.dumps({"success": False, "error": str(e)}))
+        return
 
-    Used only by the Settings "switch to faster build" flow, to prove an
-    MLX/NVFP4 tag actually loads and responds before offering to delete the
-    old GGUF build. A generous timeout accounts for MLX cold-load (several
-    seconds after a fresh pull, per local benchmarking) -- a slow-but-working
-    model must not be reported as a failure.
-    """
     from src.ollama_manager import start_ollama_server
     start_ollama_server()
     try:
@@ -8292,16 +8327,12 @@ def verify_model(model_name):
 @cli.command(name='delete-model')
 @click.argument('model_name')
 def delete_model(model_name):
-    """Delete a locally-pulled Ollama model (uses HTTP API).
+    """Delete a locally-pulled Ollama model (uses HTTP API)."""
+    from src.apple_lm import is_apple_system_model
+    if is_apple_system_model(model_name):
+        print(json.dumps({"success": False, "error": "Cannot delete built-in Apple System model"}))
+        return
 
-    Called by the Settings "switch to faster build" flow (the old GGUF tag,
-    after its NVFP4 sibling has been pulled and verified) and by the general
-    "delete this model to free up disk space" action (either the GGUF id or
-    its NVFP4 sibling) -- never a tag currently in active use. Restricted to
-    supported GGUF ids and their NVFP4 siblings: this is a destructive
-    IPC-reachable operation, so it must not delete an arbitrary
-    caller-supplied model name.
-    """
     from src.config import get_config, Config
 
     allowed = set(get_config().list_supported_models()) | set(Config._MLX_EQUIVALENTS.values())
@@ -8357,6 +8388,12 @@ def resolve_setup_model():
     whether to download. Uses the HTTP API (ollama package), not the binary.
     """
     from src.config import get_config, Config
+    from src.apple_lm import apple_lm_available, APPLE_SYSTEM_MODEL
+
+    if apple_lm_available():
+        print(json.dumps({"installed": APPLE_SYSTEM_MODEL, "pull_target": None}))
+        return
+
     from src.ollama_manager import start_ollama_server
     from src.config import is_apple_silicon
 
@@ -8407,6 +8444,13 @@ def resolve_setup_model():
         result["error"] = str(e)
     print(json.dumps(result))
 
+
+
+@cli.command(name='apple-lm-status')
+def apple_lm_status_cmd():
+    """Inspect Apple SystemLanguageModel status and availability."""
+    from src.apple_lm import apple_lm_status
+    print(json.dumps(apple_lm_status()))
 
 @cli.command(name='check-adapter')
 @click.argument('url')

--- a/src/apple_lm.py
+++ b/src/apple_lm.py
@@ -1,0 +1,254 @@
+"""Apple SystemLanguageModel sidecar: Advanced when the OS has it, else 3B Core.
+
+The public FoundationModels API exposes ``SystemLanguageModel.default`` plus an
+inspect-only ``variant`` (``coreAdvanced3`` / ``core3``). There is no
+``init(variant:)`` — the OS picks Advanced where it is available and otherwise
+serves the 3B Core model. This module probes that default and, when it is
+available, is the local summarization default on Darwin.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+APPLE_SYSTEM_MODEL = "apple:system"
+APPLE_LM_NUM_CTX = 4096
+
+_DISABLE_ENV = "STENOAI_DISABLE_APPLE_LM"
+_BIN_ENV = "STENOAI_APPLE_LM_BIN"
+
+_STATUS_LOCK = threading.Lock()
+_STATUS_CACHE: Optional[Dict[str, Any]] = None
+_STATUS_CACHE_BIN: Optional[str] = None
+
+
+def is_apple_system_model(model_id: Optional[str]) -> bool:
+    return model_id == APPLE_SYSTEM_MODEL
+
+
+def apple_lm_disabled() -> bool:
+    return os.environ.get(_DISABLE_ENV) == "1"
+
+
+def reset_apple_lm_cache() -> None:
+    """Drop the process-wide status cache. Tests only."""
+    global _STATUS_CACHE, _STATUS_CACHE_BIN
+    with _STATUS_LOCK:
+        _STATUS_CACHE = None
+        _STATUS_CACHE_BIN = None
+
+
+def resolve_apple_lm_bin() -> Optional[str]:
+    """Locate ``steno-apple-lm``. Darwin only; None when disabled or missing."""
+    if apple_lm_disabled() or sys.platform != "darwin":
+        return None
+    candidates: list[str] = []
+    override = os.environ.get(_BIN_ENV)
+    if override:
+        candidates.append(override)
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).parent
+        candidates.extend(
+            [
+                str(exe_dir / "steno-apple-lm"),
+                str(exe_dir / "_internal" / "steno-apple-lm"),
+            ]
+        )
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+        candidates.append(str(repo_root / "bin" / "steno-apple-lm"))
+    for cand in candidates:
+        if os.access(cand, os.X_OK):
+            return cand
+    return None
+
+
+def apple_lm_status() -> Dict[str, Any]:
+    """Probe sidecar ``status``. Cached per process + binary path."""
+    global _STATUS_CACHE, _STATUS_CACHE_BIN
+    if apple_lm_disabled():
+        return {"available": False, "reason": "disabled"}
+    if sys.platform != "darwin":
+        return {"available": False, "reason": "unsupported_os"}
+    binary = resolve_apple_lm_bin()
+    if not binary:
+        return {"available": False, "reason": "sidecar_missing"}
+    with _STATUS_LOCK:
+        if _STATUS_CACHE is not None and _STATUS_CACHE_BIN == binary:
+            return dict(_STATUS_CACHE)
+    try:
+        raw = _run_apple_lm(["status"], timeout=15)
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError("status payload is not an object")
+    except Exception as exc:
+        logger.info("apple-lm status failed: %s", type(exc).__name__)
+        payload = {"available": False, "reason": "sidecar_error"}
+    with _STATUS_LOCK:
+        _STATUS_CACHE = dict(payload)
+        _STATUS_CACHE_BIN = binary
+    return dict(payload)
+
+
+def apple_lm_available() -> bool:
+    return bool(apple_lm_status().get("available"))
+
+
+def resolve_default_summary_model() -> str:
+    """Apple system model when the sidecar reports available, else Ollama default."""
+    from src.config import Config
+
+    if apple_lm_available():
+        return APPLE_SYSTEM_MODEL
+    return Config.DEFAULT_MODEL
+
+
+def apple_system_model_info(*, is_default: bool = False) -> Dict[str, str]:
+    status = apple_lm_status()
+    variant = status.get("variant")
+    if variant == "coreAdvanced3":
+        quality_bit = "Advanced"
+    elif variant == "core3":
+        quality_bit = "3B Core"
+    else:
+        quality_bit = "Advanced when available, else 3B Core"
+    default_bit = " (default)" if is_default else ""
+    display = status.get("display_name") or "Apple Intelligence"
+    return {
+        "name": display if isinstance(display, str) and display.strip() else "Apple Intelligence",
+        "size": "",
+        "params": "3B",
+        "description": f"On-device System Language Model — {quality_bit}{default_bit}",
+        "speed": "fast",
+        "quality": "good",
+    }
+
+
+def complete(prompt: str, timeout: float = 7200) -> str:
+    raw = _run_apple_lm(["complete"], stdin=prompt, timeout=timeout)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Apple Intelligence returned invalid output") from exc
+    if not isinstance(payload, dict) or payload.get("error"):
+        raise RuntimeError("Apple Intelligence request failed")
+    text = payload.get("text") or ""
+    if not isinstance(text, str) or not text.strip():
+        raise RuntimeError("Apple Intelligence returned an empty response")
+    return text
+
+
+def stream_complete(prompt: str, timeout: float = 7200) -> Iterator[str]:
+    binary = resolve_apple_lm_bin()
+    if not binary:
+        raise RuntimeError("Apple Intelligence sidecar is not available")
+    proc = subprocess.Popen(
+        [binary, "stream"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    try:
+        proc.stdin.write(prompt)
+        proc.stdin.close()
+        deadline = time.monotonic() + timeout
+        line_queue: queue.Queue[Optional[str]] = queue.Queue()
+
+        def _reader():
+            try:
+                for line in proc.stdout:
+                    line_queue.put(line)
+            except Exception:
+                pass
+            finally:
+                line_queue.put(None)
+
+        reader_thread = threading.Thread(target=_reader, daemon=True)
+        reader_thread.start()
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("Apple Intelligence stream timed out")
+            try:
+                line = line_queue.get(timeout=remaining)
+            except queue.Empty:
+                raise TimeoutError("Apple Intelligence stream timed out")
+            if line is None:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise RuntimeError("Apple Intelligence returned invalid output") from exc
+            if not isinstance(rec, dict) or rec.get("error"):
+                raise RuntimeError("Apple Intelligence request failed")
+            if rec.get("done"):
+                return
+            delta = rec.get("delta") or ""
+            if delta:
+                yield delta
+        if proc.wait(timeout=5) not in (0, None):
+            raise RuntimeError("Apple Intelligence request failed")
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+def _run_apple_lm(
+    args: list[str],
+    *,
+    stdin: Optional[str] = None,
+    timeout: float = 30,
+) -> str:
+    binary = resolve_apple_lm_bin()
+    if not binary:
+        raise FileNotFoundError("steno-apple-lm not found")
+    logger.info("apple-lm %s (%s chars stdin)", args[0] if args else "?", len(stdin or ""))
+    try:
+        proc = subprocess.run(
+            [binary, *args],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError("Apple Intelligence timed out") from exc
+    if proc.returncode != 0:
+        raise RuntimeError("Apple Intelligence request failed")
+    return (proc.stdout or "").strip()
+
+
+class AppleLMClient:
+    """Duck-types the Ollama ``Client.chat`` surface used by OllamaSummarizer."""
+
+    def chat(self, *, stream: bool = False, messages=None, **_kwargs):
+        prompt = ""
+        if messages:
+            last = messages[-1] or {}
+            prompt = last.get("content") or ""
+        if stream:
+            return self._stream(prompt)
+        return {"message": {"content": complete(prompt)}}
+
+    def _stream(self, prompt: str):
+        for delta in stream_complete(prompt):
+            yield {"message": {"content": delta}}

--- a/src/apple_lm.py
+++ b/src/apple_lm.py
@@ -23,7 +23,18 @@ from typing import Any, Dict, Iterator, Optional
 logger = logging.getLogger(__name__)
 
 APPLE_SYSTEM_MODEL = "apple:system"
-APPLE_LM_NUM_CTX = 4096
+# Apple's on-device session window, in tokens. This is not a knob we send to
+# the model — the OS owns the session — it only sizes OUR prompt budgets
+# (resolve_num_ctx -> corpus/chunk/snapshot budgets in src.summarizer).
+#
+# Measured on this class of machine (AFM 3 Core Advanced, macOS 27) by feeding
+# needle-in-filler prompts of increasing size straight at the sidecar: clean
+# answers through ~37.9k chars, hard refusal from ~40.0k. At the repo's 3.5
+# chars/token English assumption that cliff is ~11k tokens, so an 8k window is
+# the honest figure and leaves the derived budgets (largest: ~15.8k chars for
+# the chat corpus) well under half the measured ceiling. It was 4096, which
+# silently halved every Apple budget.
+APPLE_LM_NUM_CTX = 8192
 
 _DISABLE_ENV = "STENOAI_DISABLE_APPLE_LM"
 _BIN_ENV = "STENOAI_APPLE_LM_BIN"

--- a/src/config.py
+++ b/src/config.py
@@ -359,6 +359,7 @@ class Config:
         self._migrate_cloud_model_map()
         self._migrate_whisper_model()
         self._migrate_summary_model()
+        self._adopt_apple_system_default()
         self._migrate_transcription_engine()
         self._migrate_language_zh()
         self._migrate_privacy_notice_seen()
@@ -599,6 +600,34 @@ class Config:
         elif current in self._RETIRED_SUMMARY_MODELS:
             self._config["model"] = self.DEFAULT_MODEL
             self._save()
+
+
+    def _adopt_apple_system_default(self) -> None:
+        """On Darwin, adopt Apple System Language Model when available and unset/auto."""
+        if self._load_failed:
+            return
+        if self.get_ai_provider() != "local":
+            return
+        source = self._config.get("summary_model_source")
+        current = self._config.get("model", self.DEFAULT_MODEL)
+        from src.apple_lm import (
+            APPLE_SYSTEM_MODEL,
+            apple_lm_available,
+        )
+
+        if source is None:
+            source = (
+                "auto"
+                if current in (self.DEFAULT_MODEL, APPLE_SYSTEM_MODEL)
+                else "user"
+            )
+            self._config["summary_model_source"] = source
+
+        if source == "auto":
+            target = APPLE_SYSTEM_MODEL if apple_lm_available() else self.DEFAULT_MODEL
+            if current != target:
+                self._config["model"] = target
+                self._save()
 
     def _migrate_cloud_model_map(self) -> None:
         """One-shot migration from legacy single 'cloud_model' to per-provider
@@ -853,8 +882,10 @@ class Config:
 
     def _get_default_config(self) -> Dict[str, Any]:
         """Get default configuration."""
+        from src.apple_lm import resolve_default_summary_model
         return {
-            "model": self.DEFAULT_MODEL,
+            "model": resolve_default_summary_model(),
+            "summary_model_source": "auto",
             "notifications_enabled": True,
             # Default ON — the calendar-based pre-meeting heads-up, independent
             # of notifications_enabled (which now only covers note-ready/
@@ -972,21 +1003,24 @@ class Config:
         """Get the configured model name."""
         return self._config.get("model", self.DEFAULT_MODEL)
 
-    def set_model(self, model_name: str) -> bool:
+    def set_model(self, model_name: str, *, source: str = "user") -> bool:
         """
         Set the model to use for summarization.
 
         Args:
-            model_name: Name of the model (e.g., "llama3.1:8b")
+            model_name: Name of the model (e.g., "llama3.1:8b" or "apple:system")
+            source: "user" (explicit user pick) or "auto" (implicit/system default resolution)
 
         Returns:
             True if saved successfully, False otherwise
         """
         # Validate model name
-        if model_name not in self.SUPPORTED_MODELS:
+        from src.apple_lm import is_apple_system_model
+        if model_name not in self.SUPPORTED_MODELS and not is_apple_system_model(model_name):
             logger.warning(f"Model {model_name} not in supported list, but allowing anyway")
 
         self._config["model"] = model_name
+        self._config["summary_model_source"] = source
         return self._save()
 
     # --- Report templates ---------------------------------------------------
@@ -1780,8 +1814,10 @@ class Config:
         Returns:
             Dictionary with model metadata or None if not found
         """
+        from src.apple_lm import is_apple_system_model, apple_system_model_info
+        if is_apple_system_model(model_name):
+            return apple_system_model_info(is_default=self.get_model() == model_name)
         return self.SUPPORTED_MODELS.get(model_name)
-
     def list_supported_models(self) -> Dict[str, Dict[str, str]]:
         """Get all supported models with their metadata."""
         return self.SUPPORTED_MODELS.copy()

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -1911,10 +1911,11 @@ TITLE:"""
             query_lang_instruction = ""
         return f"""Answer the following question based on the meeting content below (summary, key topics, and transcript).
 Be concise and direct. If the answer requires inference from what was discussed, that's fine.
-Only say you don't know if the topic truly wasn't discussed at all.{query_lang_instruction}
+If the transcript below contains no speech, reply that there is no meeting content yet.{query_lang_instruction}
 
 QUESTION: {question}
 
+TRANSCRIPT:
 {transcript}
 
 ANSWER:"""

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -112,6 +112,14 @@ CHARS_PER_TOKEN = 4               # English baseline; used for the reduce-fits s
 _CHUNK_SAFETY_CHARS_PER_TOKEN = 2 # used for chunk budget: worst-case German/BPE (2.0 c/t floor)
 _OVERLAP_RATIO = 0.05             # last 5% of previous chunk prepended to next
 
+# Apple 4k path. Advanced accepted an image Attachment (2026-08-25 probe) but
+# returned 2 chars and missed the needle — do not rasterize. Carry a bounded
+# text snapshot; keep the newest slice verbatim. Map-reduce forgets reversals
+# and dies at hierarchical depth 2 on this window.
+_SNAPSHOT_MAX_CHARS = 2800
+_SNAPSHOT_PROMPT_OVERHEAD_CHARS = 900
+_SNAPSHOT_HEAD_RATIO = 0.6
+
 
 def resolve_num_ctx(model_name: str) -> int:
     """Context window (num_ctx) to request from Ollama for ``model_name``.
@@ -301,9 +309,10 @@ class OllamaSummarizer:
         content_tokens = num_ctx - MAP_PROMPT_OVERHEAD_TOKENS - MAP_OUTPUT_MAX_TOKENS
         return int(content_tokens * _CHUNK_SAFETY_CHARS_PER_TOKEN)
 
-    def _split_into_chunks(self, transcript: str) -> list[str]:
+    def _split_into_chunks(self, transcript: str, budget: Optional[int] = None) -> list[str]:
         """Split transcript into overlapping chunks that each fit within the model context."""
-        budget = self._chunk_budget_chars()
+        if budget is None:
+            budget = self._chunk_budget_chars()
         overlap_chars = int(budget * _OVERLAP_RATIO)
         content_budget = budget - overlap_chars
 
@@ -586,6 +595,76 @@ class OllamaSummarizer:
         # STREAM_ERROR instead.
         if not ''.join(streamed_chunks).strip():
             raise ValueError("Reduce step returned empty result")
+
+    def _snapshot_slice_budget_chars(self) -> int:
+        window = resolve_num_ctx(self.model_name) * _CHUNK_SAFETY_CHARS_PER_TOKEN
+        output_reserve = MAP_OUTPUT_MAX_TOKENS * _CHUNK_SAFETY_CHARS_PER_TOKEN
+        budget = window - _SNAPSHOT_MAX_CHARS - _SNAPSHOT_PROMPT_OVERHEAD_CHARS - output_reserve
+        return max(800, budget)
+
+    def _hard_trim_snapshot(self, snapshot: str) -> str:
+        if len(snapshot) <= _SNAPSHOT_MAX_CHARS:
+            return snapshot
+        head = int(_SNAPSHOT_MAX_CHARS * _SNAPSHOT_HEAD_RATIO)
+        tail = _SNAPSHOT_MAX_CHARS - head - 5
+        return snapshot[:head] + "\n...\n" + snapshot[-tail:]
+
+    def _create_snapshot_update_prompt(
+        self, snapshot: str, slice_text: str, chunk_num: int, total_chunks: int
+    ) -> str:
+        current = snapshot.strip() or "(empty)"
+        return (
+            "Maintain a running meeting snapshot. Extract only what is explicitly stated.\n"
+            f"Hard cap: {_SNAPSHOT_MAX_CHARS} characters. Prefer dropping chatter over "
+            "decisions, actions, or reversals. If this slice contradicts the snapshot, "
+            "the slice wins and note the reversal.\n\n"
+            "Emit ONLY the updated snapshot with these headers:\n"
+            "ATTENDEES\nDECISIONS\nACTIONS\nOPEN\nTIMELINE\n\n"
+            f"CURRENT SNAPSHOT:\n{current}\n\n"
+            f"NEW TRANSCRIPT (part {chunk_num} of {total_chunks}):\n{slice_text}"
+        )
+
+    def _complete_snapshot(self, prompt: str) -> str:
+        from src.apple_lm import complete
+
+        text = (complete(prompt) or "").strip()
+        if not text:
+            raise ValueError("Snapshot update returned an empty result")
+        return self._hard_trim_snapshot(text)
+
+    def _snapshot_compact_streaming(
+        self,
+        transcript: str,
+        language: str = "en",
+        notes: str = None,
+        progress_callback=None,
+        template_prompt: Optional[str] = None,
+    ):
+        """Sequential snapshot updates, then one format pass. Apple 4k path."""
+        slices = self._split_into_chunks(transcript, budget=self._snapshot_slice_budget_chars())
+        n = len(slices)
+        snapshot = (notes or "").strip()
+        for i, slice_text in enumerate(slices):
+            if progress_callback:
+                progress_callback(i + 1, n)
+            snapshot = self._complete_snapshot(
+                self._create_snapshot_update_prompt(snapshot, slice_text, i + 1, n)
+            )
+        if progress_callback:
+            progress_callback(n + 1, n)
+        if template_prompt:
+            prompt = self._create_template_report_prompt(
+                snapshot, template_prompt, language, notes=None
+            )
+        else:
+            prompt = self._create_markdown_prompt(snapshot, language, notes=None)
+        yielded = []
+        for chunk in self._stream_direct(prompt):
+            if chunk:
+                yielded.append(chunk)
+                yield chunk
+        if not "".join(yielded).strip():
+            raise ValueError("Snapshot format step returned empty result")
 
     def _repair_json(self, json_text: str) -> Optional[str]:
         """
@@ -1575,7 +1654,15 @@ TRANSCRIPT:
             str: Text chunks as they arrive from the LLM
         """
         transcript = _strip_leading_timestamps(transcript)
-        if template_prompt:
+        if self._using_apple_lm() and self._needs_chunking(transcript, notes):
+            inner = self._snapshot_compact_streaming(
+                transcript, language, notes, progress_callback, template_prompt
+            )
+            empty_message = (
+                "Model returned an empty report" if template_prompt
+                else "Model returned an empty summary"
+            )
+        elif template_prompt:
             # Free-form template report: no chunking/map-reduce (those prompts are
             # summary-schema specific and don't apply here). Stream through the
             # ACTIVE provider — not straight to Ollama, which has no client and

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -112,7 +112,8 @@ CHARS_PER_TOKEN = 4               # English baseline; used for the reduce-fits s
 _CHUNK_SAFETY_CHARS_PER_TOKEN = 2 # used for chunk budget: worst-case German/BPE (2.0 c/t floor)
 _OVERLAP_RATIO = 0.05             # last 5% of previous chunk prepended to next
 
-# Apple 4k path. Advanced accepted an image Attachment (2026-08-25 probe) but
+# Apple on-device path (8k window — see APPLE_LM_NUM_CTX, measured, not
+# assumed). Advanced accepted an image Attachment (2026-08-25 probe) but
 # returned 2 chars and missed the needle — do not rasterize. Carry a bounded
 # text snapshot; keep the newest slice verbatim. Map-reduce forgets reversals
 # and dies at hierarchical depth 2 on this window.
@@ -640,7 +641,7 @@ class OllamaSummarizer:
         progress_callback=None,
         template_prompt: Optional[str] = None,
     ):
-        """Sequential snapshot updates, then one format pass. Apple 4k path."""
+        """Sequential snapshot updates, then one format pass. Apple on-device path."""
         slices = self._split_into_chunks(transcript, budget=self._snapshot_slice_budget_chars())
         n = len(slices)
         snapshot = (notes or "").strip()

--- a/src/summarizer.py
+++ b/src/summarizer.py
@@ -125,6 +125,9 @@ def resolve_num_ctx(model_name: str) -> int:
     canonicalize back to the GGUF id first so both runtime variants share the
     same window.
     """
+    from src.apple_lm import is_apple_system_model, APPLE_LM_NUM_CTX
+    if is_apple_system_model(model_name):
+        return APPLE_LM_NUM_CTX
     model_name = Config._MLX_TO_GGUF.get(model_name, model_name)
     base = _OLLAMA_MODEL_NUM_CTX.get(model_name, OLLAMA_NUM_CTX_DEFAULT)
     return max(OLLAMA_NUM_CTX_FLOOR, min(base, OLLAMA_NUM_CTX_CEILING))
@@ -234,10 +237,7 @@ class OllamaSummarizer:
             logger.info(f"Remote Ollama initialized: host={self.remote_url}, model={self.model_name}")
 
         else:
-            # Local mode: existing behavior
-            if not OLLAMA_AVAILABLE:
-                raise ImportError("Ollama is not installed. Please install ollama-python.")
-
+            # Local mode: existing behavior or Apple SystemLanguageModel
             if model_name is None:
                 try:
                     model_name = config.get_model()
@@ -246,10 +246,28 @@ class OllamaSummarizer:
                     logger.warning(f"Failed to load model from config: {e}, using default")
                     model_name = config.DEFAULT_MODEL
 
-            self.model_name = resolve_runtime_tag(model_name)
-            self._ensure_ollama_ready()
-            self.client = ollama.Client()
-    
+            from src.apple_lm import is_apple_system_model, AppleLMClient, apple_lm_available
+            if is_apple_system_model(model_name) and apple_lm_available():
+                self.model_name = model_name
+                self.client = AppleLMClient()
+                logger.info("Apple System Language Model initialized")
+            else:
+                if is_apple_system_model(model_name):
+                    logger.warning(
+                        "Apple System Language Model configured but not available on this platform/device; falling back to %s",
+                        config.DEFAULT_MODEL,
+                    )
+                    model_name = config.DEFAULT_MODEL
+                if not OLLAMA_AVAILABLE:
+                    raise ImportError("Ollama is not installed. Please install ollama-python.")
+                self.model_name = resolve_runtime_tag(model_name)
+                self._ensure_ollama_ready()
+                self.client = ollama.Client()
+
+    def _using_apple_lm(self) -> bool:
+        """True when local provider is routed through Apple SystemLanguageModel."""
+        from src.apple_lm import is_apple_system_model
+        return self.ai_provider == "local" and is_apple_system_model(self.model_name)
     def _is_ollama_running(self) -> bool:
         """Check if Ollama service is running."""
         return ollama_manager.is_ollama_running()
@@ -744,6 +762,8 @@ class OllamaSummarizer:
     
     def _ensure_ollama_ready(self) -> bool:
         """Ensure Ollama service is running and model is available."""
+        if self._using_apple_lm():
+            return True
         logger.info("Checking Ollama service...")
         
         # Step 1: Check if Ollama is running
@@ -1444,16 +1464,13 @@ TRANSCRIPT:
 
     def _stream_direct(self, prompt: str):
         """Stream a single non-chunked completion for ``prompt`` via local/remote
-        Ollama, yielding content chunks. ``think=False`` so a thinking-capable
-        model emits answer text directly instead of spending tokens reasoning
-        into a separate channel before the first content token (see
-        _summarize_chunk for the full rationale).
-
-        Cloud/adapter providers keep their own inline streaming in
-        ``summarize_transcript_streaming`` and never reach here — this is the
-        minimal extraction of just the local/remote Ollama path, shared by the
-        markdown and free-form template routes.
+        Ollama or Apple Intelligence, yielding content chunks.
         """
+        if self._using_apple_lm():
+            from src.apple_lm import stream_complete
+            yield from stream_complete(prompt)
+            return
+
         if self.ai_provider != "remote":
             self._ensure_ollama_ready()
         # Via _chat_stream_no_think so a remote server that rejects `think`
@@ -1723,6 +1740,9 @@ TITLE:"""
                 response_text = self._adapter_chat(prompt, 30)
             elif self.ai_provider == "cloud":
                 response_text = self._cloud_chat(prompt, 30)
+            elif self._using_apple_lm():
+                from src.apple_lm import complete
+                response_text = complete(prompt, timeout=90).strip()
             else:
                 # HTTP-level timeout must account for model cold-start (~10s Metal init)
                 title_client = ollama.Client(
@@ -1739,7 +1759,6 @@ TITLE:"""
                     options=self._ollama_options(),
                 )
                 response_text = ollama_response['message']['content'].strip()
-
             # Clean up the response. Reasoning models (e.g. deepseek-r1) can
             # ignore the "just the title" instruction and wrap the answer in a
             # <think> block, a "TITLE:" label on its own line, or markdown
@@ -1861,6 +1880,9 @@ ANSWER:"""
                         content = chunk.choices[0].delta.content
                         if content:
                             yield content
+            elif self._using_apple_lm():
+                from src.apple_lm import stream_complete
+                yield from stream_complete(prompt, timeout=300)
             else:
                 if self.ai_provider == "remote":
                     self.client = ollama.Client(host=self.remote_url)
@@ -1908,6 +1930,9 @@ ANSWER:"""
                 response_text = self._adapter_chat(prompt, 120)
             elif self.ai_provider == "cloud":
                 response_text = self._cloud_chat(prompt, 120)
+            elif self._using_apple_lm():
+                from src.apple_lm import complete
+                response_text = complete(prompt, timeout=120)
             else:
                 # Retry logic for Ollama API calls (local or remote)
                 max_retries = 2

--- a/stenoai.spec
+++ b/stenoai.spec
@@ -280,6 +280,13 @@ if os.path.exists(ollama_bin_dir):
                 # resolver probes. The guard above intentionally fails a
                 # macOS build when this required release artifact is absent.
                 binaries.append((filepath, '.'))
+            elif (
+                base == 'steno-apple-lm'
+                and _IS_DARWIN
+            ):
+                # macOS-only Swift SystemLanguageModel sidecar (built by
+                # scripts/build-apple-lm-sidecar.sh).
+                binaries.append((filepath, '.'))
             elif _IS_DARWIN:
                 # COLLECT DATA TOC 3-tuple: (dest_path_including_filename,
                 # abs_src_path, 'DATA'). Everything lives under ollama/,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+
+import os
+
+# Default unit tests to non-Apple path unless explicitly un-disabled by a test.
+os.environ.setdefault("STENOAI_DISABLE_APPLE_LM", "1")

--- a/tests/test_apple_lm.py
+++ b/tests/test_apple_lm.py
@@ -202,6 +202,55 @@ class AppleLMSummarizerIntegrationTests(BaseAppleLMTest):
                 mock_complete.assert_called_once()
                 self.assertEqual(mock_complete.call_args.kwargs.get("timeout"), 90)
 
+    def test_long_transcript_uses_snapshot_compact(self):
+        cfg = mock.Mock()
+        cfg.get_ai_provider.return_value = "local"
+        cfg.get_remote_ollama_url.return_value = None
+        cfg.get_model.return_value = APPLE_SYSTEM_MODEL
+        cfg.get_language_name.return_value = "English"
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            summarizer = OllamaSummarizer(config=cfg)
+        prompts = []
+
+        def fake_complete(prompt, timeout=7200):
+            prompts.append(prompt)
+            return f"SNAPSHOT-{len(prompts)}\nDECISIONS\n- keep going"
+
+        def fake_stream(prompt, timeout=7200):
+            yield "## Summary\nSnapshot formatted."
+
+        transcript = "".join(
+            f"Speaker A: unique-line-{i} was discussed.\n" for i in range(500)
+        )
+        with mock.patch("src.apple_lm.complete", side_effect=fake_complete), \
+             mock.patch("src.apple_lm.stream_complete", side_effect=fake_stream), \
+             mock.patch.object(summarizer, "_map_reduce_streaming") as map_reduce:
+            text = "".join(summarizer.summarize_transcript_streaming(transcript))
+        map_reduce.assert_not_called()
+        self.assertIn("Snapshot formatted.", text)
+        self.assertGreaterEqual(len(prompts), 2)
+        self.assertTrue(all("CURRENT SNAPSHOT" in p for p in prompts))
+        self.assertIn("SNAPSHOT-1", prompts[1])
+        joined = "\n".join(prompts)
+        self.assertIn("unique-line-0", joined)
+        self.assertIn("unique-line-499", joined)
+
+    def test_hard_trim_snapshot_keeps_head_and_tail(self):
+        cfg = mock.Mock()
+        cfg.get_ai_provider.return_value = "local"
+        cfg.get_remote_ollama_url.return_value = None
+        cfg.get_model.return_value = APPLE_SYSTEM_MODEL
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            summarizer = OllamaSummarizer(config=cfg)
+        from src.summarizer import _SNAPSHOT_MAX_CHARS
+        blob = "H" * 2000 + "MID" + "T" * 2000
+        trimmed = summarizer._hard_trim_snapshot(blob)
+        self.assertLessEqual(len(trimmed), _SNAPSHOT_MAX_CHARS)
+        self.assertTrue(trimmed.startswith("H"))
+        self.assertTrue(trimmed.endswith("T"))
+        self.assertIn("...", trimmed)
+
+
 class AppleLMCLITests(BaseAppleLMTest):
     def test_list_models_prepends_apple_system_when_available(self):
         with mock.patch("src.apple_lm.apple_lm_available", return_value=True), \

--- a/tests/test_apple_lm.py
+++ b/tests/test_apple_lm.py
@@ -1,0 +1,275 @@
+"""Unit tests for Apple SystemLanguageModel (Advanced / 3B Core) integration."""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from click.testing import CliRunner
+
+import simple_recorder
+from src.apple_lm import (
+    APPLE_SYSTEM_MODEL,
+    APPLE_LM_NUM_CTX,
+    AppleLMClient,
+    apple_system_model_info,
+    is_apple_system_model,
+    reset_apple_lm_cache,
+    resolve_default_summary_model,
+)
+from src.config import Config
+from src.summarizer import OllamaSummarizer, resolve_num_ctx
+
+
+class BaseAppleLMTest(unittest.TestCase):
+    def setUp(self):
+        reset_apple_lm_cache()
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self._old_user_data = os.environ.get("STENOAI_USER_DATA_DIR")
+        os.environ["STENOAI_USER_DATA_DIR"] = self._tmp_dir.name
+
+    def tearDown(self):
+        reset_apple_lm_cache()
+        if self._old_user_data is not None:
+            os.environ["STENOAI_USER_DATA_DIR"] = self._old_user_data
+        else:
+            os.environ.pop("STENOAI_USER_DATA_DIR", None)
+        self._tmp_dir.cleanup()
+
+
+class AppleLMResolutionTests(BaseAppleLMTest):
+    def test_is_apple_system_model(self):
+        self.assertTrue(is_apple_system_model("apple:system"))
+        self.assertFalse(is_apple_system_model("gemma4:e2b-it-qat"))
+        self.assertFalse(is_apple_system_model(None))
+
+    def test_resolve_default_summary_model_when_available(self):
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            self.assertEqual(resolve_default_summary_model(), APPLE_SYSTEM_MODEL)
+
+    def test_resolve_default_summary_model_when_unavailable(self):
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=False):
+            self.assertEqual(resolve_default_summary_model(), Config.DEFAULT_MODEL)
+
+    def test_resolve_default_summary_model_off_darwin(self):
+        with mock.patch("sys.platform", "win32"), \
+             mock.patch.dict(os.environ, {"STENOAI_DISABLE_APPLE_LM": "0"}):
+            reset_apple_lm_cache()
+            self.assertEqual(resolve_default_summary_model(), Config.DEFAULT_MODEL)
+
+    def test_apple_system_model_info_variant_descriptions(self):
+        with mock.patch("src.apple_lm.apple_lm_status", return_value={"available": True, "variant": "coreAdvanced3", "display_name": "Apple Intelligence"}):
+            info = apple_system_model_info(is_default=True)
+            self.assertIn("Advanced", info["description"])
+            self.assertIn("(default)", info["description"])
+
+        with mock.patch("src.apple_lm.apple_lm_status", return_value={"available": True, "variant": "core3", "display_name": "Apple Intelligence"}):
+            info = apple_system_model_info(is_default=False)
+            self.assertIn("3B Core", info["description"])
+            self.assertNotIn("(default)", info["description"])
+
+
+class AppleLMConfigAdoptionTests(BaseAppleLMTest):
+    def test_fresh_config_adopts_apple_system_when_available(self):
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            cfg_path = Path(self._tmp_dir.name) / "config.json"
+            config = Config(config_path=cfg_path)
+            self.assertEqual(config.get_model(), APPLE_SYSTEM_MODEL)
+            self.assertEqual(config._config.get("summary_model_source"), "auto")
+
+    def test_fresh_config_uses_default_when_apple_unavailable(self):
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=False):
+            cfg_path = Path(self._tmp_dir.name) / "config.json"
+            config = Config(config_path=cfg_path)
+            self.assertEqual(config.get_model(), Config.DEFAULT_MODEL)
+
+    def test_existing_auto_config_upgrades_to_apple_when_it_becomes_available(self):
+        cfg_path = Path(self._tmp_dir.name) / "config.json"
+        cfg_path.write_text(json.dumps({"model": Config.DEFAULT_MODEL, "summary_model_source": "auto"}))
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            config = Config(config_path=cfg_path)
+            self.assertEqual(config.get_model(), APPLE_SYSTEM_MODEL)
+
+    def test_existing_auto_config_falls_back_to_gemma_when_apple_becomes_unavailable(self):
+        cfg_path = Path(self._tmp_dir.name) / "config.json"
+        cfg_path.write_text(json.dumps({"model": APPLE_SYSTEM_MODEL, "summary_model_source": "auto"}))
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=False):
+            config = Config(config_path=cfg_path)
+            self.assertEqual(config.get_model(), Config.DEFAULT_MODEL)
+
+    def test_explicit_user_choice_is_not_overwritten_by_auto_adoption(self):
+        cfg_path = Path(self._tmp_dir.name) / "config.json"
+        cfg_path.write_text(json.dumps({"model": "qwen3.5:9b", "summary_model_source": "user"}))
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            config = Config(config_path=cfg_path)
+            self.assertEqual(config.get_model(), "qwen3.5:9b")
+
+    def test_get_model_info_returns_apple_metadata(self):
+        with mock.patch("src.apple_lm.apple_lm_status", return_value={"available": True, "variant": "coreAdvanced3"}):
+            config = Config(config_path=Path(self._tmp_dir.name) / "config.json")
+            info = config.get_model_info(APPLE_SYSTEM_MODEL)
+            self.assertIsNotNone(info)
+            self.assertEqual(info["name"], "Apple Intelligence")
+            self.assertEqual(info["params"], "3B")
+
+
+class AppleLMSummarizerIntegrationTests(BaseAppleLMTest):
+    def test_resolve_num_ctx_for_apple_system(self):
+        self.assertEqual(resolve_num_ctx(APPLE_SYSTEM_MODEL), APPLE_LM_NUM_CTX)
+
+    def test_summarizer_initializes_apple_client_without_ollama(self):
+        cfg = mock.Mock()
+        cfg.get_ai_provider.return_value = "local"
+        cfg.get_remote_ollama_url.return_value = None
+        cfg.get_model.return_value = APPLE_SYSTEM_MODEL
+
+        with mock.patch("src.summarizer.OLLAMA_AVAILABLE", False), \
+             mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            summarizer = OllamaSummarizer(config=cfg)
+            self.assertTrue(summarizer._using_apple_lm())
+            self.assertIsInstance(summarizer.client, AppleLMClient)
+            self.assertTrue(summarizer._ensure_ollama_ready())
+    def test_apple_lm_client_chat(self):
+        client = AppleLMClient()
+        with mock.patch("src.apple_lm.complete", return_value="Summary of meeting"):
+            res = client.chat(messages=[{"role": "user", "content": "summarize"}])
+            self.assertEqual(res, {"message": {"content": "Summary of meeting"}})
+
+    def test_apple_lm_client_stream(self):
+        client = AppleLMClient()
+        with mock.patch("src.apple_lm.stream_complete", return_value=iter(["Hello", " world"])):
+            stream = client.chat(stream=True, messages=[{"role": "user", "content": "hi"}])
+            chunks = [c["message"]["content"] for c in stream]
+            self.assertEqual(chunks, ["Hello", " world"])
+
+    def test_generate_title_routes_through_apple_lm(self):
+        cfg = mock.Mock()
+        cfg.get_ai_provider.return_value = "local"
+        cfg.get_remote_ollama_url.return_value = None
+        cfg.get_model.return_value = APPLE_SYSTEM_MODEL
+        cfg.get_language_name.return_value = "English"
+
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            summarizer = OllamaSummarizer(config=cfg)
+            with mock.patch("src.apple_lm.complete", return_value="Project Kickoff"):
+                title = summarizer.generate_title("Summary here", "transcript")
+                self.assertEqual(title, "Project Kickoff")
+
+    def test_summarizer_falls_back_when_apple_configured_but_unavailable(self):
+        cfg = mock.Mock()
+        cfg.get_ai_provider.return_value = "local"
+        cfg.get_remote_ollama_url.return_value = None
+        cfg.get_model.return_value = APPLE_SYSTEM_MODEL
+        cfg.DEFAULT_MODEL = "gemma4:e2b-it-qat"
+
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=False), \
+             mock.patch("src.config.is_apple_silicon", return_value=False), \
+             mock.patch.object(OllamaSummarizer, "_ensure_ollama_ready"), \
+             mock.patch("ollama.Client"):
+            summarizer = OllamaSummarizer(config=cfg)
+            self.assertFalse(summarizer._using_apple_lm())
+            self.assertEqual(summarizer.model_name, "gemma4:e2b-it-qat")
+
+    def test_query_transcript_ollama_retry_loop_defines_max_retries(self):
+        cfg = mock.Mock()
+        cfg.get_ai_provider.return_value = "local"
+        cfg.get_remote_ollama_url.return_value = None
+        cfg.get_model.return_value = "gemma4:e2b-it-qat"
+        cfg.DEFAULT_MODEL = "gemma4:e2b-it-qat"
+
+        with mock.patch.object(OllamaSummarizer, "_ensure_ollama_ready"), \
+             mock.patch("ollama.Client"):
+            summarizer = OllamaSummarizer(config=cfg)
+            summarizer.client = mock.MagicMock()
+            summarizer.client.chat.return_value = {"message": {"content": "Answer here"}}
+            res = summarizer.query_transcript("Transcript", "Question?")
+            self.assertEqual(res, "Answer here")
+            summarizer.client.chat.assert_called_once()
+
+    def test_generate_title_passes_timeout_to_complete(self):
+        cfg = mock.Mock()
+        cfg.get_ai_provider.return_value = "local"
+        cfg.get_remote_ollama_url.return_value = None
+        cfg.get_model.return_value = APPLE_SYSTEM_MODEL
+        cfg.get_language_name.return_value = "English"
+
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            summarizer = OllamaSummarizer(config=cfg)
+            with mock.patch("src.apple_lm.complete", return_value="Project Title") as mock_complete:
+                title = summarizer.generate_title("Summary here", "transcript")
+                self.assertEqual(title, "Project Title")
+                mock_complete.assert_called_once()
+                self.assertEqual(mock_complete.call_args.kwargs.get("timeout"), 90)
+
+class AppleLMCLITests(BaseAppleLMTest):
+    def test_list_models_prepends_apple_system_when_available(self):
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True), \
+             mock.patch("src.config.Config.get_model", return_value=APPLE_SYSTEM_MODEL):
+            runner = CliRunner()
+            result = runner.invoke(simple_recorder.list_models)
+            self.assertEqual(result.exit_code, 0)
+            data = json.loads(result.output)
+            self.assertIn(APPLE_SYSTEM_MODEL, data["supported_models"])
+            self.assertTrue(data["supported_models"][APPLE_SYSTEM_MODEL]["installed"])
+
+    def test_list_models_shows_apple_system_not_installed_when_unavailable(self):
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=False), \
+             mock.patch("src.config.Config.get_model", return_value=APPLE_SYSTEM_MODEL):
+            runner = CliRunner()
+            result = runner.invoke(simple_recorder.list_models)
+            self.assertEqual(result.exit_code, 0)
+            data = json.loads(result.output)
+            self.assertIn(APPLE_SYSTEM_MODEL, data["supported_models"])
+            self.assertFalse(data["supported_models"][APPLE_SYSTEM_MODEL]["installed"])
+
+    def test_check_model_for_apple_system(self):
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            runner = CliRunner()
+            result = runner.invoke(simple_recorder.check_model, [APPLE_SYSTEM_MODEL])
+            self.assertEqual(result.exit_code, 0)
+            data = json.loads(result.output)
+            self.assertTrue(data["installed"])
+
+    def test_pull_model_for_apple_system_succeeds_when_available(self):
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            runner = CliRunner()
+            result = runner.invoke(simple_recorder.pull_model, [APPLE_SYSTEM_MODEL])
+            self.assertEqual(result.exit_code, 0)
+            data = json.loads(result.output)
+            self.assertTrue(data["success"])
+
+    def test_delete_model_refuses_apple_system(self):
+        runner = CliRunner()
+        result = runner.invoke(simple_recorder.delete_model, [APPLE_SYSTEM_MODEL])
+        self.assertEqual(result.exit_code, 0)
+        data = json.loads(result.output)
+        self.assertFalse(data["success"])
+        self.assertIn("Cannot delete", data["error"])
+
+    def test_resolve_setup_model_returns_apple_system_when_available(self):
+        with mock.patch("src.apple_lm.apple_lm_available", return_value=True):
+            runner = CliRunner()
+            result = runner.invoke(simple_recorder.resolve_setup_model)
+            self.assertEqual(result.exit_code, 0)
+            data = json.loads(result.output)
+            self.assertEqual(data["installed"], APPLE_SYSTEM_MODEL)
+            self.assertIsNone(data["pull_target"])
+
+    def test_setup_check_reports_apple_system_model(self):
+        with mock.patch("sys.platform", "darwin"), \
+             mock.patch("src.apple_lm.apple_lm_available", return_value=True), \
+             mock.patch("src.apple_lm.apple_lm_status", return_value={"available": True, "variant": "coreAdvanced3"}):
+            runner = CliRunner()
+            result = runner.invoke(simple_recorder.setup_check, ["--json"])
+            self.assertEqual(result.exit_code, 0)
+            lines = [l for l in result.output.splitlines() if l.strip().startswith("{")]
+            data = json.loads(lines[0])
+            llm_check = next((c for c in data["checks"] if c["name"] == "llm-model"), None)
+            self.assertIsNotNone(llm_check)
+            self.assertEqual(llm_check["status"], "pass")
+            self.assertIn("Apple System Language Model (coreAdvanced3)", llm_check["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chat_corpus_budget.py
+++ b/tests/test_chat_corpus_budget.py
@@ -44,3 +44,50 @@ class ChatCorpusBudgetTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AppleWindowMeasuredCeilingTests(unittest.TestCase):
+    """Pins the Apple on-device window against what the hardware actually does.
+
+    APPLE_LM_NUM_CTX only sizes OUR prompt budgets, so nothing fails loudly if
+    it drifts — it shipped at 4096, which silently halved every Apple budget and
+    no test noticed, because every other test derives from the constant instead
+    of pinning it.
+
+    The numbers below come from feeding needle-in-filler prompts straight at the
+    sidecar on AFM 3 Core Advanced / macOS 27: clean answers with the needle
+    recovered through ~37.9k chars, hard refusal from ~40.0k. These assertions
+    encode both halves of that: the window must not shrink back, and the largest
+    derived budget must stay well under the measured cliff.
+    """
+
+    MEASURED_CLIFF_CHARS = 40_000
+    MEASURED_LAST_GOOD_CHARS = 37_900
+
+    def test_window_is_the_measured_8k_not_the_old_4k(self):
+        from src.apple_lm import APPLE_LM_NUM_CTX
+
+        self.assertEqual(APPLE_LM_NUM_CTX, 8192)
+        self.assertEqual(resolve_num_ctx("apple:system"), 8192)
+
+    def test_apple_corpus_budget_is_bigger_than_the_old_4k_figure(self):
+        budget = _chat_corpus_char_budget("local", "apple:system")
+        # The 4096 window produced 7884 chars; anything at or below that means
+        # the regression is back.
+        self.assertGreater(budget, 7884 * 1.5)
+
+    def test_apple_budget_stays_under_the_measured_cliff(self):
+        budget = _chat_corpus_char_budget("local", "apple:system")
+        # Half the last-known-good size is the margin: the prompt also carries
+        # scaffolding, the question, and the model's own answer.
+        self.assertLess(budget, self.MEASURED_LAST_GOOD_CHARS / 2)
+        self.assertLess(budget, self.MEASURED_CLIFF_CHARS)
+
+    def test_apple_snapshot_slice_budget_grew_with_the_window(self):
+        from src.summarizer import OllamaSummarizer
+
+        s = OllamaSummarizer.__new__(OllamaSummarizer)
+        s.model_name = "apple:system"
+        # The 4096 window produced 3292 chars per slice.
+        self.assertGreater(s._snapshot_slice_budget_chars(), 3292 * 2)
+


### PR DESCRIPTION
## Description

On Darwin, local summarization now prefers Apple's on-device
`SystemLanguageModel.default` (`apple:system`) whenever the sidecar reports
it available. The public FoundationModels API has no `init(variant:)` —
the OS serves **Advanced** when the Mac has it and otherwise **3B Core**.
If the sidecar is missing or reports unavailable, the existing Ollama
default (`gemma4:e2b-it-qat`) is unchanged.

Explicit user model picks (`summary_model_source: "user"`) are left alone.
Windows/Linux never resolve the sidecar.

The Swift helper (`apple-lm-sidecar/` → `bin/steno-apple-lm`) follows the
existing `steno-diarize` pattern: Python talks to it over stdin/stdout
(`status` / `complete` / `stream`). Prompts are not placed on argv; error
payloads are fixed strings. Analytics only allowlists the id `apple:system`.

First-run setup (`setup-ollama-and-model` / `resolve-setup-model`) adopts
`apple:system` and skips the Ollama pull when Apple Intelligence is ready.
`set-model apple:system` is persist-and-check, same as the existing-model
path — a failed write is returned as an error, not as setup success.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## Selection contract

```
unset / auto default:
  apple-lm available → apple:system   (Advanced, else 3B Core)
  else               → gemma4:e2b-it-qat
explicit saved model id → keep
Windows / non-local provider → no Foundation Models path
```

## Testing

- [x] `./venv/bin/python -m unittest tests.test_apple_lm` (22 tests)
- [x] T2 `apple-lm-default` (model-free mock sidecar) — passed with
      `ELECTRON_EXTRA_LAUNCH_ARGS="--no-sandbox --disable-gpu"`
- [x] macOS-only; Windows path is the existing Ollama default
- [x] No meeting text in analytics; `apple:system` is allowlisted

## Release packaging

`stenoai.spec` bundles `bin/steno-apple-lm` only when that file exists.
`scripts/build-backend.sh` tries to build it and **warns** (does not fail)
if the host lacks the macOS 26+ SDK.

The current `build-macos` job still runs on `macos-14`, which cannot
compile `FoundationModels`. A notarized DMG from that runner will keep
using Ollama until the sidecar is produced on a macOS 26+ image. The
release runner is left unchanged on purpose.

Variant inspection (`coreAdvanced3` / `core3`) is compiled behind
`#available(macOS 27.0, *)`. A binary built with the macOS 26 SDK still
runs; it just reports the model as 3B Core / Apple Intelligence.

## Additional Notes

- Model id: `apple:system`. UI label: `Apple Intelligence`.
- Test isolation: `STENOAI_DISABLE_APPLE_LM=1` (set by default in
  `tests/__init__.py` and the T2 Electron fixture). Override with
  `STENOAI_APPLE_LM_BIN` for a fake sidecar.
- Independent of the Apple SpeechTranscriber stack (#491 / #492).
- `verify-model apple:system` is a live sidecar `complete("hi")`, not a no-op.
