### PR TITLE
fix: reconcile duplicate speakers across bleed channels

### DIFF
--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -45,6 +45,7 @@ from typing import Callable, Optional, Tuple
 
 from src._heartbeat import _emit_heartbeat
 from src.speaker_suggestions import (
+    SAME_MEETING_MERGE_DISTANCE_THRESHOLD,
     SUGGESTION_MIN_AVG_TURN_SECONDS,
     build_clusters_from_diarization,
     determine_recording_type,
@@ -129,6 +130,14 @@ RMS_MAX_WINDOWS = 60
 # misattribution in _assign_asr_segments_to_diar_segments. Matches the value
 # validated against real meeting audio in the research playground.
 STENO_DIARIZE_MERGE_GAP_S = 0.3
+
+# Cross-channel echo can make the same voice appear in both independent
+# diarization runs. Only merge mutual-nearest embedding pairs that are as
+# tight as the already-validated same-meeting fragment threshold, and whose
+# runner-up is clearly worse. The margin prevents two acoustically similar
+# speakers from being joined merely because both fall below the distance
+# cutoff.
+CROSS_CHANNEL_SPEAKER_MATCH_MARGIN = 0.05
 
 # Floor for the steno-diarize subprocess timeout. Real measured runtime
 # varies a lot with recording length: single-digit-to-tens-of-seconds for
@@ -1427,9 +1436,10 @@ def _resolve_speaker_placeholders(
     channels merged and time-sorted — so a reader sees new speakers
     introduced as 2, 3, 4... regardless of which channel they came from.
 
-    No cross-channel identity matching: a mic placeholder and a system
-    placeholder are always treated as different people — telling them
-    apart would need voiceprint embeddings, out of scope here.
+    Cross-channel echo copies have already been conservatively unified by
+    _reconcile_cross_channel_speakers when embeddings made that possible.
+    Any placeholders still distinct here are intentionally numbered as
+    different people.
 
     `channel` and `raw_diarization_speaker_id` pass through untouched —
     only `label` is ever rewritten here.
@@ -1445,6 +1455,141 @@ def _resolve_speaker_placeholders(
             label = numbering[label]
         resolved.append((start, label, text, channel, raw_sid))
     return resolved
+
+
+def _reconcile_cross_channel_speakers(
+    tagged: list[tuple[float, str, str, str, Optional[str]]],
+    mic_clusters: dict,
+    system_clusters: dict,
+) -> tuple[list[tuple[float, str, str, str, Optional[str]]], dict, dict]:
+    """Collapse unambiguous mic/system copies of the same acoustic speaker.
+
+    Bleed correction removes duplicate ASR segments, but acoustic diarization
+    still runs against each complete channel WAV. With speakers playing aloud,
+    Sortformer can therefore discover the same leaked voice independently in
+    both channels. Without this reconciliation, placeholder resolution turns
+    those channel-local IDs into two visible people and speaker review exposes
+    two rows for one person.
+
+    WeSpeaker centroids from the same recording are safe enough for a narrow,
+    conservative merge: require a mutual-nearest pair at or below the existing
+    same-meeting fragment threshold and a clear runner-up margin on both sides.
+    The channel retaining more post-bleed transcript text is canonical. Alias
+    turns inherit its label and provenance, and the duplicate sidecar cluster
+    is removed. Ambiguous, malformed, or unmatched clusters stay untouched.
+    """
+    if not tagged or not mic_clusters or not system_clusters:
+        return tagged, mic_clusters, system_clusters
+
+    from src.voiceprint import cosine_distance
+
+    distances: dict[tuple[str, str], float] = {}
+    for mic_sid, mic_cluster in mic_clusters.items():
+        mic_embedding = mic_cluster.get("embedding") if isinstance(mic_cluster, dict) else None
+        if not mic_embedding:
+            continue
+        for system_sid, system_cluster in system_clusters.items():
+            system_embedding = (
+                system_cluster.get("embedding") if isinstance(system_cluster, dict) else None
+            )
+            if not system_embedding:
+                continue
+            try:
+                distance = cosine_distance(mic_embedding, system_embedding)
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if math.isfinite(distance):
+                distances[(mic_sid, system_sid)] = distance
+
+    if not distances:
+        return tagged, mic_clusters, system_clusters
+
+    def _confident_nearest(
+        sid: str,
+        *,
+        from_mic: bool,
+    ) -> Optional[tuple[str, float]]:
+        candidates = sorted(
+            (
+                (distance, system_sid if from_mic else mic_sid)
+                for (mic_sid, system_sid), distance in distances.items()
+                if (mic_sid if from_mic else system_sid) == sid
+            ),
+            key=lambda candidate: candidate[0],
+        )
+        if not candidates:
+            return None
+        best_distance, best_sid = candidates[0]
+        if best_distance > SAME_MEETING_MERGE_DISTANCE_THRESHOLD:
+            return None
+        if (
+            len(candidates) > 1
+            and candidates[1][0] - best_distance < CROSS_CHANNEL_SPEAKER_MATCH_MARGIN
+        ):
+            return None
+        return best_sid, best_distance
+
+    matches: list[tuple[str, str, float]] = []
+    for mic_sid in mic_clusters:
+        mic_best = _confident_nearest(mic_sid, from_mic=True)
+        if mic_best is None:
+            continue
+        system_sid, distance = mic_best
+        system_best = _confident_nearest(system_sid, from_mic=False)
+        if system_best is not None and system_best[0] == mic_sid:
+            matches.append((mic_sid, system_sid, distance))
+
+    if not matches:
+        return tagged, mic_clusters, system_clusters
+
+    text_weights: dict[tuple[str, str], int] = {}
+    labels: dict[tuple[str, str], str] = {}
+    for _start, label, text, channel, raw_sid in tagged:
+        if raw_sid is None:
+            continue
+        key = (channel, raw_sid)
+        text_weights[key] = text_weights.get(key, 0) + len((text or "").strip())
+        labels.setdefault(key, label)
+
+    mic_out = dict(mic_clusters)
+    system_out = dict(system_clusters)
+    aliases: dict[tuple[str, str], tuple[str, str, str]] = {}
+    for mic_sid, system_sid, distance in matches:
+        mic_key = ("mic", mic_sid)
+        system_key = ("system", system_sid)
+        mic_weight = text_weights.get(mic_key, 0)
+        system_weight = text_weights.get(system_key, 0)
+        if mic_weight == 0 and system_weight == 0:
+            continue
+
+        if mic_weight >= system_weight:
+            canonical_key, alias_key = mic_key, system_key
+            system_out.pop(system_sid, None)
+        else:
+            canonical_key, alias_key = system_key, mic_key
+            mic_out.pop(mic_sid, None)
+
+        canonical_label = labels.get(canonical_key) or labels.get(alias_key)
+        if canonical_label is None:
+            continue
+        aliases[alias_key] = (*canonical_key, canonical_label)
+        logger.info(
+            "Cross-channel speaker reconciliation: %s/%s -> %s/%s "
+            "(distance=%.3f, retained_chars=%d/%d)",
+            alias_key[0], alias_key[1], canonical_key[0], canonical_key[1],
+            distance, mic_weight, system_weight,
+        )
+
+    if not aliases:
+        return tagged, mic_clusters, system_clusters
+
+    reconciled = []
+    for start, label, text, channel, raw_sid in tagged:
+        canonical = aliases.get((channel, raw_sid)) if raw_sid is not None else None
+        if canonical is not None:
+            channel, raw_sid, label = canonical
+        reconciled.append((start, label, text, channel, raw_sid))
+    return reconciled, mic_out, system_out
 
 
 @dataclass(frozen=True)
@@ -2373,17 +2518,20 @@ class WhisperTranscriber:
                 for start, label, text, raw_sid in _tag_channel_segments(
                     mic_segments, mic_path, duration, "You",
                     allow_self_match=identity_enabled,
-                    clusters_out=mic_clusters if identity_enabled else None,
+                    clusters_out=mic_clusters,
                 )
             )
             tagged.extend(
                 (start, label, text, "system", raw_sid)
                 for start, label, text, raw_sid in _tag_channel_segments(
                     system_segments, system_path, duration, "Others",
-                    clusters_out=system_clusters if identity_enabled else None,
+                    clusters_out=system_clusters,
                 )
             )
             tagged.sort(key=lambda t: t[0])
+            tagged, mic_clusters, system_clusters = _reconcile_cross_channel_speakers(
+                tagged, mic_clusters, system_clusters,
+            )
             tagged = _resolve_speaker_placeholders(tagged)
 
             # Same {"mic"|"system": {"recording_type", "clusters"}} shape
@@ -2395,12 +2543,12 @@ class WhisperTranscriber:
             # non-empty) is included -- a channel that fell back to legacy
             # labeling has no cluster/embedding data to persist.
             speaker_clusters: dict = {}
-            if mic_clusters:
+            if identity_enabled and mic_clusters:
                 speaker_clusters["mic"] = {
                     "recording_type": determine_recording_type("mic", has_audio=True),
                     "clusters": mic_clusters,
                 }
-            if system_clusters:
+            if identity_enabled and system_clusters:
                 speaker_clusters["system"] = {
                     "recording_type": determine_recording_type("system", has_audio=True),
                     "clusters": system_clusters,
@@ -2427,8 +2575,11 @@ class WhisperTranscriber:
                 "engine": engine or self.backend,
                 # {"mic"|"system": {"recording_type", "clusters"}} for
                 # src.speaker_suggestions.write_speakers_sidecar, or {} if
-                # neither channel diarized. See _tag_channel_segments'
-                # clusters_out param.
+            # neither channel diarized. Cross-channel echo aliases were
+            # removed above, so the Speakers panel and exact relabel manifest
+            # share the same canonical cluster ids. See _tag_channel_segments'
+            # clusters_out param. Identity matching off still computes these
+            # transiently for transcript reconciliation, but persists none.
                 "speaker_clusters": speaker_clusters,
                 # list[{"start", "channel", "diarization_speaker_id"}], one
                 # per turn -- see comment above turn_manifest's construction.

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -1562,17 +1562,63 @@ def _reconcile_cross_channel_speakers(
         if mic_weight == 0 and system_weight == 0:
             continue
 
+        mic_label = labels.get(mic_key)
+        system_label = labels.get(system_key)
+        # Merging the two dominant legacy labels would erase a normal 1:1 call
+        # if unrelated centroids happen to fall below the distance threshold.
+        # For all other pairs, post-bleed text remains the best evidence of
+        # which channel contains the direct signal: minority echo clusters may
+        # have been folded into either channel's legacy label.
+        if mic_label == "You" and system_label == "Others":
+            continue
         if mic_weight >= system_weight:
             canonical_key, alias_key = mic_key, system_key
-            system_out.pop(system_sid, None)
         else:
             canonical_key, alias_key = system_key, mic_key
-            mic_out.pop(mic_sid, None)
 
         canonical_label = labels.get(canonical_key) or labels.get(alias_key)
         if canonical_label is None:
             continue
         aliases[alias_key] = (*canonical_key, canonical_label)
+
+        canonical_out = mic_out if canonical_key[0] == "mic" else system_out
+        alias_out = mic_out if alias_key[0] == "mic" else system_out
+        canonical_cluster = canonical_out.get(canonical_key[1])
+        alias_cluster = alias_out.get(alias_key[1])
+        if isinstance(canonical_cluster, dict) and isinstance(alias_cluster, dict):
+            # Transcript provenance is rewritten to the canonical cluster, so
+            # retain the alias time ranges there as well. This keeps review
+            # clips placeable without double-counting overlapping echo ranges.
+            segments = []
+            for cluster in (canonical_cluster, alias_cluster):
+                for segment in cluster.get("segments") or []:
+                    try:
+                        start = float(segment["start"])
+                        end = float(segment["end"])
+                    except (KeyError, TypeError, ValueError):
+                        continue
+                    if math.isfinite(start) and math.isfinite(end) and end > start:
+                        segments.append((start, end))
+            if segments:
+                merged_segments: list[list[float]] = []
+                for start, end in sorted(segments):
+                    if merged_segments and start <= merged_segments[-1][1]:
+                        merged_segments[-1][1] = max(merged_segments[-1][1], end)
+                    else:
+                        merged_segments.append([start, end])
+                canonical_cluster = dict(canonical_cluster)
+                canonical_cluster["segments"] = [
+                    {"start": start, "end": end} for start, end in merged_segments
+                ]
+                canonical_cluster["speech_duration_seconds"] = sum(
+                    end - start for start, end in merged_segments
+                )
+                canonical_cluster["segment_count"] = sum(
+                    int(cluster.get("segment_count") or 0)
+                    for cluster in (canonical_cluster, alias_cluster)
+                )
+                canonical_out[canonical_key[1]] = canonical_cluster
+        alias_out.pop(alias_key[1], None)
         logger.info(
             "Cross-channel speaker reconciliation: %s/%s -> %s/%s "
             "(distance=%.3f, retained_chars=%d/%d)",
@@ -1589,6 +1635,17 @@ def _reconcile_cross_channel_speakers(
         if canonical is not None:
             channel, raw_sid, label = canonical
         reconciled.append((start, label, text, channel, raw_sid))
+    original_labels = {
+        label for _start, label, _text, _channel, _raw_sid
+        in _resolve_speaker_placeholders(tagged)
+    }
+    resolved_labels = {
+        label for _start, label, _text, _channel, _raw_sid
+        in _resolve_speaker_placeholders(reconciled)
+    }
+    if len(original_labels) > 1 and len(resolved_labels) <= 1:
+        logger.info("Cross-channel speaker reconciliation skipped: would erase speaker split")
+        return tagged, mic_clusters, system_clusters
     return reconciled, mic_out, system_out
 
 
@@ -2518,20 +2575,21 @@ class WhisperTranscriber:
                 for start, label, text, raw_sid in _tag_channel_segments(
                     mic_segments, mic_path, duration, "You",
                     allow_self_match=identity_enabled,
-                    clusters_out=mic_clusters,
+                    clusters_out=mic_clusters if identity_enabled else None,
                 )
             )
             tagged.extend(
                 (start, label, text, "system", raw_sid)
                 for start, label, text, raw_sid in _tag_channel_segments(
                     system_segments, system_path, duration, "Others",
-                    clusters_out=system_clusters,
+                    clusters_out=system_clusters if identity_enabled else None,
                 )
             )
             tagged.sort(key=lambda t: t[0])
-            tagged, mic_clusters, system_clusters = _reconcile_cross_channel_speakers(
-                tagged, mic_clusters, system_clusters,
-            )
+            if identity_enabled:
+                tagged, mic_clusters, system_clusters = _reconcile_cross_channel_speakers(
+                    tagged, mic_clusters, system_clusters,
+                )
             tagged = _resolve_speaker_placeholders(tagged)
 
             # Same {"mic"|"system": {"recording_type", "clusters"}} shape
@@ -2575,11 +2633,11 @@ class WhisperTranscriber:
                 "engine": engine or self.backend,
                 # {"mic"|"system": {"recording_type", "clusters"}} for
                 # src.speaker_suggestions.write_speakers_sidecar, or {} if
-            # neither channel diarized. Cross-channel echo aliases were
-            # removed above, so the Speakers panel and exact relabel manifest
-            # share the same canonical cluster ids. See _tag_channel_segments'
-            # clusters_out param. Identity matching off still computes these
-            # transiently for transcript reconciliation, but persists none.
+                # neither channel diarized. Cross-channel echo aliases were
+                # removed above, so the Speakers panel and exact relabel manifest
+                # share the same canonical cluster ids. See _tag_channel_segments'
+                # clusters_out param. Identity matching off neither collects nor
+                # compares embeddings here.
                 "speaker_clusters": speaker_clusters,
                 # list[{"start", "channel", "diarization_speaker_id"}], one
                 # per turn -- see comment above turn_manifest's construction.

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -43,6 +43,7 @@ from src.transcriber import (
     _merge_close_diar_segments,
     _parse_channels_from_ffmpeg_stderr,
     _parse_duration_from_ffmpeg_stderr,
+    _reconcile_cross_channel_speakers,
     _resolve_speaker_placeholders,
     _run_steno_diarize,
     _terminate_process_tree,
@@ -1358,6 +1359,84 @@ class ResolveSpeakerPlaceholdersTests(unittest.TestCase):
         # Same placeholder key reuses the same number on a later turn.
         self.assertEqual(resolved[3], (3.0, "Speaker 2", "d", "mic", "SPEAKER_1"))
         # channel/raw_sid pass through untouched -- only label is rewritten.
+
+
+class ReconcileCrossChannelSpeakersTests(unittest.TestCase):
+    @staticmethod
+    def _cluster(embedding):
+        return {
+            "embedding": embedding,
+            "speech_duration_seconds": 10.0,
+            "segment_count": 2,
+        }
+
+    def test_merges_unambiguous_pairs_and_keeps_post_bleed_dominant_channel(self):
+        mic_clusters = {
+            "SPEAKER_0": self._cluster([1.0, 0.0, 0.0]),
+            "SPEAKER_1": self._cluster([0.0, 1.0, 0.0]),
+            "SPEAKER_2": self._cluster([0.0, 0.0, 1.0]),
+        }
+        system_clusters = {
+            "SPEAKER_0": self._cluster([1.0, 0.0, 0.0]),
+            "SPEAKER_1": self._cluster([0.0, 0.0, 1.0]),
+            "SPEAKER_2": self._cluster([0.0, 1.0, 0.0]),
+        }
+        tagged = [
+            (0.0, "You", "the longer direct local turn", "mic", "SPEAKER_0"),
+            (1.0, "Others", "echo", "system", "SPEAKER_0"),
+            (2.0, "__diar__You__SPEAKER_1", "echo", "mic", "SPEAKER_1"),
+            (3.0, "__diar__Others__SPEAKER_2", "the longer direct remote turn", "system", "SPEAKER_2"),
+            (4.0, "__diar__You__SPEAKER_2", "small", "mic", "SPEAKER_2"),
+            (5.0, "__diar__Others__SPEAKER_1", "another longer remote turn", "system", "SPEAKER_1"),
+        ]
+
+        reconciled, mic_out, system_out = _reconcile_cross_channel_speakers(
+            tagged, mic_clusters, system_clusters,
+        )
+
+        self.assertEqual(
+            reconciled,
+            [
+                (0.0, "You", "the longer direct local turn", "mic", "SPEAKER_0"),
+                (1.0, "You", "echo", "mic", "SPEAKER_0"),
+                (2.0, "__diar__Others__SPEAKER_2", "echo", "system", "SPEAKER_2"),
+                (3.0, "__diar__Others__SPEAKER_2", "the longer direct remote turn", "system", "SPEAKER_2"),
+                (4.0, "__diar__Others__SPEAKER_1", "small", "system", "SPEAKER_1"),
+                (5.0, "__diar__Others__SPEAKER_1", "another longer remote turn", "system", "SPEAKER_1"),
+            ],
+        )
+        self.assertEqual(set(mic_out), {"SPEAKER_0"})
+        self.assertEqual(set(system_out), {"SPEAKER_1", "SPEAKER_2"})
+        resolved = _resolve_speaker_placeholders(reconciled)
+        self.assertEqual({turn[1] for turn in resolved}, {"You", "Speaker 2", "Speaker 3"})
+
+    def test_ambiguous_near_ties_are_not_merged(self):
+        mic_clusters = {"SPEAKER_0": self._cluster([1.0, 0.0])}
+        system_clusters = {
+            "SPEAKER_0": self._cluster([1.0, 0.0]),
+            "SPEAKER_1": self._cluster([1.0, 0.0]),
+        }
+        tagged = [
+            (0.0, "You", "mic", "mic", "SPEAKER_0"),
+            (1.0, "Others", "system a", "system", "SPEAKER_0"),
+            (2.0, "__diar__Others__SPEAKER_1", "system b", "system", "SPEAKER_1"),
+        ]
+
+        result = _reconcile_cross_channel_speakers(tagged, mic_clusters, system_clusters)
+
+        self.assertEqual(result, (tagged, mic_clusters, system_clusters))
+
+    def test_unrelated_cross_channel_clusters_are_not_merged(self):
+        mic_clusters = {"SPEAKER_0": self._cluster([1.0, 0.0])}
+        system_clusters = {"SPEAKER_0": self._cluster([0.0, 1.0])}
+        tagged = [
+            (0.0, "You", "mic", "mic", "SPEAKER_0"),
+            (1.0, "Others", "system", "system", "SPEAKER_0"),
+        ]
+
+        result = _reconcile_cross_channel_speakers(tagged, mic_clusters, system_clusters)
+
+        self.assertEqual(result, (tagged, mic_clusters, system_clusters))
 
 
 class AssembleDiarisedTurnsTests(unittest.TestCase):

--- a/tests/test_transcriber_diarisation.py
+++ b/tests/test_transcriber_diarisation.py
@@ -247,6 +247,53 @@ class TranscribeDiarisedMultiSpeakerTests(unittest.TestCase):
         self.assertEqual(clusters["system"]["recording_type"], "remote")
         self.assertEqual(clusters["system"]["clusters"]["SPEAKER_0"]["embedding"], [0.5, 0.6])
 
+    def test_enabled_pipeline_reconciles_sidecar_and_turn_manifest_together(self):
+        mic_diar = [
+            {"start": 0.0, "end": 2.0, "speaker": "SPEAKER_0"},
+            {"start": 2.5, "end": 4.5, "speaker": "SPEAKER_1"},
+        ]
+        system_diar = [
+            {"start": 5.0, "end": 7.0, "speaker": "SPEAKER_0"},
+            {"start": 7.5, "end": 9.5, "speaker": "SPEAKER_1"},
+        ]
+        mic_embeddings = {
+            "SPEAKER_0": [1.0, 0.0, 0.0],
+            "SPEAKER_1": [0.0, 1.0, 0.0],
+        }
+        system_embeddings = {
+            "SPEAKER_0": [0.0, 0.0, 1.0],
+            "SPEAKER_1": [0.0, 1.0, 0.0],
+        }
+        with patch("src.transcriber._identity_matching_enabled", return_value=True), \
+             patch("src.config.get_config") as mock_get_config, \
+             patch(
+                "src.transcriber._run_steno_diarize",
+                side_effect=[(mic_diar, mic_embeddings), (system_diar, system_embeddings)],
+             ):
+            mock_get_config.return_value.get_voiceprints.return_value = []
+            self.transcriber.transcribe_audio = Mock(side_effect=[
+                {"text": "Local. Echo.", "segments": [
+                    {"text": "Local.", "start": 0.5, "end": 1.5},
+                    {"text": "Echo.", "start": 3.0, "end": 4.0},
+                ]},
+                {"text": "Remote one. Remote participant speaking.", "segments": [
+                    {"text": "Remote one.", "start": 5.5, "end": 6.5},
+                    {"text": "Remote participant speaking.", "start": 8.0, "end": 9.0},
+                ]},
+            ])
+
+            result = self.transcriber.transcribe_diarised(self.audio_path)
+
+        self.assertEqual(set(result["speaker_clusters"]["mic"]["clusters"]), {"SPEAKER_0"})
+        self.assertEqual(
+            set(result["speaker_clusters"]["system"]["clusters"]),
+            {"SPEAKER_0", "SPEAKER_1"},
+        )
+        self.assertIn(
+            {"start": 2.5, "channel": "system", "diarization_speaker_id": "SPEAKER_1"},
+            result["turn_manifest"],
+        )
+
     def test_speaker_clusters_empty_and_no_self_match_when_identity_matching_disabled(self):
         # identity_matching_enabled=False must stop per-meeting speaker
         # embeddings from ever reaching speaker_clusters (so nothing is
@@ -268,6 +315,7 @@ class TranscribeDiarisedMultiSpeakerTests(unittest.TestCase):
         system_embeddings = {"SPEAKER_0": [0.5, 0.6]}
         self_voiceprint = {"is_self": True, "centroid": [0.3, 0.4]}  # matches SPEAKER_1
         with patch("src.transcriber._identity_matching_enabled", return_value=False), \
+             patch("src.transcriber._reconcile_cross_channel_speakers") as reconcile, \
              patch(
                 "src.transcriber._run_steno_diarize",
                 side_effect=[(mic_diar, mic_embeddings), (system_diar, system_embeddings)],
@@ -284,6 +332,7 @@ class TranscribeDiarisedMultiSpeakerTests(unittest.TestCase):
             ])
             result = self.transcriber.transcribe_diarised(self.audio_path)
         self.assertEqual(result["speaker_clusters"], {})
+        reconcile.assert_not_called()
         # Dominant-by-duration labeling survives untouched: SPEAKER_1 stays
         # "Speaker 2", it is NOT re-anchored to "You" despite matching the
         # self voiceprint above -- proving self-matching never ran.
@@ -1370,7 +1419,7 @@ class ReconcileCrossChannelSpeakersTests(unittest.TestCase):
             "segment_count": 2,
         }
 
-    def test_merges_unambiguous_pairs_and_keeps_post_bleed_dominant_channel(self):
+    def test_merges_unambiguous_echo_pairs_but_keeps_dominant_legacy_pair(self):
         mic_clusters = {
             "SPEAKER_0": self._cluster([1.0, 0.0, 0.0]),
             "SPEAKER_1": self._cluster([0.0, 1.0, 0.0]),
@@ -1398,7 +1447,7 @@ class ReconcileCrossChannelSpeakersTests(unittest.TestCase):
             reconciled,
             [
                 (0.0, "You", "the longer direct local turn", "mic", "SPEAKER_0"),
-                (1.0, "You", "echo", "mic", "SPEAKER_0"),
+                (1.0, "Others", "echo", "system", "SPEAKER_0"),
                 (2.0, "__diar__Others__SPEAKER_2", "echo", "system", "SPEAKER_2"),
                 (3.0, "__diar__Others__SPEAKER_2", "the longer direct remote turn", "system", "SPEAKER_2"),
                 (4.0, "__diar__Others__SPEAKER_1", "small", "system", "SPEAKER_1"),
@@ -1406,9 +1455,12 @@ class ReconcileCrossChannelSpeakersTests(unittest.TestCase):
             ],
         )
         self.assertEqual(set(mic_out), {"SPEAKER_0"})
-        self.assertEqual(set(system_out), {"SPEAKER_1", "SPEAKER_2"})
+        self.assertEqual(set(system_out), {"SPEAKER_0", "SPEAKER_1", "SPEAKER_2"})
         resolved = _resolve_speaker_placeholders(reconciled)
-        self.assertEqual({turn[1] for turn in resolved}, {"You", "Speaker 2", "Speaker 3"})
+        self.assertEqual(
+            {turn[1] for turn in resolved},
+            {"You", "Others", "Speaker 2", "Speaker 3"},
+        )
 
     def test_ambiguous_near_ties_are_not_merged(self):
         mic_clusters = {"SPEAKER_0": self._cluster([1.0, 0.0])}
@@ -1437,6 +1489,87 @@ class ReconcileCrossChannelSpeakersTests(unittest.TestCase):
         result = _reconcile_cross_channel_speakers(tagged, mic_clusters, system_clusters)
 
         self.assertEqual(result, (tagged, mic_clusters, system_clusters))
+
+    def test_dominant_legacy_pair_is_not_merged(self):
+        mic_clusters = {"SPEAKER_0": self._cluster([1.0, 0.0])}
+        system_clusters = {"SPEAKER_0": self._cluster([1.0, 0.0])}
+        tagged = [
+            (0.0, "You", "local speaker", "mic", "SPEAKER_0"),
+            (1.0, "Others", "remote speaker", "system", "SPEAKER_0"),
+        ]
+
+        result = _reconcile_cross_channel_speakers(tagged, mic_clusters, system_clusters)
+
+        self.assertEqual(result, (tagged, mic_clusters, system_clusters))
+
+    def test_placeholder_pair_is_not_merged_when_it_would_erase_speaker_split(self):
+        mic_clusters = {"SPEAKER_0": self._cluster([1.0, 0.0])}
+        system_clusters = {"SPEAKER_0": self._cluster([1.0, 0.0])}
+        tagged = [
+            (0.0, "__diar__You__SPEAKER_0", "first", "mic", "SPEAKER_0"),
+            (1.0, "__diar__Others__SPEAKER_0", "second", "system", "SPEAKER_0"),
+        ]
+
+        result = _reconcile_cross_channel_speakers(tagged, mic_clusters, system_clusters)
+
+        self.assertEqual(result, (tagged, mic_clusters, system_clusters))
+
+    def test_post_bleed_text_weight_beats_folded_legacy_label(self):
+        mic_clusters = {
+            "SPEAKER_0": self._cluster([1.0, 0.0]),
+            "SPEAKER_1": self._cluster([0.0, 1.0]),
+        }
+        system_clusters = {
+            "SPEAKER_0": self._cluster([0.0, 1.0]),
+            "SPEAKER_1": self._cluster([1.0, 0.0]),
+        }
+        tagged = [
+            (0.0, "You", "short", "mic", "SPEAKER_0"),
+            (1.0, "__diar__Others__SPEAKER_1", "a much longer echo turn", "system", "SPEAKER_1"),
+            (2.0, "__diar__You__SPEAKER_1", "echo", "mic", "SPEAKER_1"),
+            (3.0, "Others", "remote speaker", "system", "SPEAKER_0"),
+        ]
+
+        reconciled, mic_out, system_out = _reconcile_cross_channel_speakers(
+            tagged, mic_clusters, system_clusters,
+        )
+
+        self.assertEqual(
+            reconciled[0][1:],
+            ("__diar__Others__SPEAKER_1", "short", "system", "SPEAKER_1"),
+        )
+        self.assertEqual(set(mic_out), set())
+        self.assertEqual(set(system_out), {"SPEAKER_0", "SPEAKER_1"})
+
+    def test_merge_preserves_union_of_segment_ranges(self):
+        mic_clusters = {
+            "SPEAKER_0": {
+                **self._cluster([1.0, 0.0]),
+                "segments": [{"start": 0.0, "end": 2.0}],
+            },
+            "SPEAKER_1": self._cluster([0.0, 1.0]),
+        }
+        system_clusters = {
+            "SPEAKER_0": self._cluster([0.0, 1.0]),
+            "SPEAKER_1": {
+                **self._cluster([1.0, 0.0]),
+                "segments": [{"start": 1.5, "end": 3.0}],
+            },
+        }
+        tagged = [
+            (0.0, "You", "direct local", "mic", "SPEAKER_0"),
+            (1.5, "__diar__Others__SPEAKER_1", "echo", "system", "SPEAKER_1"),
+            (4.0, "__diar__You__SPEAKER_1", "echo", "mic", "SPEAKER_1"),
+            (5.0, "Others", "direct remote", "system", "SPEAKER_0"),
+        ]
+
+        _reconciled, mic_out, _system_out = _reconcile_cross_channel_speakers(
+            tagged, mic_clusters, system_clusters,
+        )
+
+        self.assertEqual(mic_out["SPEAKER_0"]["segments"], [{"start": 0.0, "end": 3.0}])
+        self.assertEqual(mic_out["SPEAKER_0"]["speech_duration_seconds"], 3.0)
+        self.assertEqual(mic_out["SPEAKER_0"]["segment_count"], 4)
 
 
 class AssembleDiarisedTurnsTests(unittest.TestCase):


### PR DESCRIPTION
## What users see

Steno records calls on two audio tracks:

- the microphone track, normally the person using the Mac;
- the system-audio track, normally everyone speaking through Zoom, Google Meet, and similar apps.

When someone uses laptop speakers instead of headphones, the microphone can also hear the voices coming from the computer.
Steno already removes most repeated words from the final transcript, but speaker identification still analyzes both original tracks.

The same real person can therefore be detected twice: once on the clean system-audio track and once through the quieter echo on the microphone track.
A transcript may switch between labels such as `Speaker 2` and `Speaker 5` even though both labels belong to the same person, and the Speakers panel can show duplicate people.

The original report reproduced this on a 4:55 meeting in Steno v0.7.0.
Steno reported three speakers on each track, with three clear cross-channel pairs at cosine distances 0.088, 0.065, and 0.092; every next-best match was at least 0.522 away.

No meeting content, names, audio, or voice embeddings are included in this PR.

## Why it happens

Text-level bleed correction runs before speaker identification and removes duplicate transcript segments.
Speaker identification then analyzes each complete channel WAV independently, including audio that produced removed segments.
Sortformer can therefore create two channel-local speaker IDs for the same leaked voice, and placeholder resolution treats those IDs as different people.

## What this changes

- Compares the per-meeting voiceprints produced by both diarization passes when identity matching is enabled.
- Merges only mutual-nearest mic/system pairs below the existing strict same-meeting distance threshold.
- Requires a clear runner-up margin on both sides.
- Never merges the dominant `You` and `Others` pair, and rejects any merge set that would erase an existing speaker split.
- Keeps the channel containing more post-bleed transcript text as the canonical copy.
- Updates transcript provenance and the Speakers panel to the same canonical speaker ID.
- Preserves the union of both clusters' time ranges for review clips without double-counting overlapping duration.
- Performs no cross-channel embedding comparison when identity matching is disabled.

## Result

Clear non-dominant echo pairs collapse to one canonical speaker.
Ambiguous pairs, the dominant `You`/`Others` pair, and meetings processed with identity matching disabled remain unchanged.
Transcript text is never deleted by reconciliation.

## Reviewer notes

- **No additional model run:** reconciliation reuses WeSpeaker embeddings already produced by the diarization sidecar.
- **Fails closed:** a pair must be mutual-nearest, be at or below the existing `0.10` same-meeting threshold, beat the runner-up by at least `0.05` on both sides, and pass the speaker-split guards.
- **Platform scope:** the path is active only when both stereo channels produced acoustic clusters and identity matching is enabled. Mono recordings and Windows/Linux fallback behavior are unchanged.
- **Privacy behavior:** when identity matching is disabled, this path neither collects clusters nor compares or persists embeddings.

## Validation

- `python -m unittest tests.test_transcriber_diarisation`: 151 passed
- `ruff check src/transcriber.py tests/test_transcriber_diarisation.py`: passed
- Full GitHub CI: passed on macOS, Windows, and Linux, including both T2 paths
- Independent architecture and code review: no remaining findings after two correction rounds
