### PR TITLE
fix(deps): pin mlx, and guard the pin at build time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,21 @@ numpy>=2.0,<3.0
 # x86_64 wheels). Gated to darwin so Windows / Linux installs don't
 # trip a ResolutionImpossible.
 parakeet-mlx>=0.5.0; sys_platform == 'darwin'
+# mlx is PINNED, not floored. parakeet-mlx only asks for `mlx>=0.22.1`, so an
+# unpinned build resolves to whatever PyPI serves that day — and the version
+# decides whether the shipped app works at all. mlx 0.32.x fails inside the
+# PyInstaller bundle with "Failed to load the default metallib": the shader
+# library is present at _internal/mlx/lib/mlx.metallib and is simply not found
+# at load time, which kills Parakeet — the DEFAULT macOS engine. 0.31.2 is the
+# build this app is verified against.
+#
+# Nothing in CI can catch a regression here: GitHub's macOS runners have no
+# Metal device, so the macOS @pipeline job runs whisper and the parakeet jobs
+# are Windows/onnx. scripts/verify_mlx_bundle.py therefore asserts the bundled
+# version matches this pin — provenance, since behaviour can't be tested.
+# Moving the pin means rebuilding the bundle and running `stenoai spike-parakeet`
+# on a real Apple Silicon machine.
+mlx==0.31.2; sys_platform == 'darwin'
 # onnx-asr is the cross-platform Parakeet backend. Used on Windows and
 # Linux where parakeet-mlx can't install. Wraps the istupakov/parakeet-tdt-0.6b-v3-onnx
 # weights (int8 quantised, ~670 MB) via ONNX Runtime CPU; pure Python,

--- a/scripts/verify_mlx_bundle.py
+++ b/scripts/verify_mlx_bundle.py
@@ -225,6 +225,70 @@ def check_dlopen_probes() -> None:
             _ok(f"dlopen: {rel}")
 
 
+_VERSION_H = os.path.join(_INTERNAL, 'mlx', 'include', 'mlx', 'version.h')
+_REQUIREMENTS = os.path.join(_REPO_ROOT, 'requirements.txt')
+_PIN_RE = re.compile(r"^mlx==([0-9][^\s;]*)", re.MULTILINE)
+_VERSION_RE = re.compile(
+    r"#define\s+MLX_VERSION_MAJOR\s+(\d+).*?"
+    r"#define\s+MLX_VERSION_MINOR\s+(\d+).*?"
+    r"#define\s+MLX_VERSION_PATCH\s+(\d+)",
+    re.DOTALL,
+)
+
+
+def check_pinned_version() -> None:
+    """The bundled mlx must be exactly the version requirements.txt pins.
+
+    This is a PROVENANCE check, not a behaviour one, and that distinction is the
+    whole point. Whether mlx works is decided by whether it can load its Metal
+    shader library, and no GitHub runner has a Metal device to find out: the
+    macOS @pipeline job runs whisper, and the parakeet jobs are Windows/onnx.
+    So the bundled mlx build is never actually exercised anywhere in CI.
+
+    What CI *can* do is refuse to ship a version nobody verified. mlx is a
+    transitive dep of parakeet-mlx with only a `>=0.22.1` floor, so before the
+    pin an ordinary rebuild silently upgraded it — that is exactly how 0.32.x,
+    which cannot find its metallib inside the bundle, reached a build and
+    killed Parakeet (the default macOS engine) with no test going red.
+    """
+    if not os.path.exists(_REQUIREMENTS):
+        _fail('pinned-version', f'requirements.txt not found at {_REQUIREMENTS}')
+        return
+    with open(_REQUIREMENTS, encoding='utf-8') as fh:
+        pin_match = _PIN_RE.search(fh.read())
+    if not pin_match:
+        _fail(
+            'pinned-version',
+            'requirements.txt no longer pins mlx (expected a line like '
+            "`mlx==X.Y.Z; sys_platform == 'darwin'`). Without the pin an "
+            'ordinary rebuild can ship an unverified mlx.',
+        )
+        return
+    pinned = pin_match.group(1)
+
+    if not os.path.exists(_VERSION_H):
+        _fail('pinned-version', f'bundled mlx version.h not found at {_VERSION_H}')
+        return
+    with open(_VERSION_H, encoding='utf-8') as fh:
+        ver_match = _VERSION_RE.search(fh.read())
+    if not ver_match:
+        _fail('pinned-version', f'could not parse MLX_VERSION_* from {_VERSION_H}')
+        return
+    bundled = '.'.join(ver_match.groups())
+
+    if bundled != pinned:
+        _fail(
+            'pinned-version',
+            f'bundle ships mlx {bundled} but requirements.txt pins {pinned}. '
+            'Parakeet is the default macOS engine and no CI job can load Metal '
+            'to test it, so an unverified mlx must not ship. Rebuild against '
+            'the pin, or move the pin deliberately after running '
+            '`dist/stenoai/stenoai spike-parakeet` on real Apple Silicon.',
+        )
+        return
+    _ok('pinned-version', f'bundled mlx {bundled} matches the requirements.txt pin')
+
+
 def main() -> int:
     if sys.platform != 'darwin':
         print(f"verify_mlx_bundle: no-op on {sys.platform} (darwin-only check). PASS.")
