### PR TITLE
feat(website): government & defence focus, hero rework, StenoAI branding

### DIFF
--- a/website/src/components/AppWindowDemo.jsx
+++ b/website/src/components/AppWindowDemo.jsx
@@ -95,7 +95,7 @@ function AppSidebar({ activeScreen }) {
           </svg>
         </span>
         <span style={{ fontFamily: "var(--font-serif)", fontWeight: 400, fontSize: 18, letterSpacing: "-0.02em", color: "var(--fg-1)", lineHeight: 1 }}>
-          Steno
+          StenoAI
         </span>
       </div>
 

--- a/website/src/components/Brand.jsx
+++ b/website/src/components/Brand.jsx
@@ -30,7 +30,7 @@ export function Wordmark({ size = 19 }) {
         lineHeight: 1,
       }}
     >
-      Steno
+      StenoAI
     </span>
   );
 }

--- a/website/src/components/IndustryPage.astro
+++ b/website/src/components/IndustryPage.astro
@@ -1,10 +1,10 @@
 ---
-import { Check, ShieldCheck, Plus, Minus } from "lucide-react";
+import { Check, ShieldCheck, Plus, Minus, ArrowUpRight } from "lucide-react";
 import { Nav } from "../sections/Nav";
 import Footer from "../sections/Footer.astro";
 import CTAFooter from "../sections/CTAFooter.astro";
 import AppleIcon from "./icons/AppleIcon.astro";
-import { ALL, COMPLIANCE_BODY, CTA_MAILTO } from "../content/industries.data.js";
+import { ALL, COMPLIANCE_BODY, CTA_MAILTO, BREACHES_VERIFIED } from "../content/industries.data.js";
 
 const { data } = Astro.props;
 const others = ALL.filter((c) => c.slug !== data.slug);
