### PR TITLE
fix(macos): declare NSLocalNetworkUsageDescription so LAN Ollama works on macOS 15+

### DIFF
--- a/app/electron-builder.ci.yml
+++ b/app/electron-builder.ci.yml
@@ -1,6 +1,10 @@
 # electron-builder config for CI dry-runs (pack:unsigned).
 #
-# Inherits the base "build" config from package.json, but strips:
+# This is a standalone config, NOT an override on top of the "build" config in
+# package.json — electron-builder treats a --config file as the whole config
+# unless it declares "extends", and this file does not (see #438). Anything
+# from package.json that has to reach the CI-built Info.plist must be repeated
+# here. Compared to a release build it deliberately leaves out:
 #   - extraResources (../dist/stenoai is not built in CI — no PyInstaller)
 #   - afterSign hook (no notarization in unsigned packs)
 #   - DMG signing (no cert in CI)
@@ -22,3 +26,6 @@ dmg:
 mac:
   identity: null
   notarize: false
+  # Keep in sync with build.mac.extendInfo in package.json.
+  extendInfo:
+    NSLocalNetworkUsageDescription: "Steno needs local network access to reach Ollama or other AI services you host on your own network."

--- a/app/local-network-usage.test.js
+++ b/app/local-network-usage.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// #499: macOS 15+ blocks outbound connections to local-network addresses
+// unless the app declares NSLocalNetworkUsageDescription in its Info.plist.
+// Without it, pointing the Ollama server URL (or any other user-supplied host
+// setting) at a LAN address fails with a generic connection error.
+//
+// The key has to be in BOTH configs: electron-builder.ci.yml is a standalone
+// config, not an override on top of package.json (see #438), so a key added
+// only to package.json never reaches a CI-built Info.plist.
+//
+// A Playwright e2e spec cannot cover this — it drives a dev-mode Electron
+// process, not a packaged bundle — so this test guards the configs instead.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const KEY = 'NSLocalNetworkUsageDescription';
+
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8')
+);
+const ciYml = fs.readFileSync(
+  path.join(__dirname, 'electron-builder.ci.yml'),
+  'utf8'
+);
+
+// Minimal reader for `mac: > extendInfo: > <key>: "<value>"` in the CI yml.
+// Deliberately dependency-free: js-yaml is only a transitive dependency here.
+function readCiExtendInfo(key) {
+  const lines = ciYml.split('\n');
+  const macAt = lines.findIndex((l) => l === 'mac:');
+  assert.notStrictEqual(macAt, -1, 'electron-builder.ci.yml has no mac: block');
+
+  let inExtendInfo = false;
+  for (const line of lines.slice(macAt + 1)) {
+    if (line.trim() === '' || line.trim().startsWith('#')) continue;
+    // Any non-indented line ends the mac: block.
+    if (!/^\s/.test(line)) break;
+    if (/^ {2}extendInfo:\s*$/.test(line)) {
+      inExtendInfo = true;
+      continue;
+    }
+    if (inExtendInfo && !/^ {4}/.test(line)) inExtendInfo = false;
+    if (!inExtendInfo) continue;
+    const m = line.match(/^ {4}([A-Za-z0-9_]+):\s*"(.*)"\s*$/);
+    if (m && m[1] === key) {
+      // This reader does not decode YAML escapes, so a value containing one
+      // would be compared wrongly. Fail loudly instead of silently.
+      assert.ok(
+        !m[2].includes('\\'),
+        `${key} contains a YAML escape; this reader cannot decode it`
+      );
+      return m[2];
+    }
+  }
+  return undefined;
+}
+
+test('package.json declares NSLocalNetworkUsageDescription for macOS', () => {
+  const extendInfo = pkg.build.mac.extendInfo;
+  assert.ok(extendInfo, 'build.mac.extendInfo is missing');
+  assert.strictEqual(typeof extendInfo[KEY], 'string');
+  assert.ok(extendInfo[KEY].length > 0, `${KEY} must not be empty`);
+});
+
+test('electron-builder.ci.yml declares it too (it does not inherit, see #438)', () => {
+  const value = readCiExtendInfo(KEY);
+  assert.ok(value, `${KEY} missing from the mac.extendInfo block of the CI config`);
+});
+
+test('both configs use the same wording', () => {
+  assert.strictEqual(readCiExtendInfo(KEY), pkg.build.mac.extendInfo[KEY]);
+});

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "typecheck:renderer": "tsc -p renderer/tsconfig.json --noEmit",
     "lint:renderer": "eslint --config renderer/eslint.config.mjs renderer/src",
     "format:renderer": "prettier --write renderer/src",