@@ -238,6 +302,7 @@ def main() -> int:
         )
         return 1
 
+    check_pinned_version()
     check_bit_identity()
     check_layout_contract()
     check_rpath_contract()
@@ -253,7 +318,7 @@ def main() -> int:
     if _failures:
         print(
             f"\nverify_mlx_bundle: FAIL - {len(_failures)} check(s) failed "
-            "(libmlx ABI-collision guard tripped).",
+            "(libmlx ABI-collision / mlx provenance guard tripped).",
             file=sys.stderr,
         )
         return 1

--- a/src/_parakeet_mlx.py
+++ b/src/_parakeet_mlx.py
@@ -145,9 +145,19 @@ def _load_model(model_id: str):
         try:
             from parakeet_mlx import from_pretrained
         except ImportError as e:
+            # Do NOT report this as "not installed" without saying what actually
+            # failed. `import parakeet_mlx` pulls in mlx, which dlopens libmlx
+            # and loads its Metal shader library; when THAT fails the ImportError
+            # lands here too, and a bare "run pip install" message sends the
+            # reader after a package that is already present and correctly
+            # bundled. Carry the real error in the message so the failing layer
+            # is named. (This is not hypothetical: an unpinned mlx upgrade broke
+            # the bundle with "Failed to load the default metallib".)
             raise ImportError(
-                "parakeet-mlx is not installed. Run `pip install parakeet-mlx` "
-                "in the venv (dev) or rebuild the PyInstaller bundle (prod)."
+                f"Could not import parakeet-mlx: {e}. If parakeet-mlx itself is "
+                "missing, run `pip install parakeet-mlx` in the venv (dev) or "
+                "rebuild the PyInstaller bundle (prod); if the message above "
+                "names mlx or its metallib, the bundled mlx build is at fault."
             ) from e
         logger.info("Loading Parakeet model: %s", model_id)
         model = from_pretrained(model_id)

