### PR TITLE
docs: v0.7.0 release notes and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,17 @@
 If you're looking for a hosted desktop recording API, consider checking out [Recall.ai](https://www.recall.ai/product/desktop-recording-sdk?utm_source=github&utm_medium=sponsorship&utm_campaign=ruzin-stenoai), an API that records Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
 ## 📢 What's New
-- **2026-08-04** 💎 Sync to Obsidian — mirror your notes into an Obsidian vault folder as Markdown. Turn it on in Settings → Integrations and pick a vault folder. One-way (Steno → vault); notes you edit in Obsidian are never overwritten.
-- **2026-08-03** 🔔 One-tap meeting notes — "Take Notes" starts recording instantly, meetings auto-stop when they end, and a single "Summarise?" tap opens the note and generates it. Recordings are transcript-first now — turn on auto-summarise in Settings → AI for automatic notes.
-- **2026-07-26** 🎙️ System audio without Screen Recording — record both sides of a call with no Screen Recording permission. Now requires macOS 14.4 or later.
-- **2026-07-26** ⬇️ Automatic updates — Steno installs a downloaded update while you're idle and relaunches, never mid-recording. Turn it off in Settings to keep the manual prompt.
+- **2026-08-31** 🗣️ Individual speaker labels — Steno now tells apart the voices sharing one side of a call, so a three-person meeting reads as `Speaker 2` / `Speaker 3` instead of one merged `[Others]`. macOS only.
+- **2026-08-31** 👤 Name a speaker once — confirm who someone is and Steno suggests them in later meetings. Off by default: turn on Speaker identification in Settings → AI, and manage or delete profiles in Settings → People.
+- **2026-08-31** 📄 Readable transcript export — exported transcripts open with a clean conversation view, with the original timestamped transcript kept below it.
+- **2026-08-31** 🇷🇺 Russian — pick Russian in Settings → Transcribe and summaries, titles and chat come back in Russian instead of English.
 
 
 ## Features
 
 - **Privacy-first** — 100% on-device; your recordings, transcripts, and summaries never leave your Mac.
-- **Live speaker labels** — Real-time on-screen text as you speak via Parakeet TDT v3 on Apple Silicon (MLX). Granola-style chat-bubble view with `[You]` vs `[Others]` attribution live during the recording and on the final note.
+- **Live speaker labels** — Real-time on-screen text as you speak via Parakeet TDT v3 on Apple Silicon (MLX). Granola-style chat-bubble view with `[You]` vs `[Others]` attribution live during the recording.
+- **Individual speakers (macOS)** — Once the recording stops, Steno separates the voices sharing each channel, so the saved transcript reads `Speaker 2` / `Speaker 3` rather than one merged `[Others]`. Name a speaker once and Steno can suggest them in later meetings — that part is off by default, and the voice profiles never leave your Mac.
 - **Auto start/stop meetings** — Steno notices when a meeting starts and offers to take notes, then offers to summarise when it ends. Granola-style frictionless capture.
 - **System audio capture** — Record both sides of virtual meetings, headphones on, no extra setup or virtual cable. Native Core Audio Tap on macOS 14.4+, with selectable microphone input.
 - **Recording that coexists** — A compact transcription pill docks beside the app instead of taking over; Stop lands you on the note instantly and you can resume recording into an existing note (it appends and re-generates on demand).

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "AI powered intelligence layer for confidential workflows",
   "main": "main.js",
   "homepage": "https://github.com/stenolabs/stenoai",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,32 @@ title: "Changelog"
 description: "What's new in Steno -- recent releases and notable changes."
 ---
 