@@ -90,6 +90,66 @@ const H2_STYLE = {
       </ul>
     </div>
   </section>
+
+  {data.breaches && (
+    <section class="pt-[64px] pb-[8px]">
+      <div class="container-site" style="max-width: 880px">
+        <h2 class="mb-5" style={H2_STYLE}>{data.breaches.heading}</h2>
+        <p class="text-fg-2 text-[15px] leading-[1.65] mb-9" style="max-width: 68ch">
+          {data.breaches.intro}
+        </p>
+
+        <div class="flex flex-col">
+          {data.breaches.items.map((b, i) => (
+            <article
+              class="py-8"
+              style={{
+                borderTop: "1px solid var(--border-subtle)",
+                borderBottom: i === data.breaches.items.length - 1 ? "1px solid var(--border-subtle)" : "none",
+              }}
+            >
+              <p
+                class="text-fg-muted text-[11px] mb-3"
+                style={{ fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.12em" }}
+              >
+                {b.meta}
+              </p>
+              <h3 class="text-fg-1 mb-3" style={{ fontWeight: 500, fontSize: 18, lineHeight: 1.35 }}>
+                {b.title}
+              </h3>
+              <p class="text-fg-2 text-[15px] leading-[1.65]" style="max-width: 68ch">{b.what}</p>
+
+              <div class="mt-5 pl-5" style="border-left: 2px solid var(--fg-1)">
+                <p
+                  class="text-fg-muted text-[11px] mb-2"
+                  style={{ fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.12em" }}
+                >
+                  What Steno changes
+                </p>
+                <p class="text-fg-2 text-[15px] leading-[1.65]" style="max-width: 64ch">{b.why}</p>
+              </div>
+
+              <a
+                href={b.source.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1.5 text-fg-2 text-[13px] mt-5"
+              >
+                {b.source.label}
+                <span class="sr-only">(opens in a new tab)</span>
+                <ArrowUpRight size={13} aria-hidden="true" class="flex-shrink-0" />
+              </a>
+            </article>
+          ))}
+        </div>
+
+        <p class="text-fg-muted text-[13px] mt-5" style="max-width: 70ch">
+          Each incident above is a matter of public record, summarised from the linked source and
+          verified {BREACHES_VERIFIED}. Steno is not affiliated with any organisation named here.
+        </p>
+      </div>
+    </section>
+  )}
 
   <section class="pt-[56px] pb-[8px]">
     <div class="container-site" style="max-width: 880px">

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -63,6 +63,25 @@ const industries = defineCollection({
         b: z.string(),
       }),
     ),
+    // Documented incidents shown on the industry page. Optional so a new
+    // industry can ship before its evidence has been researched and sourced;
+    // when present, every item must carry a source link (see the editorial
+    // rules in industries.data.js).
+    breaches: z
+      .object({
+        heading: z.string(),
+        intro: z.string(),
+        items: z.array(
+          z.object({
+            title: z.string(),
+            meta: z.string(),
+            what: z.string(),
+            why: z.string(),
+            source: z.object({ label: z.string(), href: z.string().url() }),
+          }),
+        ),
+      })
+      .optional(),
     faqs: z.array(faqSchema),
   }),
 })

--- a/website/src/content/industries.data.js
+++ b/website/src/content/industries.data.js
@@ -16,6 +16,25 @@ const CHIPS = {
   airGapped: "Runs air-gapped / offline",
 };
 
+// Every incident below is a matter of public record and each one carries a
+// link to a primary or first-tier source (CISA, the CSRB, a parliamentary
+// committee, or wire reporting). Same rule as the /vs/ pages: if a detail
+// can't be checked from the linked source, it doesn't ship. Update
+// BREACHES_VERIFIED whenever these are re-checked.
+//
+// Wording rules, in addition to the compliance policy above:
+//   - Ongoing litigation is described as "alleges", never as fact.
+//   - `why` must state what Steno's architecture actually removes, and must
+//     not imply it removes risks it doesn't (see the SolarWinds entry, which
+//     says so explicitly). A buyer's security team will read these.
+export const BREACHES_VERIFIED = "September 2026";
+
+const BREACH_INTRO_GOV =
+  "None of these were careless organisations. In each case the data was lost somewhere outside the walls of the organisation that owned it — at a cloud provider, at a processor, or inside a tool that quietly took a copy.";
+
+const BREACH_INTRO_DEF =
+  "The pattern is consistent: the compromise happens at a link in the chain that isn't yours. A contractor's system, a vendor's build server, a file that left the enclave and couldn't be recalled.";
+
 const CTA_MAILTO =
   "mailto:chantelle@stenoai.co?subject=Steno%20demo%20request&body=Hi%20Steno%20team%2C%0A%0AWe%27d%20like%20to%20see%20a%20demo.%0A%0AOrganisation%3A%20%0ATeam%20size%3A%20%0AUse%20case%3A%20%0A%0AThanks%2C";
 
@@ -41,6 +60,42 @@ export const government = {
     { h: "No bot in the room", b: "Steno captures system and microphone audio directly — nothing joins the meeting as a participant." },
     { h: "Auditable by design", b: "It's open source. Your security team can read exactly what touches the audio and confirm the no-network claim themselves." },
   ],
+  breaches: {
+    heading: "What happens when the data leaves",
+    intro: BREACH_INTRO_GOV,
+    items: [
+      {
+        title: "A stolen signing key opened government mailboxes",
+        meta: "Microsoft Exchange Online · 2023",
+        what: "A China-linked actor, tracked as Storm-0558, used a stolen Microsoft consumer signing key to forge authentication tokens and read Exchange Online mailboxes belonging to 22 organisations and more than 500 individuals, including officials at the US State and Commerce Departments. Roughly 60,000 State Department emails were taken. The Cyber Safety Review Board concluded in 2024 that the intrusion was preventable and traced it to a cascade of avoidable failures at Microsoft.",
+        why: "No tenant setting would have stopped this. The affected departments did nothing wrong — the compromise was inside the provider holding their mail. Steno removes that dependency for meeting content: there is no provider account, no key and no server holding your transcripts to be compromised.",
+        source: {
+          label: "Cyber Safety Review Board report (CISA, 2024)",
+          href: "https://www.cisa.gov/sites/default/files/2025-03/CSRBReviewOfTheSummer2023MEOIntrusion508.pdf",
+        },
+      },
+      {
+        title: "One file-transfer product, 2,500 organisations",
+        meta: "MOVEit Transfer · 2023",
+        what: "From 27 May 2023 the CL0P group exploited a zero-day in Progress Software's MOVEit Transfer to steal data from every instance it could reach. More than 2,500 organisations were affected, among them multiple US federal agencies — the Department of Energy confirmed two of its entities were caught in it.",
+        why: "Most of those organisations would not have named MOVEit if you had asked them to list their data path. Meeting recordings and transcripts are exactly the kind of data that accumulates in that sort of intermediary. Steno's pipeline has no intermediary: capture, transcription and summarisation all happen on the machine.",
+        source: {
+          label: "CISA advisory AA23-158A",
+          href: "https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-158a",
+        },
+      },
+      {
+        title: "The notetaker itself became the exposure",
+        meta: "Otter.ai litigation · 2025",
+        what: "Class actions consolidated as In re Otter.AI Privacy Litigation in the Northern District of California allege that the AI notetaker joined Zoom, Teams and Google Meet calls and recorded participants who were not its customers, transmitted call content to its servers, and used those conversations to train its models — without the consent of everyone in the room. The claims are unproven and Otter.ai disputes them.",
+        why: "Whatever the outcome, the exposure is structural: once a notetaker sends audio off the device, consent, retention and model-training become somebody else's policy. Steno never sends the audio anywhere, so those questions stay yours to answer.",
+        source: {
+          label: "NPR, August 2025",
+          href: "https://www.npr.org/2025/08/15/g-s1-83087/otter-ai-transcription-class-action-lawsuit",
+        },
+      },
+    ],
+  },
   faqs: [
     { q: "Does Steno meet data-residency requirements?", a: "Because processing and storage happen on the device and nothing is uploaded, your data never leaves the machine — or the jurisdiction it's in. There is no cloud region to configure and no cross-border transfer to account for." },
     { q: "Can it run on an isolated or air-gapped network?", a: "Yes. Once the models are downloaded during first-run setup, recording, transcription, and summarization all run offline. Steno makes no network requests with your meeting content." },
@@ -70,6 +125,42 @@ export const defense = {
     { h: "On-device models", b: "Transcription (Parakeet, Whisper) and summarization run locally on your hardware — no external inference service is ever called." },
     { h: "Open and inspectable", b: "MIT-licensed source your security authority can review and build in a controlled environment." },
   ],
+  breaches: {
+    heading: "What happens when the data leaves",
+    intro: BREACH_INTRO_DEF,
+    items: [
+      {
+        title: "A spreadsheet that left the building",
+        meta: "UK Ministry of Defence, Afghan relocations · 2022, disclosed 2025",
+        what: "In February 2022 a member of staff at UK Special Forces headquarters emailed out a dataset holding the names and details of roughly 19,000 Afghans who had applied for relocation under ARAP. It was not discovered until August 2023, when part of it surfaced in a Facebook group. The government obtained an unprecedented superinjunction that kept the breach — and a secret resettlement scheme built in response — out of public view until July 2025.",
+        why: "Nothing was hacked. A copy was made and sent, and it could not be recalled. Steno cannot stop a person emailing a file, and doesn't claim to — but it adds no copies of its own: no vendor-side duplicate, no automatic sync, no export step in the pipeline. Recordings, transcripts and summaries are ordinary local files, held under whatever controls you already run on that machine.",
+        source: {
+          label: "House of Commons Defence Committee report",
+          href: "https://publications.parliament.uk/pa/cm5902/cmselect/cmdfence/69/report.html",
+        },
+      },
+      {
+        title: "The contractor was the way in",
+        meta: "UK MoD payroll provider · 2024",
+        what: "Disclosed to Parliament in May 2024: an external payroll system operated by contractor Shared Services Connected Ltd was accessed by what the Defence Secretary called a malign actor, exposing names and bank details of up to around 270,000 serving personnel, reservists and veterans. The MoD's own networks were not the entry point — the third party's system was.",
+        why: "Defence security is bounded by the least-defended system holding the data, and that system frequently belongs to someone else. Every SaaS notetaker adds one. Steno adds none: there is no vendor holding your meeting content, so there is no vendor to breach.",
+        source: {
+          label: "AP / SecurityWeek, May 2024",
+          href: "https://www.securityweek.com/the-uk-says-a-huge-payroll-data-breach-by-a-malign-actor-has-exposed-details-of-military-personnel/",
+        },
+      },
+      {
+        title: "A trusted update carried the attacker in",
+        meta: "SolarWinds Orion · 2020",
+        what: "An actor the US government attributed to Russia's SVR compromised SolarWinds' build process and planted a backdoor in signed Orion updates shipped between March and June 2020. CISA issued Emergency Directive 21-01 ordering federal civilian agencies to disconnect the product; agencies including Treasury, Commerce and DHS were breached through it.",
+        why: "Steno does not make supply-chain risk disappear — no software does, and any vendor claiming otherwise is selling you something. What it removes is the standing data flow a compromise could ride: Steno makes no network calls with your meeting content, so there is no established channel out. And it is MIT-licensed, so your security authority can review the source and build it themselves rather than trusting a binary.",
+        source: {
+          label: "CISA advisory AA20-352A",
+          href: "https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a",
+        },
+      },
+    ],
+  },
   faqs: [
     { q: "Can Steno run in an air-gapped environment?", a: "Yes — that's a primary design target. After the one-time model download, everything runs with no network connection at all." },
     { q: "Is any data ever sent to Steno's servers?", a: "No. Steno makes no network calls with your meeting content. Recordings, transcripts, and summaries are ordinary files in local storage on your device." },

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -15,10 +15,10 @@ const isHome = Astro.url.pathname === '/'
 const softwareApplicationJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
-  name: 'Steno',
+  name: 'StenoAI',
   url: 'https://stenoai.co/',
   description:
-    'Steno is the highly-secure AI notetaker for confidential conversations in government and defence. No cloud, no usage limits and your private data never leaves your premises.',
+    'StenoAI is the highly-secure AI notetaker for confidential conversations in government and defence. No cloud, no usage limits and your private data never leaves your premises.',
   applicationCategory: 'BusinessApplication',
   operatingSystem: 'macOS, Windows',
   offers: {

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -2,7 +2,6 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { Nav } from "../sections/Nav";
 import Hero from "../sections/Hero.astro";
-import TrustStrip from "../sections/TrustStrip.astro";
 import HowItWorks from "../sections/HowItWorks.astro";
 import Features from "../sections/Features.astro";
 import Models from "../sections/Models.astro";
@@ -11,16 +10,15 @@ import { FAQ } from "../sections/FAQ";
 import CTAFooter from "../sections/CTAFooter.astro";
 import Footer from "../sections/Footer.astro";
 
-const title = "Steno — Highly-Secure AI Notetaker for Government & Defence";
+const title = "StenoAI — Highly-Secure AI Notetaker for Government & Defence";
 const description =
-  "Steno is the highly-secure AI notetaker for confidential conversations in government and defence. No cloud, no usage limits and your private data never leaves your premises.";
+  "StenoAI is the highly-secure AI notetaker for confidential conversations in government and defence. No cloud, no usage limits and your private data never leaves your premises.";
 ---
 
 <BaseLayout title={title} description={description} canonical="https://stenoai.co/">
   <Nav client:load />
   <main>
     <Hero />
-    <TrustStrip />
     <HowItWorks />
     <Features />
     <Models />

--- a/website/src/sections/CTAFooter.astro
+++ b/website/src/sections/CTAFooter.astro
@@ -25,7 +25,7 @@ import { WINDOWS_EXE_URL } from "../lib/downloads";
           Start keeping private notes.
         </h2>
         <p class="text-lg mb-8" style={{ color: "var(--primary-fg)", opacity: 0.7 }}>
-          Free. Open source. No account needed.
+          Free. Open source.
         </p>
 
         <div class="flex gap-[10px] justify-center flex-wrap">

--- a/website/src/sections/Hero.astro
+++ b/website/src/sections/Hero.astro
@@ -1,10 +1,16 @@
 ---
 import { ShieldCheck, Lock, HandCoins, BotOff } from "lucide-react";
 import ProviderCluster from "../components/ProviderCluster.astro";
+import TrustStrip from "./TrustStrip.astro";
 import { AppWindowDemo } from "../components/AppWindowDemo";
 import AppleIcon from "../components/icons/AppleIcon.astro";
 import WindowsIcon from "../components/icons/WindowsIcon.astro";
 import { WINDOWS_EXE_URL } from "../lib/downloads";
+
+// The hero download buttons are hidden for now — the nav and the CTA footer
+// both carry a download link. Flip back to true to restore them; the markup,
+// the OS-detection script below, and its analytics attributes are all intact.
+const SHOW_HERO_CTA = false;
 ---
 
 <section class="pt-[40px] pb-[56px] md:pt-[56px] md:pb-[80px]">
@@ -26,45 +32,55 @@ import { WINDOWS_EXE_URL } from "../lib/downloads";
         margin: "0 auto",
       }}
     >
-      Protect your sensitive conversations.
+      Protect your classified conversations.
     </h1>
 
     <p
-      class="text-fg-2 text-lg leading-[1.55] mt-6 mb-8 mx-auto"
+      class="text-fg-2 text-lg leading-[1.55] mt-6 mx-auto"
       style="max-width: 64ch"
     >
-      Steno is the highly-secure AI notetaker for confidential conversations in
+      StenoAI is the highly-secure AI notetaker for confidential conversations in
       government and defence. No cloud, no usage limits and your private data
       never leaves your premises.
     </p>
 
-    <div class="flex gap-[10px] flex-wrap justify-center" id="hero-cta">
-      <a
-        href="/download/?src=hero"
-        data-os-cta="mac"
-        class="btn-base btn-primary inline-flex items-center gap-2 no-underline hover:no-underline"
-      >
-        <AppleIcon size={15} />
-        <span data-os-cta-label="mac">Download for macOS</span>
-      </a>
-      <a
-        href={WINDOWS_EXE_URL}
-        data-track="download"
-        data-location="hero"
-        data-arch="win-x64"
-        data-os-cta="windows"
-        class="btn-base btn-ghost inline-flex items-center gap-2 no-underline hover:no-underline"
-        style="display: none"
-      >
-        <WindowsIcon size={15} />
-        <span data-os-cta-label="windows">Download for Windows (alpha)</span>
-      </a>
-    </div>
-    <noscript>
-      <style>#hero-cta [data-os-cta="windows"] { display: inline-flex !important; }</style>
-    </noscript>
+    <TrustStrip class="mt-11 mb-11" />
 
-    <div class="flex gap-5 flex-wrap justify-center mt-6 mb-12">
+    <div class="mx-auto" style="max-width: 960px">
+      <AppWindowDemo client:visible />
+    </div>
+
+    {SHOW_HERO_CTA && (
+      <>
+        <div class="flex gap-[10px] flex-wrap justify-center mt-12" id="hero-cta">
+          <a
+            href="/download/?src=hero"
+            data-os-cta="mac"
+            class="btn-base btn-primary inline-flex items-center gap-2 no-underline hover:no-underline"
+          >
+            <AppleIcon size={15} />
+            <span data-os-cta-label="mac">Download for macOS</span>
+          </a>
+          <a
+            href={WINDOWS_EXE_URL}
+            data-track="download"
+            data-location="hero"
+            data-arch="win-x64"
+            data-os-cta="windows"
+            class="btn-base btn-ghost inline-flex items-center gap-2 no-underline hover:no-underline"
+            style="display: none"
+          >
+            <WindowsIcon size={15} />
+            <span data-os-cta-label="windows">Download for Windows (alpha)</span>
+          </a>
+        </div>
+        <noscript>
+          <style>#hero-cta [data-os-cta="windows"] { display: inline-flex !important; }</style>
+        </noscript>
+      </>
+    )}
+
+    <div class={`flex gap-5 flex-wrap justify-center ${SHOW_HERO_CTA ? "mt-6" : "mt-10"}`}>
       <span class="inline-flex items-center gap-1.5 text-fg-2 text-[13px]">
         <ShieldCheck size={13} aria-hidden="true" /> Open source
       </span>
@@ -79,16 +95,14 @@ import { WINDOWS_EXE_URL } from "../lib/downloads";
       </span>
     </div>
 
-    <div class="mx-auto" style="max-width: 960px">
-      <AppWindowDemo client:visible />
-    </div>
-
   </div>
 </section>
 
 <script>
   // Best-effort client OS detection, ported from Hero.jsx's detectOS(). The
   // primary CTA follows the visitor's OS; on ambiguous UAs both are shown.
+  // Dormant while SHOW_HERO_CTA is false — #hero-cta isn't rendered, so the
+  // guard below no-ops. Kept in step with the flag, not deleted with it.
   function detectOS() {
     if (typeof navigator === "undefined") return "mac";
     const hint = navigator.userAgentData?.platform || navigator.platform || "";

--- a/website/src/sections/TrustStrip.astro
+++ b/website/src/sections/TrustStrip.astro
@@ -1,4 +1,7 @@
 ---
+// The customer logo band. Rendered inline inside the hero (between the
+// subhead and the app screenshot), so this component deliberately owns no
+// <section> or .container-site wrapper — the caller places and spaces it.
 const logos = [
   { name: "AWS", src: "/logos/aws.svg", w: 80, hpx: 32 },
   { name: "HashiCorp", src: "/logos/hashicorp.svg", w: 24, hpx: 24 },
@@ -7,25 +10,25 @@ const logos = [
   { name: "Rutgers", src: "/logos/rutgers.svg", w: 100, hpx: 32 },
   { name: "European Union", src: "/logos/european-union.svg", w: 150, hpx: 32 },
 ];
+
+const { class: className = "" } = Astro.props;
 ---
 
-<section class="py-6 md:py-8">
-  <div class="container-site">
-    <div class="text-center text-fg-2 text-xs tracking-[0.06em] uppercase mb-7">
-      Trusted by teams at
-    </div>
-    <div class="flex flex-wrap justify-center items-center gap-x-12 sm:gap-x-20 gap-y-6">
-      {logos.map((l) => (
-        <img
-          key={l.name}
-          src={l.src}
-          alt={l.name}
-          width={l.w}
-          height={l.hpx}
-          class={`${l.h || "h-6 sm:h-7"} w-auto dark:invert`}
-          style={{ opacity: 0.5 }}
-        />
-      ))}
-    </div>
+<div class={className}>
+  <div class="text-center text-fg-2 text-xs tracking-[0.06em] uppercase mb-6">
+    Trusted by teams at
   </div>
-</section>
+  <div class="flex flex-wrap justify-center items-center gap-x-10 sm:gap-x-16 gap-y-5">
+    {logos.map((l) => (
+      <img
+        key={l.name}
+        src={l.src}
+        alt={l.name}
+        width={l.w}
+        height={l.hpx}
+        class={`${l.h || "h-6 sm:h-7"} w-auto dark:invert`}
+        style={{ opacity: 0.45 }}
+      />
+    ))}
+  </div>
+</div>


### PR DESCRIPTION
Website-only change. Sharpens the government/defence positioning, reworks the homepage hero, and renames the visible brand to StenoAI.

## Government & Defence pages

New **"What happens when the data leaves"** section on each page, sitting between the pains list and the feature grid. Three documented incidents per page — what happened, a *What Steno changes* callout, and a link to a primary or first-tier source.

| Government | Defence |
|---|---|
| Storm-0558 / Exchange Online, 2023 ([CSRB report](https://www.cisa.gov/sites/default/files/2025-03/CSRBReviewOfTheSummer2023MEOIntrusion508.pdf)) | MoD Afghan relocation dataset, 2022 / disclosed 2025 ([Defence Committee](https://publications.parliament.uk/pa/cm5902/cmselect/cmdfence/69/report.html)) |
| MOVEit Transfer, 2023 ([CISA AA23-158A](https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-158a)) | MoD payroll contractor, 2024 ([AP / SecurityWeek](https://www.securityweek.com/the-uk-says-a-huge-payroll-data-breach-by-a-malign-actor-has-exposed-details-of-military-personnel/)) |
| Otter.ai privacy litigation, 2025 ([NPR](https://www.npr.org/2025/08/15/g-s1-83087/otter-ai-transcription-class-action-lawsuit)) | SolarWinds Orion, 2020 ([CISA AA20-352A](https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a)) |

Written against the editorial policy in `src/content/README.md`:

- Otter.ai is framed as **allegations**, with "the claims are unproven and Otter.ai disputes them".
- The Afghan-leak entry states outright that Steno cannot stop someone emailing a file — the claim is only that it adds no copies of its own.
- The SolarWinds entry says plainly that Steno does not remove supply-chain risk.
- `BREACHES_VERIFIED = "September 2026"` mirrors the `/vs/` pages' `VERIFIED` date, with a footnote disclaiming affiliation.

The collection schema gains an **optional** `breaches` object, so a future industry can ship before its evidence is researched and sourced.

## Homepage hero

```
  [ provider tiles ]
  Protect your classified conversations.
  StenoAI is the highly-secure AI notetaker for...

  TRUSTED BY TEAMS AT
  [aws] [hashicorp] [tesco] [EU] ...

  ┌────────────────────────┐
  │      app screenshot    │
  └────────────────────────┘

  Open source · Data never leaves your premises
  · No meeting bots · No usage limits
```

- Logo strip moves up out of its own section into the hero, above the screenshot. `TrustStrip` no longer owns a `<section>`/`.container-site` wrapper — the caller places and spaces it.
- Download buttons and feature chips move below the screenshot.
- The hero download CTA is then **hidden behind a `SHOW_HERO_CTA` flag** (nav + CTA footer already carry a download link). Markup, `data-track` attributes and the OS-detection script all stay intact, so restoring it is a one-line flip.
- `"No account needed."` dropped from the CTA footer subline.

## Branding

`StenoAI` in the nav and footer wordmark, the app-window screenshot's sidebar, the hero copy, the `<title>`, the meta description and the `SoftwareApplication` JSON-LD. **Body copy elsewhere still says "Steno" on second reference** — a full prose sweep, and the other page titles (`Download Steno for Mac`, `Steno vs Granola`, …), were left alone deliberately since several are deliberate SEO strings.

## Reviewer notes

- **"Classified" in the H1** is worth a second opinion. The Defence page intro says accreditation for any specific classified environment is the deployer's responsibility, not the app's — so the headline and that caveat pull slightly in different directions. Kept at the maintainer's direction; `"Protect your most sensitive conversations."` is the alternative.
- Only the website changed — no app, backend or e2e surface is touched, so no spec updates apply.
- `npm run build` passes (12 pages). `npm run lint` reports 2 errors, both **pre-existing** parse errors in `AppleIcon.astro` / `WindowsIcon.astro`, files this PR does not touch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Website-only change that sharpens the government/defence positioning, reworks the homepage hero, and renames the visible brand to StenoAI.

**Government & Defence pages**
- Adds a "What happens when the data leaves" section to each page: three documented incidents per page, each with a source link and a "What Steno changes" callout.
- Entries follow the editorial policy — Otter.ai is framed as allegations, and each entry states only what Steno's architecture actually removes.
- The schema gains an optional `breaches` object so a future industry can ship before its evidence is researched.

**Homepage hero & branding**
- The customer logo strip moves into the hero; download buttons and feature chips move below the screenshot.
- The hero download CTA is hidden behind a `SHOW_HERO_CTA` flag — markup and OS detection stay intact for a one-line restore.
- Visible brand reads `StenoAI` in the nav, footer, hero, `<title>`, meta description, and JSON-LD; body copy elsewhere still says Steno.
- "No account needed." is dropped from the CTA footer.
- "Classified" in the H1 is worth a second opinion — the Defence page intro puts accreditation responsibility on the deployer, which pulls against the headline.

<sup>Written for commit 2d7998aa06c64a50b9080cef2ce057c69fa06fa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

