### PR TITLE
fix: recover quiet microphone speech in stereo recordings

### DIFF
--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -296,6 +296,13 @@ def _parse_duration_from_ffmpeg_stderr(stderr: str) -> Optional[float]:
     return int(m.group(1)) * 3600 + int(m.group(2)) * 60 + float(m.group(3))
 
 
+def _duration_scaled_audio_timeout(duration_seconds: Optional[float], floor_s: int) -> int:
+    """Return a generous bounded timeout for a full-length audio pass."""
+    if duration_seconds and duration_seconds > 0:
+        return max(floor_s, int(duration_seconds * 2))
+    return floor_s
+
+
 def _diarised_split_timeout(duration_seconds: Optional[float]) -> int:
     """Wall-clock cap for one per-channel ffmpeg decode of the full recording.
 
@@ -307,9 +314,7 @@ def _diarised_split_timeout(duration_seconds: Optional[float]) -> int:
     transcript. When duration is unknown (some WebM headers) we fall back to
     the floor, which still comfortably beats the old 120 s.
     """
-    if duration_seconds and duration_seconds > 0:
-        return max(DIARISED_SPLIT_TIMEOUT_S, int(duration_seconds * 2))
-    return DIARISED_SPLIT_TIMEOUT_S
+    return _duration_scaled_audio_timeout(duration_seconds, DIARISED_SPLIT_TIMEOUT_S)
 
 
 def _audio_preprocess_timeout(duration_seconds: Optional[float]) -> int:
@@ -319,9 +324,7 @@ def _audio_preprocess_timeout(duration_seconds: Optional[float]) -> int:
     the same duration-scaled headroom as the preceding channel split. Mono
     callers generally do not know the duration yet and use the fixed floor.
     """
-    if duration_seconds and duration_seconds > 0:
-        return max(AUDIO_PREPROCESS_TIMEOUT_S, int(duration_seconds * 2))
-    return AUDIO_PREPROCESS_TIMEOUT_S
+    return _duration_scaled_audio_timeout(duration_seconds, AUDIO_PREPROCESS_TIMEOUT_S)
 
 
 try:

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -2234,11 +2234,15 @@ class WhisperTranscriber:
             mic_result: Optional[dict] = None
             sys_result: Optional[dict] = None
 
-            # Split channels are already 16 kHz mono + high-passed by the
-            # split ffmpeg pass above — skip the mono pre-processing pass.
+            # Keep the split files high-pass-only so the cross-channel bleed
+            # heuristics below can compare their original relative levels.
+            # The ASR inputs still need the normal pre-processing pass,
+            # especially per-channel loudness normalisation: a quiet, sparse
+            # microphone channel can otherwise decode as mostly silence even
+            # though it contains real speech.
             if mic_has_audio:
                 logger.info("Transcribing mic channel (You)...")
-                mic_result = self.transcribe_audio(mic_path, language, _preprocessed=True)
+                mic_result = self.transcribe_audio(mic_path, language)
                 if mic_result and mic_result.get("transcription_failed"):
                     channel_failed = True
                     channel_error = channel_error or mic_result.get("error")
@@ -2265,7 +2269,7 @@ class WhisperTranscriber:
 
             if system_has_audio:
                 logger.info("Transcribing system channel (Others)...")
-                sys_result = self.transcribe_audio(system_path, language, _preprocessed=True)
+                sys_result = self.transcribe_audio(system_path, language)
                 if sys_result and sys_result.get("transcription_failed"):
                     channel_failed = True
                     channel_error = channel_error or sys_result.get("error")

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -1711,7 +1711,7 @@ class WhisperTranscriber:
         include_highpass: bool = True,
         timeout_s: int = AUDIO_PREPROCESS_TIMEOUT_S,
     ) -> Tuple[Path, bool]:
-        """Clean mono audio before transcription: high-pass + loudnorm.
+        """Clean mono audio before transcription with loudnorm and optional high-pass.
 
         Returns ``(path_to_transcribe, is_temp)``. On any problem — ffmpeg
         missing, non-zero exit, timeout — falls back to ``(original, False)``
@@ -2003,7 +2003,9 @@ class WhisperTranscriber:
         ``_preprocessed`` skips the cleaning pass only when the caller has
         already applied the complete high-pass + loudness-normalisation
         chain. Stereo split files are high-pass-only, so the diarised path
-        leaves this false and creates normalised copies for ASR.
+        leaves this false and creates loudness-normalised copies for ASR.
+        Its private preprocessing options avoid applying the high-pass twice
+        and scale the subprocess timeout to the known recording duration.
         """
         if not audio_filepath.exists():
             logger.error(f"Audio file not found: {audio_filepath}")

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -17,7 +17,8 @@ the rest of the codebase doesn't churn:
 
 The stereo channel split, RMS-energy gating, and speaker-bleed collapse
 all stay — they operate on transcript text + audio metadata, not on the