+<Update label="v0.7.0" description="August 31, 2026">
+**New**
+- **Individual speaker labels (macOS)** — Steno now separates the voices that share one side of a call. A meeting with several remote participants reads as `Speaker 2`, `Speaker 3`, and so on, instead of collapsing everyone into a single `[Others]`. This runs on-device after the recording stops, and works whether the people are around one microphone or joining remotely.
+- **Speaker identification** — Name a speaker once and Steno suggests that person in later meetings. This is off by default: turn it on under Settings → AI → Speaker identification. It creates a numerical voice profile, so enable it only if you have told the people you record and are authorised to do so. Anonymous per-meeting splitting keeps working with it off.
+- **People management** — Settings → People lists everyone you have named, plays back the voice sample behind each profile, and deletes a person and their profile permanently. Recordings and transcripts are stored separately and are not deleted with a profile.
+- **Review who is who** — When Steno is unsure, a review panel in the note offers excerpts you can play, lets you confirm or rename a speaker, mark a cluster as more than one person, or keep the generic label. It also says what a delete would cost before you confirm it.
+- **FaceTime and Phone calls are detected** — Calls through FaceTime and Phone.app now trigger the meeting prompt like any other call.
+- **Readable transcript export** — Exported transcripts now open with a clean conversation view that merges each speaker's consecutive lines into paragraphs, with the original timestamped transcript kept below it. Falls back to the raw transcript when timestamps aren't usable.
+- **Russian** — Russian can now be selected in Settings → Transcribe, so summaries, titles and chat come back in Russian instead of defaulting to English. Available on both engines, and covered by auto-detect.
+
+**Improved**
+- Diarization is roughly 6.65x faster, using Sortformer's offline chunk preset.
+- Processing shows live per-stage progress while speakers are being worked out, rather than one long opaque step.
+- The Overview now marks which notes still have their original audio, so you can see what can be re-transcribed.
+- Interrupted Parakeet model downloads resume instead of starting over.
+
+**Fixed**
+- macOS no longer shows an unexplained local-network prompt on first launch; Steno now declares why it needs local network access.
+- An interrupted batch transcription now keeps what it managed to transcribe instead of discarding the whole run.
+
+**Known Issues**
+- Speaker separation is macOS-only. Windows keeps the existing `[You]` / `[Others]` channel labels.
+- Speaker accuracy depends on recording quality; overlapping speech and shared microphones are the hardest cases.
+- Selecting Russian pins the language of the summary, title and chat. Transcription accuracy for Russian on the default Parakeet engine has not been measured; switch to Whisper in Settings → AI if the transcript itself is poor.
+</Update>
+
 <Update label="v0.6.7" description="August 4, 2026">
 **Added**
 - **Sync to Obsidian** — mirror your notes into an Obsidian vault folder as Markdown, one file per note with Obsidian-friendly properties, organised into subfolders that mirror your Steno folders. Turn it on in Settings → Integrations and choose a vault folder. One-way (Steno → vault); notes you edit in Obsidian are never overwritten, and renames/deletes are kept in sync.


### PR DESCRIPTION
Release prep for v0.7.0. No code changes — README, changelog, and the version bump only.

## What's shipping

180 commits since v0.6.7 (3 Aug), headlined by **speaker diarization and speaker identification** — roughly 130 of them. That's a minor bump, not a patch.

- Per-channel acoustic diarization via the Swift/CoreML Sortformer sidecar — real `Speaker N` labels instead of collapsing every remote voice into `[Others]`, plus mono-audio diarization and a 6.65x speedup
- Speaker identity: cross-meeting voice profiles, the review panel, People management. `identity_matching_enabled` defaults **false**
- #504 FaceTime/Phone detection, #500 `NSLocalNetworkUsageDescription`, #490 resumable Parakeet downloads
- #508 readable transcript export, #512 Russian, #509 CI lint gates, #514 the mlx pin

## Why the README changed the way it did

`README.md:54` still described attribution as `[You]` vs `[Others]` "on the final note" — that became wrong the moment diarization merged, so it's narrowed to live-during-recording and a new **Individual speakers (macOS)** bullet carries the rest.

The "What's New" marquee is trimmed to the 4 most recent per the rolling-marquee rule, which drops the Obsidian and one-tap entries from 0.6.7.

## Honesty notes in the changelog

Three things are called out under Known Issues rather than left for users to discover:

- Speaker separation is **macOS-only** — Windows gets none of the headline feature, so the notes say so instead of reading as a universal upgrade
- Speaker accuracy degrades on overlapping speech and shared mics
- Selecting Russian pins the *output* language; Parakeet's Russian transcription accuracy is unmeasured (per the discussion on #498), with Whisper named as the fallback

The Speaker identification entry deliberately keeps the in-app copy's framing about informing people and being authorised — it's a biometric opt-in and the changelog shouldn't undercut the settings text.

## Not included

Left for their own releases: #502 (Linux — new platform tier, plus an open question about the loopback toggle), #511 (cloud ASR — introduces a third i18n runtime while #494's direction is unresolved), and the remaining audreyt PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares v0.7.0 for release: bumps `stenoai` to 0.7.0 (minor, not a patch), adds the v0.7.0 changelog entry, and fixes the README's speaker-attribution claim — it still sold `[You]` vs `[Others]` as the final-note attribution, which post-recording diarization made wrong.

**Changelog highlights**
- Headline features are per-channel speaker diarization (~6.65x faster) and speaker identification across meetings, the latter off by default under `identity_matching_enabled`.
- Known Issues flag macOS-only separation, accuracy drops on overlapping speech and shared mics, and Russian pinning the output language with Whisper named as the fallback.
- The README marquee is trimmed to the four most recent entries, dropping the Obsidian and one-tap notes.

<sup>Written for commit c1866987fa29bc8772cf3b24ecfcc4df2a69ca6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

