### PR TITLE
fix(ci): run real-summary nightly on Windows CPU

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -119,13 +119,16 @@ jobs:
   # summarize-contract.t2 can't cover. Heavy + non-deterministic, so it is kept
   # OUT of the per-PR lanes (e2e.yml greps @summarize-real out of the model-free
   # t2 jobs; the @pipeline jobs never select it) and asserts only WEAK
-  # invariants (a non-empty, floored, structurally-parsed summary — never
-  # section-exactness, which a 1B model won't reliably emit). Reuses the macOS
+  # invariants (a non-empty, floored, structurally-parsed summary - never
+  # section-exactness, which a 1B model won't reliably emit). Reuses the Windows
   # backend bundle the suite just built (download-artifact across the
-  # reusable-workflow boundary), same as long-meeting-windows.
-  summarize-real-macos:
-    name: T2 real-summarize (llama3.2:1b, macOS CPU)
-    runs-on: macos-latest
+  # reusable-workflow boundary), same as long-meeting-windows. Run this GGUF
+  # model on Windows CPU: GitHub's headless macOS runner exposes no usable Metal
+  # command queue, while Ollama's universal Darwin llama-server initializes the
+  # Metal backend even for a zero-GPU request and exits 500 before inference.
+  summarize-real-windows:
+    name: T2 real-summarize (llama3.2:1b, Windows CPU)
+    runs-on: windows-latest
     needs: suite
     steps:
       - name: Checkout
@@ -141,19 +144,12 @@ jobs:
       - name: Download backend bundle
         uses: actions/download-artifact@v4
         with:
-          name: e2e-backend-macos
+          name: e2e-backend-windows
           path: dist/stenoai
 
-      # upload-artifact strips the exec bit — restore it or the app can't launch
-      # the bundled launcher / spawn ollama (mirrors t2-pipeline-macos).
-      - name: Restore exec bits on bundled binaries
-        run: |
-          find dist/stenoai -type f \( -name stenoai -o -name ffmpeg -o -name ollama \) \
-            -exec chmod +x {} +
-          test -x dist/stenoai/stenoai
-
       - name: Ensure no stray Ollama
-        run: pkill -f ollama || true
+        shell: pwsh
+        run: Stop-Process -Name ollama -Force -ErrorAction SilentlyContinue
 
       # Cache the pulled model blobs in Ollama's default store (~/.ollama/models)
       # so only the first nightly pays the ~1.3 GB download; later runs restore
@@ -163,7 +159,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ollama/models
-          key: ollama-summary-llama3.2-1b
+          key: ollama-summary-${{ runner.os }}-llama3.2-1b
 
       - name: Install Electron dependencies
         working-directory: app
@@ -179,10 +175,16 @@ jobs:
       # instead of letting the spec silently skip green with zero real-summary
       # coverage — mirrors the whisper/parakeet model guards in e2e.yml.
       - name: Ensure summary model present
+        shell: pwsh
         run: |
-          ./dist/stenoai/stenoai pull-model llama3.2:1b
-          ./dist/stenoai/stenoai verify-model llama3.2:1b \
-            | python3 -c "import sys,json; sys.exit(0 if json.load(sys.stdin).get('success') else 1)"
+          ./dist/stenoai/stenoai.exe pull-model llama3.2:1b
+          $verifyJson = ./dist/stenoai/stenoai.exe verify-model llama3.2:1b
+          $verifyJson | Write-Output
+          $verify = $verifyJson | ConvertFrom-Json
+          if (-not $verify.success) {
+            Write-Error "Summary model verification failed"
+            exit 1
+          }
 
       # Playwright exits 0 when --grep matches no tests. Assert the tagged spec is
       # actually selected so a future rename / dropped @summarize-real tag can't

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -304,7 +304,7 @@ jobs:
 
       # Exclude @pipeline AND @summarize-real — both need a real model and run in
       # their own model-bearing jobs (t2-pipeline-macos / the nightly
-      # summarize-real-macos) so this job stays fast and model-free.
+      # summarize-real-windows) so this job stays fast and model-free.
       - name: Run T2 (org-lock, model-free)
         working-directory: app
         run: npm run test:e2e -- --project=t2 --grep-invert '@pipeline|@summarize-real'

--- a/e2e/specs/summarize-real.t2.spec.ts
+++ b/e2e/specs/summarize-real.t2.spec.ts
@@ -18,7 +18,7 @@ import { readFileSync } from 'fs';
  *   - It is kept OUT of the per-PR lanes: not tagged @pipeline (so the
  *     model-bearing pipeline jobs don't pick it up) and grep-inverted out of the
  *     model-free t2 jobs in e2e.yml. It runs only in the dedicated
- *     e2e-nightly.yml `summarize-real-macos` job.
+ *     e2e-nightly.yml `summarize-real-windows` job.
  *   - It asserts ONLY WEAK INVARIANTS. A 1B model does not reliably emit an
  *     exact section set, so there is NO section-list / exact-heading assertion
  *     and NO content-quality check — only: a summary was written and is


### PR DESCRIPTION
## Summary

- Move the nightly `@summarize-real` smoke from macOS to Windows CPU.
- Reuse the existing `e2e-backend-windows` artifact.
- Keep model verification as a hard failure and key the Ollama cache by runner OS.
- Update stale job references.

## Why

The model downloads successfully on the headless macOS runner, but Ollama's Darwin llama server cannot create a Metal command queue and returns HTTP 500 before inference.
The same failure reproduced locally with bundled Ollama 0.31.1 and upstream 0.31.2 and 0.33.1, including with `num_gpu: 0` and the CPU library forced.

Windows already runs the real Parakeet pipeline on CPU in this workflow and provides the required backend artifact, so it is the model-agnostic runner for this smoke.

## Verification

- Parsed both changed workflow files as YAML.
- `git diff --check`
- Independent Claude review, with its artifact-name and executable-path checks verified against the workflow.

Addresses the permanently red nightly canary noted in #503.
