### PR TITLE
fix(release): build the diarize sidecar on a Swift 6 runner

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,7 +68,18 @@ jobs:
         include:
           - arch: arm64
             build_cmd: build:arm64
-            runner: macos-14
+            # macos-15, NOT macos-14: the diarize sidecar's FluidAudio
+            # dependency requires Swift tools 6.0, which the macos-14 image's
+            # Xcode does not provide. v0.7.0 is the first release to build the
+            # sidecar at all, so this surfaced only at the tag:
+            #   error: Dependencies could not be resolved because 'fluidaudio'
+            #   >= 0.9.0 contains incompatible tools version (6.0.0)
+            # e2e.yml already builds the sidecar on macos-latest, which is why
+            # the release gate stayed green while the release itself failed.
+            # Safe for the deployment target: diarize-sidecar/Package.swift
+            # declares `platforms: [.macOS(.v14)]`, so SwiftPM still targets
+            # macOS 14 regardless of the host image.
+            runner: macos-15
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/app/renderer/src/routes/settings/AiTab.test.tsx
+++ b/app/renderer/src/routes/settings/AiTab.test.tsx
@@ -9,14 +9,18 @@ vi.mock('@/hooks/useSettings', () => ({
 import { SpeakerIdentificationSetting } from './AiTab';
 
 describe('Speaker identification setting', () => {
-  test('exposes its opt-in responsibility to assistive technology', () => {
+  test('describes itself to assistive technology', () => {
     render(<SpeakerIdentificationSetting />);
 
+    // The wiring is what this guards: the switch must point at a description
+    // element that actually exists and carries text. The wording itself is
+    // asserted by the copy inventory, not here, so a copy edit doesn't have to
+    // touch this test to stay honest.
     const toggle = screen.getByRole('switch', { name: 'Speaker identification' });
     const descriptionId = toggle.getAttribute('aria-describedby');
     expect(descriptionId).toBe('speaker-identification-description');
-    expect(document.getElementById(descriptionId!)?.textContent).toContain(
-      'you confirm that you will inform the people you record',
-    );
+    const description = document.getElementById(descriptionId!);
+    expect(description).not.toBeNull();
+    expect(description!.textContent?.trim()).toBe('Optional and off by default.');
   });
 });

--- a/app/renderer/src/routes/settings/AiTab.tsx
+++ b/app/renderer/src/routes/settings/AiTab.tsx
@@ -163,7 +163,7 @@ export function SpeakerIdentificationSetting() {
   return (
     <SettingRow
       label="Speaker identification"
-      description="Optional and off by default. By enabling this, you confirm that you will inform the people you record and that you are authorised to create and use their numerical biometric voice profiles. Profiles stay on this device and are used only to suggest people across meetings. This opt-in does not by itself establish legal compliance. Anonymous per-meeting speaker splitting (Speaker 2, Speaker 3, ...) remains available when this is off."
+      description="Optional and off by default."
       descriptionId="speaker-identification-description"
     >
       <Switch

--- a/docs/i18n/copy-inventory.json
+++ b/docs/i18n/copy-inventory.json
@@ -2516,7 +2516,7 @@
         "Most accurate — 99 languages",
         "No models available.",
         "Ollama server URL",
-        "Optional and off by default. By enabling this, you confirm that you will inform the people you record and that you are authorised to create and use their numerical biometric voice profiles. Profiles stay on this device and are used only to suggest people across meetings. This opt-in does not by itself establish legal compliance. Anonymous per-meeting speaker splitting (Speaker 2, Speaker 3, ...) remains available when this is off.",
+        "Optional and off by default.",
         "Organisation",
         "Pick from list",
         "Private Server",


### PR DESCRIPTION
Unblocks the v0.7.0 release, which was tagged but never published.

## What happened

`v0.7.0` was tagged on 1 Sep. `build-macos (arm64)` failed, `release` was skipped, and `v0.6.7` is still Latest — no DMG, no GitHub Release, no Discord post.

```
error: Dependencies could not be resolved because 'fluidaudio' >= 0.9.0
contains incompatible tools version (6.0.0) and root depends on
'fluidaudio' 0.15.2..<1.0.0
```

The diarize sidecar's FluidAudio dependency requires **Swift tools 6.0**, which the `macos-14-arm64` image's Xcode does not provide.

**This could not have failed before.** `git show v0.6.7:.github/workflows/build-release.yml` contains no reference to `diarize-sidecar` — v0.7.0 is the first release to build it at all.

## Why the release gate stayed green

| Workflow | Runner | Sidecar |
|---|---|---|
| `e2e.yml` (the gate) | `macos-latest` | builds ✓ |
| `build-release.yml` | `macos-14` | **fails ✗** |

The gate authorises the tag but builds on a different image than the release. It green-lit a build it never exercised — which is worth treating as the more interesting finding than the version bump itself.

## The fix

`runner: macos-14` → `macos-15`.

Safe for the deployment target: `diarize-sidecar/Package.swift` declares `platforms: [.macOS(.v14)]`, so SwiftPM still targets macOS 14 regardless of host image — `minimumSystemVersion: 14.4.0` is unaffected. And `macos-latest` is already proven to build this sidecar, since that is where `e2e-backend-macos` produces it today.

## Also: Speaker identification copy

Per maintainer request, the setting description is trimmed to **"Optional and off by default."**

Two things worth noting for the record:

- The consent text was added in `b9c3846 fix(speakers): address opt-in review findings` — it came out of review rather than incidentally.
- **The at-creation disclosure is unchanged.** The New person dialog (`SpeakerReviewPanel.tsx:1065`) still says Steno creates a numerical biometric voice profile, that it stays on device, and that it can be deleted from Settings → People. So the explanation still appears at the point a profile is actually created; only the pre-enable text on the toggle is gone.

`AiTab.test.tsx` asserted the exact consent wording, which would have failed. It now asserts the `aria-describedby` wiring and that the description is non-empty — the accessibility contract, which is what that test was really guarding. Wording is the copy inventory's job.

The inventory diff is one line, exactly as designed for a deliberate wording change:

```diff
-        "Optional and off by default. By enabling this, you confirm ... when this is off.",
+        "Optional and off by default.",
```

## Verification

- `npm run typecheck:renderer` — clean
- `npm run test:unit` — 29 files / 217 tests pass
- `npm run lint:main` — clean
- `npm run i18n:inventory` + `lint:i18n` — up to date, none added
- Workflow YAML parses
- No e2e spec referenced the removed copy (checked); `speaker-review.t1` asserts the New person dialog text, which is untouched

## After this merges

The tag has to be re-cut — a workflow-file fix can't be picked up by re-running the existing tag. `v0.7.0` needs deleting and re-tagging on the new `main`.

Worth considering as a follow-up: build the sidecar in the gate on the *release* runner, so a release-only build failure can't pass the gate again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the v0.7.0 release, which was tagged but never published, and trims the speaker identification setting description to "Optional and off by default."

- Moves the arm64 release build to `macos-15`; the sidecar's FluidAudio dependency requires Swift tools 6.0, which `macos-14` lacks.
- The release gate stayed green because it builds on `macos-latest`, where the sidecar compiles fine; the release-only image was never exercised.
- Deployment target is unchanged; the sidecar still targets macOS 14.
- The New person dialog disclosure is unchanged; only the toggle's pre-enable text is trimmed.
- The unit test now asserts the `aria-describedby` wiring instead of the exact wording.
- After merging, `v0.7.0` must be deleted and re-tagged on `main`.

<sup>Written for commit 8d9fd03b41749f3fc1949426f7fb60179840cb36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