--- a/tests/test_bundle_mlx.py
+++ b/tests/test_bundle_mlx.py
@@ -47,3 +47,89 @@ class BundleMLXCollisionTests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class PinnedMLXVersionTests(unittest.TestCase):
+    """Unit tests for check_pinned_version, the guard that would have caught
+    the unpinned-mlx regression.
+
+    Deliberately NOT artifact-gated like the collision test above: this check is
+    pure text comparison (requirements.txt pin vs the bundled version.h), so it
+    can and should run on every platform in the ordinary `python -m unittest`
+    job, rather than only when a darwin-arm64 bundle happens to exist. The guard
+    exists precisely because no CI job can load Metal to test mlx for real, so
+    its own logic had better be covered.
+    """
+
+    def _module(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location('_verify_mlx_bundle', _SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def _run(self, *, pin: str | None, bundled: str | None):
+        """Drive check_pinned_version against synthetic requirements/version.h."""
+        import tempfile
+        mod = self._module()
+        with tempfile.TemporaryDirectory() as tmp:
+            req = os.path.join(tmp, 'requirements.txt')
+            with open(req, 'w', encoding='utf-8') as fh:
+                fh.write('sounddevice>=0.4.6\n')
+                if pin is not None:
+                    fh.write(f"mlx=={pin}; sys_platform == 'darwin'\n")
+            mod._REQUIREMENTS = req
+
+            if bundled is None:
+                mod._VERSION_H = os.path.join(tmp, 'missing', 'version.h')
+            else:
+                major, minor, patch = bundled.split('.')
+                vh = os.path.join(tmp, 'version.h')
+                with open(vh, 'w', encoding='utf-8') as fh:
+                    fh.write(
+                        f'#define MLX_VERSION_MAJOR {major}\n'
+                        f'#define MLX_VERSION_MINOR {minor}\n'
+                        f'#define MLX_VERSION_PATCH {patch}\n'
+                    )
+                mod._VERSION_H = vh
+
+            mod._failures = []
+            mod._passes = []
+            mod.check_pinned_version()
+            return mod._failures, mod._passes
+
+    def test_matching_version_passes(self):
+        failures, passes = self._run(pin='0.31.2', bundled='0.31.2')
+        self.assertEqual(failures, [])
+        self.assertTrue(any('0.31.2' in p for p in passes))
+
+    def test_drifted_version_fails(self):
+        # The exact regression: an unpinned rebuild picked up 0.32.2.
+        failures, _ = self._run(pin='0.31.2', bundled='0.32.2')
+        self.assertEqual(len(failures), 1)
+        self.assertIn('0.32.2', failures[0])
+        self.assertIn('0.31.2', failures[0])
+
+    def test_removing_the_pin_fails(self):
+        # Deleting the pin must not silently disable the guard.
+        failures, _ = self._run(pin=None, bundled='0.31.2')
+        self.assertEqual(len(failures), 1)
+        self.assertIn('no longer pins mlx', failures[0])
+
+    def test_missing_bundled_version_header_fails(self):
+        failures, _ = self._run(pin='0.31.2', bundled=None)
+        self.assertEqual(len(failures), 1)
+        self.assertIn('version.h', failures[0])
+
+    def test_repo_requirements_actually_pins_mlx(self):
+        """The real requirements.txt must carry the pin -- not a fixture."""
+        import re
+        req = os.path.join(_REPO_ROOT, 'requirements.txt')
+        with open(req, encoding='utf-8') as fh:
+            content = fh.read()
+        self.assertRegex(
+            content,
+            re.compile(r"^mlx==[0-9][^\s;]*", re.MULTILINE),
+            'requirements.txt must pin mlx exactly; a floor lets an unverified '
+            'mlx reach the shipped bundle and break Parakeet.',
+        )

--- a/tests/test_bundle_mlx.py
+++ b/tests/test_bundle_mlx.py
@@ -9,6 +9,8 @@ matching this repo's skip convention for environment-dependent tests - it never
 fails just because the bundle wasn't built.
 """
 
+from __future__ import annotations
+
 import os
 import platform
 import subprocess
@@ -45,8 +47,6 @@ class BundleMLXCollisionTests(unittest.TestCase):
         )
 
 
-if __name__ == '__main__':
-    unittest.main()
 
 
 class PinnedMLXVersionTests(unittest.TestCase):
@@ -133,3 +133,7 @@ class PinnedMLXVersionTests(unittest.TestCase):
             'requirements.txt must pin mlx exactly; a floor lets an unverified '
             'mlx reach the shipped bundle and break Parakeet.',
         )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The bug

`requirements.txt` never pinned `mlx`. It arrives as a transitive dep of `parakeet-mlx`, which floors it at `mlx>=0.22.1`, so every build resolved to whatever PyPI served that day.

**mlx 0.32.x cannot load its Metal shader library inside the PyInstaller bundle** — `Failed to load the default metallib. library not found` — even though the file is present at `_internal/mlx/lib/mlx.metallib`. That kills Parakeet, the default macOS engine.

Same commit, same spec, only the resolved dep differs:

| Bundle | mlx | Parakeet |
|---|---|---|
| built 2 Aug | 0.31.2 | works |
| built from `main` today | **0.32.2** | **dead** |

Verified by rebuilding the *same commit* locally against 0.31.2: `spike-parakeet` transcribes normally.

## Why no test caught it

`parakeet-mlx` is exercised by **no CI job on any platform**:

- macOS `@pipeline` → `STENOAI_E2E_ENGINE: whisper` (GitHub runners have no Metal device)
- Windows `@pipeline` and the T3 nightly → `parakeet`, but that is the **onnx** path — no MLX

So the default engine on the primary platform had zero automated coverage, which is exactly how a floating dep broke it silently.

## What this changes

- **Pin `mlx==0.31.2`** on darwin — the build the app is verified against.
- **`verify_mlx_bundle.py` asserts the bundled version matches the pin**, and fails if the pin is removed. This is a *provenance* check, not a behaviour one — behaviour can't be tested without a Metal device, but CI can refuse to ship a version nobody verified. It already runs in both `e2e.yml` and `build-release.yml`, so it gates the signed build.
- **Fix the misleading error.** `_parakeet_mlx.py` reported *every* `ImportError` as "parakeet-mlx is not installed. Run `pip install parakeet-mlx`". The package was installed and correctly bundled; the real failure was in mlx. The underlying error is now carried in the message.

## Tests

`PinnedMLXVersionTests` covers match, drift (the actual 0.31.2 → 0.32.2 regression), pin removal, and a missing header — deliberately **not** artifact-gated like the existing collision test, so it runs in the ordinary Python job on every platform. Plus an assertion that the real `requirements.txt` carries the pin.

- `python -m unittest discover tests` — 1221 pass
- `ruff check` on changed files — clean (repo baseline of 29 findings unchanged)
- Guard verified both ways: passes on the 0.31.2 bundle, fails on the 0.32.2 one with an actionable message

## Follow-ups (not in scope here)

- **Why** 0.32.x can't find the metallib is unresolved — the pin buys time, it isn't the root fix. Worth an upstream look before moving the pin forward.
- Real runtime coverage for parakeet-mlx needs a self-hosted Apple Silicon runner. Worth its own issue.
- Moving the pin should mean rebuilding and running `stenoai spike-parakeet` on real Apple Silicon.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the default macOS Parakeet engine silently breaking on newer `mlx` builds by pinning `mlx==0.31.2`, the only version verified in the bundle, and adding a build-time guard that refuses any unpinned or mismatched `mlx`. `mlx` previously floated via `parakeet-mlx`'s `>=0.22.1` floor, and 0.32.x can't find its Metal shader library inside the PyInstaller bundle.

**What changed**
- Pins `mlx==0.31.2` for darwin in `requirements.txt` and adds a provenance check to `verify_mlx_bundle.py` that gates the signed build in `e2e.yml` and `build-release.yml`.
- `_parakeet_mlx.py` now surfaces the real `ImportError` instead of always claiming `parakeet-mlx` isn't installed.
- `PinnedMLXVersionTests` covers match, drift, pin removal, and a missing version header; it also runs when the test file is executed directly, and `from __future__ import annotations` keeps it on the Python 3.9 floor.

**Rollout notes**
- No CI job can validate mlx behavior: GitHub runners lack Metal, the macOS `@pipeline` job runs whisper, and the parakeet jobs are Windows/onnx.
- Moving the pin requires rebuilding the bundle and running `stenoai spike-parakeet` on real Apple Silicon.
- The 0.32.x metallib failure is unresolved; the pin buys time, not a permanent fix.

<sup>Written for commit b4f622b6054d3dc75bb2602dae3d3528e48ca831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