-specific ASR engine.
+specific ASR engine. Split channels keep their original relative volume for
+bleed checks; separate loudness-normalised copies are sent to ASR.
 
 Whisper-era hallucination filtering ("Thank you." / "Bye." on silence)
 is gone: Parakeet doesn't produce those canned phrases on silent or
@@ -727,29 +728,23 @@ def _assign_asr_segments_to_diar_segments(
     return unplaceable
 
 
-# How often to print a HEARTBEAT: line while blocked waiting on
-# steno-diarize. Comfortably under Electron's TRANSCRIBE_INACTIVITY_MS
+# How often to print a HEARTBEAT: line while blocked on work that cannot
+# report its own progress. Comfortably under Electron's TRANSCRIBE_INACTIVITY_MS
 # (8 minutes, app/main.js) -- see _heartbeat_while_waiting's docstring for
 # why this can't just reuse the existing chunk-progress heartbeat registry.
-STENO_DIARIZE_HEARTBEAT_INTERVAL_S = 60.0
+BLOCKING_HEARTBEAT_INTERVAL_S = 60.0
 
 
 @contextlib.contextmanager
-def _heartbeat_while_waiting(label: str, interval_s: float = STENO_DIARIZE_HEARTBEAT_INTERVAL_S):
+def _heartbeat_while_waiting(label: str, interval_s: float = BLOCKING_HEARTBEAT_INTERVAL_S):
     """Print a HEARTBEAT: line every ``interval_s`` seconds on a background
     thread for the duration of the ``with`` block.
 
-    src._heartbeat's chunk-progress registry only works for backends that
-    call back into Python from INSIDE their own per-chunk loop (Parakeet,
-    Whisper.cpp) -- steno-diarize is an opaque external binary invoked via a
-    single blocking subprocess.run() call, with no such checkpoint to hang a
-    callback off of. Without this, a diarization run on an hours-long
-    channel prints nothing for its entire duration, which Electron's
-    inactivity watchdog (app/main.js) can't tell apart from a hung process
-    -- and kills, discarding a real, working meeting (confirmed against a
-    real ~3.5h recording: steno-diarize needed longer than the 8-minute
-    watchdog window and got killed mid-run, losing already-completed
-    transcription work along with it).
+    src._heartbeat's chunk-progress registry only works for code that calls
+    back into Python during its own loop. Opaque subprocess work, including
+    ffmpeg preprocessing and steno-diarize, has no checkpoint for that
+    callback. Without this heartbeat, Electron can mistake a long healthy
+    subprocess for a hang and stop the meeting job after eight minutes.
 
     Never affects the wrapped call's own return value or exceptions --
     the background thread only ever writes heartbeat lines.
@@ -1727,14 +1722,15 @@ class WhisperTranscriber:
             # without this, the terminal goes silent for that whole stretch
             # right after "Saved: ...", which reads as a hang.
             logger.info(f"Pre-processing audio (highpass + loudnorm): {audio_filepath.name}...")
-            result = subprocess.run(
-                [ffmpeg, '-y', '-i', str(audio_filepath),
-                 '-af', _audio_filter_chain(),
-                 '-ar', '16000', '-ac', '1', '-c:a', 'pcm_s16le',
-                 str(temp_path)],
-                capture_output=True,
-                timeout=AUDIO_PREPROCESS_TIMEOUT_S,
-            )
+            with _heartbeat_while_waiting("transcribe:preprocess"):
+                result = subprocess.run(
+                    [ffmpeg, '-y', '-i', str(audio_filepath),
+                     '-af', _audio_filter_chain(),
+                     '-ar', '16000', '-ac', '1', '-c:a', 'pcm_s16le',
+                     str(temp_path)],
+                    capture_output=True,
+                    timeout=AUDIO_PREPROCESS_TIMEOUT_S,
+                )
             if result.returncode == 0 and temp_path.exists() and temp_path.stat().st_size > 0:
                 logger.info("Audio pre-processed (highpass + loudnorm): %s", temp_path.name)
                 return temp_path, True
@@ -1979,9 +1975,10 @@ class WhisperTranscriber:
         otherwise a dict with ``text`` / ``segments`` / ``duration_seconds`` /
         ``detected_language`` / ``detected_language_probability``.
 
-        ``_preprocessed`` marks input that is already cleaned (the diarised
-        path's split channels are 16 kHz mono + high-passed by the split
-        ffmpeg pass) so the mono pre-processing pass isn't applied twice.
+        ``_preprocessed`` skips the cleaning pass only when the caller has
+        already applied the complete high-pass + loudness-normalisation
+        chain. Stereo split files are high-pass-only, so the diarised path
+        leaves this false and creates normalised copies for ASR.
         """
         if not audio_filepath.exists():
             logger.error(f"Audio file not found: {audio_filepath}")

--- a/src/transcriber.py
+++ b/src/transcriber.py
@@ -257,9 +257,13 @@ def _resolve_steno_diarize() -> Optional[str]:
         return None
 
 
-def _audio_filter_chain() -> str:
+def _audio_filter_chain(*, include_highpass: bool = True) -> str:
     """The ffmpeg ``-af`` chain applied to mono audio before transcription."""
-    return f"highpass=f={AUDIO_HIGHPASS_HZ},loudnorm={AUDIO_LOUDNORM}"
+    filters = []
+    if include_highpass:
+        filters.append(f"highpass=f={AUDIO_HIGHPASS_HZ}")
+    filters.append(f"loudnorm={AUDIO_LOUDNORM}")
+    return ",".join(filters)
 
 
 def _parse_channels_from_ffmpeg_stderr(stderr: str) -> Optional[int]:
@@ -297,6 +301,18 @@ def _diarised_split_timeout(duration_seconds: Optional[float]) -> int:
     if duration_seconds and duration_seconds > 0:
         return max(DIARISED_SPLIT_TIMEOUT_S, int(duration_seconds * 2))
     return DIARISED_SPLIT_TIMEOUT_S
+
+
+def _audio_preprocess_timeout(duration_seconds: Optional[float]) -> int:
+    """Wall-clock cap for preprocessing one full-length channel.
+
+    Stereo channel copies cover the complete recording, so long meetings need
+    the same duration-scaled headroom as the preceding channel split. Mono
+    callers generally do not know the duration yet and use the fixed floor.
+    """
+    if duration_seconds and duration_seconds > 0:
+        return max(AUDIO_PREPROCESS_TIMEOUT_S, int(duration_seconds * 2))
+    return AUDIO_PREPROCESS_TIMEOUT_S
 
 
 try:
@@ -1688,7 +1704,13 @@ class WhisperTranscriber:
         else:
             logger.warning("ffmpeg not found - stereo diarisation will fall back to mono")
 
-    def _preprocess_audio(self, audio_filepath: Path) -> Tuple[Path, bool]:
+    def _preprocess_audio(
+        self,
+        audio_filepath: Path,
+        *,
+        include_highpass: bool = True,
+        timeout_s: int = AUDIO_PREPROCESS_TIMEOUT_S,
+    ) -> Tuple[Path, bool]:
         """Clean mono audio before transcription: high-pass + loudnorm.
 
         Returns ``(path_to_transcribe, is_temp)``. On any problem — ffmpeg
@@ -1721,18 +1743,19 @@ class WhisperTranscriber:
             # time on a long recording, with zero other output in between --
             # without this, the terminal goes silent for that whole stretch
             # right after "Saved: ...", which reads as a hang.
-            logger.info(f"Pre-processing audio (highpass + loudnorm): {audio_filepath.name}...")
+            filter_description = "highpass + loudnorm" if include_highpass else "loudnorm"
+            logger.info(f"Pre-processing audio ({filter_description}): {audio_filepath.name}...")
             with _heartbeat_while_waiting("transcribe:preprocess"):
                 result = subprocess.run(
                     [ffmpeg, '-y', '-i', str(audio_filepath),
-                     '-af', _audio_filter_chain(),
+                     '-af', _audio_filter_chain(include_highpass=include_highpass),
                      '-ar', '16000', '-ac', '1', '-c:a', 'pcm_s16le',
                      str(temp_path)],
                     capture_output=True,
-                    timeout=AUDIO_PREPROCESS_TIMEOUT_S,
+                    timeout=timeout_s,
                 )
             if result.returncode == 0 and temp_path.exists() and temp_path.stat().st_size > 0:
-                logger.info("Audio pre-processed (highpass + loudnorm): %s", temp_path.name)
+                logger.info("Audio pre-processed (%s): %s", filter_description, temp_path.name)
                 return temp_path, True
             logger.warning(
                 "Audio pre-processing failed (rc=%s); using original audio: %s",
@@ -1968,6 +1991,8 @@ class WhisperTranscriber:
         audio_filepath: Path,
         language: str = "en",
         _preprocessed: bool = False,
+        _preprocess_include_highpass: bool = True,
+        _preprocess_timeout_s: int = AUDIO_PREPROCESS_TIMEOUT_S,
     ) -> Optional[dict]:
         """Transcribe a single-channel (or mono-mixed) audio file.
 
@@ -2001,7 +2026,11 @@ class WhisperTranscriber:
 
             transcribe_path = audio_filepath
             if not _preprocessed:
-                transcribe_path, is_temp = self._preprocess_audio(audio_filepath)
+                transcribe_path, is_temp = self._preprocess_audio(
+                    audio_filepath,
+                    include_highpass=_preprocess_include_highpass,
+                    timeout_s=_preprocess_timeout_s,
+                )
                 if is_temp:
                     preprocess_temp = transcribe_path
 
@@ -2129,13 +2158,14 @@ class WhisperTranscriber:
                 # would erase the relative-RMS difference that
                 # _drop_per_segment_bleed uses to tell the direct signal
                 # from its attenuated echo on the other channel.
-                result = subprocess.run(
-                    [ffmpeg, '-y', '-i', str(audio_filepath),
-                     '-af', f'pan=mono|c0=c{ch_idx},highpass=f={AUDIO_HIGHPASS_HZ}',
-                     '-ar', '16000', '-ac', '1', '-c:a', 'pcm_s16le',
-                     str(out_path)],
-                    capture_output=True, timeout=split_timeout
-                )
+                with _heartbeat_while_waiting("transcribe:split"):
+                    result = subprocess.run(
+                        [ffmpeg, '-y', '-i', str(audio_filepath),
+                         '-af', f'pan=mono|c0=c{ch_idx},highpass=f={AUDIO_HIGHPASS_HZ}',
+                         '-ar', '16000', '-ac', '1', '-c:a', 'pcm_s16le',
+                         str(out_path)],
+                        capture_output=True, timeout=split_timeout
+                    )
                 if result.returncode != 0:
                     logger.error(f"Channel {ch_idx} extraction failed: {result.stderr.decode()}")
                     return None, None, None
@@ -2230,6 +2260,7 @@ class WhisperTranscriber:
             # window-coverage roll-up at the end) can't hit an unbound name.
             mic_result: Optional[dict] = None
             sys_result: Optional[dict] = None
+            preprocess_timeout = _audio_preprocess_timeout(duration)
 
             # Keep the split files high-pass-only so the cross-channel bleed
             # heuristics below can compare their original relative levels.
@@ -2239,7 +2270,12 @@ class WhisperTranscriber:
             # though it contains real speech.
             if mic_has_audio:
                 logger.info("Transcribing mic channel (You)...")
-                mic_result = self.transcribe_audio(mic_path, language)
+                mic_result = self.transcribe_audio(
+                    mic_path,
+                    language,
+                    _preprocess_include_highpass=False,
+                    _preprocess_timeout_s=preprocess_timeout,
+                )
                 if mic_result and mic_result.get("transcription_failed"):
                     channel_failed = True
                     channel_error = channel_error or mic_result.get("error")
@@ -2266,7 +2302,12 @@ class WhisperTranscriber:
 
             if system_has_audio:
                 logger.info("Transcribing system channel (Others)...")
-                sys_result = self.transcribe_audio(system_path, language)
+                sys_result = self.transcribe_audio(
+                    system_path,
+                    language,
+                    _preprocess_include_highpass=False,
+                    _preprocess_timeout_s=preprocess_timeout,
+                )
                 if sys_result and sys_result.get("transcription_failed"):
                     channel_failed = True
                     channel_error = channel_error or sys_result.get("error")

--- a/tests/test_audio_preprocess.py
+++ b/tests/test_audio_preprocess.py
@@ -107,6 +107,17 @@ class PreprocessAudioTests(unittest.TestCase):
             if out_path.exists():
                 out_path.unlink()
 
+    def test_emits_heartbeats_while_ffmpeg_is_blocking(self):
+        transcriber = _build_transcriber()
+        completed = SimpleNamespace(returncode=1, stderr=b"boom")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            audio = _make_audio_file(tmp_dir)
+            with patch.object(transcriber_mod, "_resolve_ffmpeg", return_value="/fake/ffmpeg"), \
+                 patch.object(transcriber_mod, "_heartbeat_while_waiting") as heartbeat_mock, \
+                 patch.object(transcriber_mod.subprocess, "run", return_value=completed):
+                transcriber._preprocess_audio(audio)
+        heartbeat_mock.assert_called_once_with("transcribe:preprocess")
+
 
 class ConvertTo16khzSkipTests(unittest.TestCase):
     def test_already_16k_mono_pcm_is_not_reconverted(self):
@@ -172,6 +183,12 @@ class TranscribeAudioPreprocessIntegrationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             mic = _make_audio_file(tmp_dir, "stenoai_ch0_meeting.wav")
             system = _make_audio_file(tmp_dir, "stenoai_ch1_meeting.wav")
+
+            def fake_preprocess(path):
+                normalised = Path(tmp_dir) / f"normalised_{path.name}"
+                normalised.write_bytes(b"\x00" * 2048)
+                return normalised, True
+
             with patch.object(
                      transcriber, "_split_stereo_to_channels",
                      return_value=(mic, system, 10.0),
@@ -181,15 +198,19 @@ class TranscribeAudioPreprocessIntegrationTests(unittest.TestCase):
                      transcriber, "transcribe_audio",
                      wraps=transcriber.transcribe_audio,
                  ) as ta_mock, \
-                 patch.object(transcriber, "_preprocess_audio") as prep_mock, \
-                 patch.object(transcriber, "_run_backend", return_value=dict(_OK_RESULT)):
-                transcriber.transcribe_diarised(Path(tmp_dir) / "meeting.wav", language="en")
+                 patch.object(transcriber, "_preprocess_audio", side_effect=fake_preprocess) as prep_mock, \
+                 patch.object(transcriber, "_run_backend", return_value=dict(_OK_RESULT)) as run_mock:
+                result = transcriber.transcribe_diarised(
+                    Path(tmp_dir) / "meeting.wav", language="en"
+                )
             # The split files stay high-pass-only for later relative-RMS bleed
             # checks, but each ASR call gets its own normalised temp input.
             self.assertEqual(ta_mock.call_count, 2)
             for call in ta_mock.call_args_list:
                 self.assertFalse(call.kwargs.get("_preprocessed", False))
             self.assertEqual(prep_mock.call_count, 2)
+            self.assertEqual(run_mock.call_count, 2)
+            self.assertFalse(result.get("transcription_failed", False))
 
     def test_split_filter_includes_highpass_no_loudnorm(self):
         """The diarised split applies highpass only — per-channel loudnorm

--- a/tests/test_audio_preprocess.py
+++ b/tests/test_audio_preprocess.py
@@ -14,7 +14,11 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import src.transcriber as transcriber_mod
-from src.transcriber import WhisperTranscriber, _audio_filter_chain
+from src.transcriber import (
+    WhisperTranscriber,
+    _audio_filter_chain,
+    _audio_preprocess_timeout,
+)
 
 
 def _build_transcriber() -> WhisperTranscriber:
@@ -48,6 +52,19 @@ class FilterChainTests(unittest.TestCase):
         chain = _audio_filter_chain()
         self.assertIn(f"highpass=f={transcriber_mod.AUDIO_HIGHPASS_HZ}", chain)
         self.assertIn(f"loudnorm={transcriber_mod.AUDIO_LOUDNORM}", chain)
+
+    def test_chain_can_skip_highpass_for_already_filtered_split(self):
+        chain = _audio_filter_chain(include_highpass=False)
+        self.assertNotIn("highpass", chain)
+        self.assertEqual(chain, f"loudnorm={transcriber_mod.AUDIO_LOUDNORM}")
+
+    def test_preprocess_timeout_scales_for_long_recordings(self):
+        four_hours = 4 * 60 * 60
+        self.assertEqual(_audio_preprocess_timeout(four_hours), four_hours * 2)
+        self.assertEqual(
+            _audio_preprocess_timeout(None),
+            transcriber_mod.AUDIO_PREPROCESS_TIMEOUT_S,
+        )
 
 
 class PreprocessAudioTests(unittest.TestCase):
@@ -107,7 +124,7 @@ class PreprocessAudioTests(unittest.TestCase):
             if out_path.exists():
                 out_path.unlink()
 
-    def test_emits_heartbeats_while_ffmpeg_is_blocking(self):
+    def test_wraps_ffmpeg_in_heartbeat(self):
         transcriber = _build_transcriber()
         completed = SimpleNamespace(returncode=1, stderr=b"boom")
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -184,9 +201,12 @@ class TranscribeAudioPreprocessIntegrationTests(unittest.TestCase):
             mic = _make_audio_file(tmp_dir, "stenoai_ch0_meeting.wav")
             system = _make_audio_file(tmp_dir, "stenoai_ch1_meeting.wav")
 
-            def fake_preprocess(path):
+            normalised_paths = []
+
+            def fake_preprocess(path, **kwargs):
                 normalised = Path(tmp_dir) / f"normalised_{path.name}"
                 normalised.write_bytes(b"\x00" * 2048)
+                normalised_paths.append(normalised)
                 return normalised, True
 
             with patch.object(
@@ -199,7 +219,15 @@ class TranscribeAudioPreprocessIntegrationTests(unittest.TestCase):
                      wraps=transcriber.transcribe_audio,
                  ) as ta_mock, \
                  patch.object(transcriber, "_preprocess_audio", side_effect=fake_preprocess) as prep_mock, \
-                 patch.object(transcriber, "_run_backend", return_value=dict(_OK_RESULT)) as run_mock:
+                 patch.object(transcriber, "_run_backend", return_value=dict(_OK_RESULT)) as run_mock, \
+                 patch.object(
+                     transcriber_mod,
+                     "_drop_per_segment_bleed",
+                     side_effect=lambda mic_segments, system_segments, **kwargs: (
+                         mic_segments,
+                         system_segments,
+                     ),
+                 ) as bleed_mock:
                 result = transcriber.transcribe_diarised(
                     Path(tmp_dir) / "meeting.wav", language="en"
                 )
@@ -208,8 +236,28 @@ class TranscribeAudioPreprocessIntegrationTests(unittest.TestCase):
             self.assertEqual(ta_mock.call_count, 2)
             for call in ta_mock.call_args_list:
                 self.assertFalse(call.kwargs.get("_preprocessed", False))
+                self.assertFalse(call.kwargs["_preprocess_include_highpass"])
+                self.assertEqual(
+                    call.kwargs["_preprocess_timeout_s"],
+                    _audio_preprocess_timeout(10.0),
+                )
             self.assertEqual(prep_mock.call_count, 2)
             self.assertEqual(run_mock.call_count, 2)
+            self.assertEqual(
+                [call.args[0] for call in run_mock.call_args_list],
+                normalised_paths,
+            )
+            for call in prep_mock.call_args_list:
+                self.assertFalse(call.kwargs["include_highpass"])
+                self.assertEqual(
+                    call.kwargs["timeout_s"],
+                    _audio_preprocess_timeout(10.0),
+                )
+            bleed_mock.assert_called_once()
+            self.assertEqual(bleed_mock.call_args.kwargs["mic_path"], mic)
+            self.assertEqual(bleed_mock.call_args.kwargs["system_path"], system)
+            for normalised in normalised_paths:
+                self.assertFalse(normalised.exists())
             self.assertFalse(result.get("transcription_failed", False))
 
     def test_split_filter_includes_highpass_no_loudnorm(self):
@@ -237,3 +285,26 @@ class TranscribeAudioPreprocessIntegrationTests(unittest.TestCase):
             af = cmd[cmd.index("-af") + 1]
             self.assertIn(f"highpass=f={transcriber_mod.AUDIO_HIGHPASS_HZ}", af)
             self.assertNotIn("loudnorm", af)
+
+    def test_split_wraps_each_full_decode_in_heartbeat(self):
+        transcriber = _build_transcriber()
+
+        def fake_run(cmd, **kwargs):
+            if "-t" in cmd:
+                return SimpleNamespace(
+                    returncode=0,
+                    stderr="Audio: pcm_s16le, stereo\nDuration: 00:00:10.00",
+                    stdout="",
+                )
+            Path(cmd[-1]).write_bytes(b"\x00" * 64)
+            return SimpleNamespace(returncode=0, stderr=b"")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            audio = _make_audio_file(tmp_dir)
+            with patch.object(transcriber_mod, "_resolve_ffmpeg", return_value="/fake/ffmpeg"), \
+                 patch.object(transcriber_mod.subprocess, "run", side_effect=fake_run), \
+                 patch.object(transcriber_mod, "_heartbeat_while_waiting") as heartbeat_mock:
+                transcriber._split_stereo_to_channels(audio)
+
+        self.assertEqual(heartbeat_mock.call_count, 2)
+        heartbeat_mock.assert_any_call("transcribe:split")

--- a/tests/test_audio_preprocess.py
+++ b/tests/test_audio_preprocess.py
@@ -2,9 +2,9 @@
 
 The contract: pre-processing improves the input when it can and silently
 steps aside when it can't — a missing ffmpeg, a failed run, or a timeout
-must never fail the meeting. Temp files are always cleaned up, and the
-diarised path's split channels (already 16 kHz mono + high-passed) skip
-the mono pass instead of being processed twice.
+must never fail the meeting. Temp files are always cleaned up. Stereo split
+files preserve their relative levels for bleed detection, while separate
+normalised copies are passed to ASR so quiet channels remain transcribable.
 """
 
 import tempfile
@@ -167,7 +167,7 @@ class TranscribeAudioPreprocessIntegrationTests(unittest.TestCase):
                 transcriber.transcribe_audio(audio, language="en", _preprocessed=True)
             prep_mock.assert_not_called()
 
-    def test_diarised_channels_skip_mono_pass(self):
+    def test_diarised_channels_are_normalised_for_asr(self):
         transcriber = _build_transcriber()
         with tempfile.TemporaryDirectory() as tmp_dir:
             mic = _make_audio_file(tmp_dir, "stenoai_ch0_meeting.wav")
@@ -184,12 +184,12 @@ class TranscribeAudioPreprocessIntegrationTests(unittest.TestCase):
                  patch.object(transcriber, "_preprocess_audio") as prep_mock, \
                  patch.object(transcriber, "_run_backend", return_value=dict(_OK_RESULT)):
                 transcriber.transcribe_diarised(Path(tmp_dir) / "meeting.wav", language="en")
-            # Both per-channel calls passed _preprocessed=True and the mono
-            # pre-processing pass never ran.
+            # The split files stay high-pass-only for later relative-RMS bleed
+            # checks, but each ASR call gets its own normalised temp input.
             self.assertEqual(ta_mock.call_count, 2)
             for call in ta_mock.call_args_list:
-                self.assertTrue(call.kwargs.get("_preprocessed"))
-            prep_mock.assert_not_called()
+                self.assertFalse(call.kwargs.get("_preprocessed", False))
+            self.assertEqual(prep_mock.call_count, 2)
 
     def test_split_filter_includes_highpass_no_loudnorm(self):
         """The diarised split applies highpass only — per-channel loudnorm

--- a/tests/test_transcriber_failure.py
+++ b/tests/test_transcriber_failure.py
@@ -291,7 +291,7 @@ class TranscribeDiarisedFailureTests(unittest.TestCase):
             "detected_language": None,
         }
 
-        def fake_transcribe(path, language="en", _preprocessed=False):
+        def fake_transcribe(path, language="en", _preprocessed=False, **_preprocess_options):
             return failed if path == mic else ok
 
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## The problem

In some Zoom and Google Meet recordings, Steno captures the local microphone much more quietly than the other people in the call.

The voice is present in the recording, but Steno sends the quiet audio directly to the transcription model. The model can then miss most of what the local user said, leaving the note with very few `[You]` turns.

The author reproduced this with a 30-minute recording:

- Before the fix: 7 `[You]` turns and 136 characters.
- After the fix: 61 `[You]` turns and 5,105 characters.

The microphone was about 10.6 dB quieter than the call audio. No private transcript text or recording data is included in this PR.

## The fix

Steno already has a step that adjusts quiet audio before transcription. This PR makes sure that step also runs for recordings with separate microphone and system-audio channels.

Steno still keeps the original channel volumes when it checks for echo and audio bleed. Only the copies sent to the transcription model are adjusted.

The preprocessing timeout now scales with recording duration, stereo splitting reports heartbeat progress, and the stereo path avoids applying the high-pass filter twice.

## Testing

- 193 focused audio, speaker, timeout, and integration tests pass locally.
- The backend CI suite passes: 1,271 tests, with 1 skipped.
- The complete CI matrix passes on macOS, Windows, and Linux, including packaged-backend builds and real-backend T2 pipelines.
- The author reports that a complete reprocess of the 30-minute recording finished successfully and recovered the missing local-speaker turns.