-    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js person-sample-ipc.test.js speaker-ipc.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js settings-ipc.test.js regen-title-busy-guard.test.js update-idle-gate.test.js update-os-gate.test.js update-error-copy.test.js notification-copy.test.js obsidian-sync.test.js e2e-window-visibility.test.js && vitest run",
+    "test:unit": "node --test processing-log.test.js meeting-detect.test.js notes-file.test.js backend-stream.test.js ipc-contract.test.js person-sample-ipc.test.js speaker-ipc.test.js shortcut-url.test.js setup-check-parse.test.js diagnostics-forward.test.js analytics-helpers.test.js live-snapshot-sweep.test.js backend-cli.test.js debug-log.test.js teardown.test.js folders-ipc.test.js settings-ipc.test.js regen-title-busy-guard.test.js update-idle-gate.test.js update-os-gate.test.js local-network-usage.test.js update-error-copy.test.js notification-copy.test.js obsidian-sync.test.js e2e-window-visibility.test.js && vitest run",
     "build": "npm run build:renderer && electron-builder",
     "pack:unsigned": "npm run build:renderer && electron-builder --dir --config electron-builder.ci.yml",
     "build-mac": "npm run build:renderer && electron-builder --mac",
@@ -166,6 +166,7 @@
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Steno needs microphone access to record and transcribe meetings.",
         "NSAudioCaptureUsageDescription": "Steno needs audio capture access to record system audio from virtual meetings.",
+        "NSLocalNetworkUsageDescription": "Steno needs local network access to reach Ollama or other AI services you host on your own network.",
         "LSMinimumSystemVersion": "14.4.0"
       }
     },


### PR DESCRIPTION
Fixes #499.

## The failure

Point **Ollama server URL** at another machine on the LAN (`http://192.168.x.x:11434`) and **Test connection** fails on macOS 15+ with:

> Failed to connect to Ollama. Please check that Ollama is downloaded, running and accessible. https://ollama.com/download

Nothing is wrong with the server or with our code. Since macOS 15 (Sequoia), an outbound connection to a local-network address needs the user's consent, and the system only presents that prompt for an app that declares `NSLocalNetworkUsageDescription` in its `Info.plist`. Steno declared `NSMicrophoneUsageDescription` and `NSAudioCaptureUsageDescription`, but not this one, so the connection was simply dropped.

`127.0.0.1` is unaffected — loopback is not "local network" — which is why the default local-Ollama setup has always worked and this went unnoticed.

The message the user sees is `CONNECTION_ERROR_MESSAGE` from the `ollama` Python client, raised on `httpx.ConnectError`. It points at a download page, so it actively misleads: the server is running and reachable, the app just is not allowed to talk to it.

Reproduction that isolates the cause — the same bundled binary, invoked two ways:

```
# From Terminal (Terminal holds the permission) — works
$ /Applications/Steno.app/Contents/Resources/stenoai/stenoai test-remote-ollama http://<lan-ip>:11434
{"success": true, "models": ["...", "..."]}

# Same command spawned by the app via Test connection — fails
```

## The change

One key, in both build configs:

```
NSLocalNetworkUsageDescription:
  "Steno needs local network access to reach Ollama or other AI services you host on your own network."
```

