### PR TITLE
Add FaceTime/Phone.app avconferenced to meeting detect allowlist

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -6810,8 +6810,10 @@ const MIC_MONITOR_HEALTHY_RESET_MS = 30_000;
 // Browsers route media capture through helper sub-processes (Safari →
 // com.apple.WebKit.GPU, Chrome → com.google.Chrome.helper, etc.), so the raw
 // app_name reads as "Safari Graphics and Media" / "Google Chrome Helper".
-// Translate those back to the user-recognisable parent app name.
+// FaceTime, Phone.app and Continuity calls use the daemon "avconferenced".
+// Translate both back to the user-recognisable parent app name.
 const APP_NAME_OVERRIDES = [
+  { match: /^com\.apple\.avconferenced/, name: 'Call' },
   { match: /^com\.apple\.WebKit/, name: 'Safari' },
   { match: /^com\.google\.Chrome/, name: 'Google Chrome' },
   { match: /^org\.chromium\./, name: 'Chromium' },

--- a/app/meeting-detect.js
+++ b/app/meeting-detect.js
@@ -9,6 +9,7 @@ const MEETING_APP_ALLOWLIST = [
   /^com\.cisco\.webexmeetingsapp/,     // Cisco Webex
   /^com\.webex\.meetingmanager/,       // Cisco Webex (alt id)
   /^com\.apple\.FaceTime/,             // FaceTime
+  /^com\.apple\.avconferenced/,        // FaceTime / Phone.app / Continuity call audio
   /^com\.hnc\.Discord/,                // Discord
   /^com\.tinyspeck\.slackmacgap/,      // Slack (huddles)
   /^com\.logmein\.GoToMeeting/,        // GoToMeeting

--- a/app/meeting-detect.test.js
+++ b/app/meeting-detect.test.js
@@ -8,6 +8,11 @@ test('isMeetingApp accepts a known meeting app bundle id', () => {
   assert.strictEqual(isMeetingApp({ app_id: 'com.microsoft.teams2' }), true);
 });
 
+test('isMeetingApp accepts the Apple avconferenced daemon bundle id', () => {
+  // FaceTime, Phone.app and Continuity calls open the mic via avconferenced
+  assert.strictEqual(isMeetingApp({ app_id: 'com.apple.avconferenced' }), true);
+});
+
 test('isMeetingApp accepts browser helper-process bundle ids', () => {
   // Chromium browsers capture the mic in a helper process, whose bundle id
   // may differ in case from the main app (Arc: company.thebrowser.Browser


### PR DESCRIPTION
## Description

Meeting autodetect didn’t fire for Facetime.app or Phone.app. Fix that by allowlisting avconferenced.

## Type of Change

- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Tested locally with `npm start`
- [ ] Verified CLI functionality works
- [x] Tested on macOS
- [x] No breaking changes to existing functionality

## Additional Notes

Meeting autodetect puts up a notification if the mic is enabled by an allowlisted process. com.apple.FaceTime is already allowlisted, but FaceTime.app and Phone.app don’t open the microphone themselves. Audio is handled by avconferenced. So meeting autodetect didn’t fire for calls. With this added entry, autodetect works for FaceTime and Phone.

Continuity Camera, SideCar, or Use iPhone as Microphone don’t appear to trigger autodetect.

Tested by patching the released 0.6.7 version of the app on macOS 15.7.7 and 26.6.2.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `avconferenced` to the meeting detect allowlist and maps it to "Call" so FaceTime and Phone calls trigger autodetect. These apps delegate microphone access, so the existing `com.apple.FaceTime` entry wasn't enough. Adds unit test coverage; verified on macOS 15.7.7 and 26.6.2. Continuity Camera and SideCar don't trigger autodetect.

<sup>Written for commit b1a91dab49b271e973c9363017e631cac0f2fcbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