**Why both files.** `app/electron-builder.ci.yml` is a standalone config, not an override on top of `package.json` — electron-builder treats a `--config` file as the whole config unless it declares `extends`, and this file does not (#438). A key added only to `package.json` would be missing from every CI-built artifact. Verified rather than assumed, by packing the same commit both ways:

| | CI config (`pack:unsigned`) | package.json config |
|---|---|---|
| bundle | `stenoai.app` | `Steno.app` |
| `CFBundleIdentifier` | `com.electron.stenoai` | `com.stenoai.recorder` |
| `LSMinimumSystemVersion` | `12.0` (Electron default) | `14.4.0` |
| `NSMicrophoneUsageDescription` | `This app needs access to the microphone` (electron-builder default) | ours |

Nothing from `package.json` reaches the CI build. The file's header comment claimed the opposite, so this PR corrects that one paragraph too — otherwise the next reader deletes the duplicate as redundant.

**Wording is deliberately not Ollama-only.** Three settings let a user type a host that can resolve to the LAN, and this single Info.plist key covers all of them:

- `remote_ollama_url` — "Ollama server URL" (placeholder is literally `http://192.168.1.100:11434`)
- `cloud_api_url` — the OpenAI-compatible "API base URL", i.e. self-hosted vLLM / LM Studio / LiteLLM
- the org adapter URL — self-hosted enterprise adapter, default `http://localhost:8000`, on-prem deployments use an internal address

(`bedrock_region` is regex-constrained to AWS region codes and cannot be pointed at a private address.) No code touched for any of them — the key is all that was missing.

## Verification

`app/build/entitlements.mac.plist` already grants `com.apple.security.network.client`, so no entitlements change is needed, and signing/notarisation is untouched.

Both build paths produce the key. Unsigned pack via the CI config:

```
$ npm run pack:unsigned
$ /usr/libexec/PlistBuddy -c "Print :NSLocalNetworkUsageDescription" \
    app/dist/mac-arm64/stenoai.app/Contents/Info.plist
Steno needs local network access to reach Ollama or other AI services you host on your own network.
```

And the release config (`electron-builder --dir` with only `mac.identity`/`mac.notarize` overridden, since there is no signing identity here — `extendInfo` untouched):

```
$ /usr/libexec/PlistBuddy -c "Print :NSLocalNetworkUsageDescription" \
    app/dist/mac-arm64/Steno.app/Contents/Info.plist
Steno needs local network access to reach Ollama or other AI services you host on your own network.
```

`npm run test:unit` (node lane): 338 tests, 338 pass, 0 fail.

**Not verified here:** the end-user behaviour — that macOS now shows the consent prompt and the LAN connection succeeds. That needs a signed build. Local-network permission binds to the app's *code identity*, and an ad-hoc-signed local build gets a new identity on every rebuild, so a previously granted permission silently stops applying while the toggle in System Settings still reads as enabled. Whoever verifies this should use a signed build, or `tccutil reset LocalNetwork com.stenoai.recorder` between attempts.

## No e2e spec

The repo's standing rule asks for an e2e spec with every user-facing change. It does not apply here: Playwright drives a dev-mode Electron process, not a packaged bundle, so no spec can observe an `Info.plist` key — and the permission itself is a system prompt outside the app. Instead there is a cheap unit-level guard, `app/local-network-usage.test.js`, which reads both config files and asserts the key is present in each and that the two strings match. It fails when the key is removed from either side (checked by removing it).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS 15+ failure where pointing the Ollama server URL at a LAN address (e.g. `http://192.168.x.x:11434`) was silently dropped because the app never declared `NSLocalNetworkUsageDescription`. Loopback (`127.0.0.1`) was unaffected, so the default local setup kept working.

- Adds the `NSLocalNetworkUsageDescription` key to both build configs, since `electron-builder.ci.yml` is standalone and doesn't inherit from `package.json` (#438).
- The same key covers the OpenAI-compatible API base URL and the self-hosted org adapter URL too, not just the Ollama URL.
- Corrects the CI config header comment, which wrongly claimed it inherits the `package.json` build config.
- Adds `local-network-usage.test.js` to fail the unit run if the key is missing from either config or the two strings drift apart.
- No entitlements changes needed — `com.apple.security.network.client` is already granted; end-user verification requires a signed build, since the permission binds to code identity.

<sup>Written for commit 47c91eac29e4650929ede673d32adf52a5b8986c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

