### PR TITLE
ci(linux): smoke-test the installed package, then publish it on release

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -200,17 +200,19 @@ jobs:
           # to go to stderr.
           node -e "
             const fs = require('fs');
-            const { extractSetupCheckPayload } = require('./app/setup-check-parse');
-            const payload = extractSetupCheckPayload(fs.readFileSync('setup-check.txt', 'utf8'));
-            if (!payload) {
-              console.error('::error::setup-check emitted no valid JSON payload — the bundle crashed rather than reporting');
+            const { parseSetupCheckOutput } = require('./app/setup-check-parse');
+            let payload;
+            try {
+              payload = parseSetupCheckOutput(fs.readFileSync('setup-check.txt', 'utf8'));
+            } catch (error) {
+              console.error('::error::setup-check emitted an invalid payload — ' + error.message);
               process.exit(1);
             }
-            const failed = (payload.checks || []).filter((c) => c.status === 'fail').map((c) => c.name);
+            const failed = payload.checks.filter((c) => c.status === 'fail').map((c) => c.name);
             console.log('setup-check parsed: allGood=' + payload.allGood + ', failing=' + (failed.join(',') || 'none'));
             // sounddevice is the check libportaudio2 exists for (#502). A model
             // not being downloaded is expected here; a broken native lib is not.
-            const sd = (payload.checks || []).find((c) => c.name === 'sounddevice');
+            const sd = payload.checks.find((c) => c.name === 'sounddevice');
             if (!sd || sd.status !== 'pass') {
               console.error('::error::sounddevice check did not pass — the .deb dependency chain is not delivering PortAudio');
               process.exit(1);

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -188,10 +188,34 @@ jobs:
           # setup-check exits non-zero with no model downloaded, which is
           # expected on a fresh runner; we only require that it runs to
           # completion without an import or native-library crash.
-          "$BACKEND" setup-check --json > setup-check.json || true
-          cat setup-check.json
-          python3 -c "import json,sys; json.load(open('setup-check.json'))" \
-            || { echo "::error::setup-check produced no parseable JSON — the bundle crashed rather than reporting"; exit 1; }
+          "$BACKEND" setup-check --json > setup-check.txt 2>&1 || true
+          cat setup-check.txt
+          # Parse with app/setup-check-parse.js, the same module main.js uses,
+          # rather than json.load over the whole file. The checks import
+          # sounddevice/pywhispercpp/ollama, any of which can print to stdout
+          # ahead of the payload — that module exists precisely because the
+          # buffer is not guaranteed to be pure JSON, and it is unit tested.
+          # Redirecting stderr in too makes this strictly harsher than the
+          # earlier version, which only survived because Python logging happens
+          # to go to stderr.
+          node -e "
+            const fs = require('fs');
+            const { extractSetupCheckPayload } = require('./app/setup-check-parse');
+            const payload = extractSetupCheckPayload(fs.readFileSync('setup-check.txt', 'utf8'));
+            if (!payload) {
+              console.error('::error::setup-check emitted no valid JSON payload — the bundle crashed rather than reporting');
+              process.exit(1);
+            }
+            const failed = (payload.checks || []).filter((c) => c.status === 'fail').map((c) => c.name);
+            console.log('setup-check parsed: allGood=' + payload.allGood + ', failing=' + (failed.join(',') || 'none'));
+            // sounddevice is the check libportaudio2 exists for (#502). A model
+            // not being downloaded is expected here; a broken native lib is not.
+            const sd = (payload.checks || []).find((c) => c.name === 'sounddevice');
+            if (!sd || sd.status !== 'pass') {
+              console.error('::error::sounddevice check did not pass — the .deb dependency chain is not delivering PortAudio');
+              process.exit(1);
+            }
+          "
 
       - name: Verify the AppImage is well-formed
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -2,12 +2,15 @@ name: Build Linux installer
 
 # End-to-end Linux build: PyInstaller backend (onnx-asr Parakeet + whisper.cpp,
 # same CPU backend as Windows) + Electron .deb/AppImage. Mirrors
-# build-windows.yml's shape and trigger, but NOT its release-attach step: Linux
-# is not a shipped platform yet, so the .deb/AppImage stay CI artifacts and no
-# tagged release carries them. This job exists to keep the Linux backend and
-# packaging honest on every push to main. Attaching to releases is a small
-# follow-up (mirror build-windows.yml's step + contents: write) for whenever
-# that call is made.
+# build-windows.yml's shape and trigger, including its release-attach step: on
+# a tag push this waits for build-release.yml to publish the release, then
+# uploads the .deb/AppImage alongside the macOS DMG. On pushes to main it stops
+# at CI artifacts.
+#
+# The install smoke test below is the reason this can publish at all: a .deb
+# that builds is not a .deb that installs, and the dependency list is the part
+# most likely to be wrong (see #526 — a bad `depends` would have produced a
+# package apt could not satisfy, and nothing here would have noticed).
 
 on:
   workflow_dispatch:
@@ -20,7 +23,7 @@ on:
       - 'v*.*.*'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build-linux:
@@ -115,6 +118,92 @@ jobs:
           npm run build:renderer
           npx electron-builder --linux --publish=never
 
+      # Prove the package INSTALLS, not just that it builds. This is the check
+      # that would have caught a wrong `depends` list: apt resolves the
+      # declared dependencies against a real archive here, so a missing or
+      # misspelled one fails the job rather than a user's machine.
+      #
+      # Deliberately BEFORE the release-attach step below, so a package that
+      # cannot install can never be published.
+      - name: Install the built .deb and smoke-test it
+        run: |
+          set -euo pipefail
+          DEB=$(ls app/dist/*.deb | head -1)
+
+          # 1. The declared dependency list itself. fpm's customDepends REPLACES
+          # electron-builder's defaults rather than extending them, so the
+          # failure mode is a package that declares libportaudio2 and none of
+          # the Electron runtime libs (#526). Assert the whole set explicitly —
+          # installing on a runner that already has GTK would not notice.
+          DEPENDS=$(dpkg-deb -f "$DEB" Depends)
+          echo "Depends: $DEPENDS"
+          for dep in libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils \
+                     libatspi2.0-0 libuuid1 libsecret-1-0 libportaudio2; do
+            # ,name, for a plain dep and ,name( for a versioned one. A bare
+            # prefix match would let libnss3-tools satisfy a check for libnss3.
+            case ",${DEPENDS// /}," in
+              *",${dep},"*|*",${dep}("*) ;;
+              *) echo "::error::.deb does not declare $dep — electron-builder's defaults were likely replaced rather than extended"; exit 1 ;;
+            esac
+          done
+
+          # 2. That the chain actually RESOLVES. An earlier step installed
+          # libportaudio2 so the bundled CLI could run pre-packaging, which
+          # would let a package with a wrong dependency list install cleanly
+          # here. Remove it first so apt has to pull it back in via the .deb.
+          sudo apt-get remove -y libportaudio2
+          ! dpkg-query -W -f='${Status}' libportaudio2 2>/dev/null | grep -q '^install ok installed' \
+            || { echo "::error::libportaudio2 still installed after remove — the check below would prove nothing"; exit 1; }
+
+          echo "Installing $DEB"
+          # `apt-get install ./file.deb` (not `dpkg -i`) so declared
+          # dependencies are actually RESOLVED — dpkg would happily leave the
+          # package unconfigured on a missing dep.
+          sudo apt-get update
+          sudo apt-get install -y "./$DEB"
+
+          # The .deb, not the earlier step, is what put it back.
+          dpkg-query -W -f='${Status}' libportaudio2 | grep -q '^install ok installed' \
+            || { echo "::error::installing the .deb did not pull in libportaudio2"; exit 1; }
+
+          # Fails if the package is unpacked-but-unconfigured, which is how a
+          # broken dependency chain usually presents.
+          STATUS=$(dpkg-query -W -f='${Status}' stenoai)
+          echo "dpkg status: $STATUS"
+          [ "$STATUS" = "install ok installed" ] || { echo "::error::stenoai is not fully installed: $STATUS"; exit 1; }
+
+          # Desktop integration: the launcher and the icon this build ships.
+          test -f /usr/share/applications/stenoai.desktop
+          test -f /usr/share/icons/hicolor/512x512/apps/stenoai.png
+          test -x /opt/Steno/stenoai
+
+          # The bundled Python backend, run from where it actually lands after
+          # an install (extraResources -> resources/stenoai). Exercises the
+          # PyInstaller bundle against the system's real shared libraries,
+          # including the libportaudio2 that `depends` is there to guarantee —
+          # the crash that motivated adding it (#502) was exactly this.
+          BACKEND=/opt/Steno/resources/stenoai/stenoai
+          test -x "$BACKEND"
+          "$BACKEND" --help > /dev/null
+          # setup-check exits non-zero with no model downloaded, which is
+          # expected on a fresh runner; we only require that it runs to
+          # completion without an import or native-library crash.
+          "$BACKEND" setup-check --json > setup-check.json || true
+          cat setup-check.json
+          python3 -c "import json,sys; json.load(open('setup-check.json'))" \
+            || { echo "::error::setup-check produced no parseable JSON — the bundle crashed rather than reporting"; exit 1; }
+
+      - name: Verify the AppImage is well-formed
+        run: |
+          set -euo pipefail
+          APPIMAGE=$(ls app/dist/*.AppImage | head -1)
+          chmod +x "$APPIMAGE"
+          # No FUSE on the runner, so extract rather than execute.
+          "$APPIMAGE" --appimage-extract > /dev/null
+          test -x squashfs-root/stenoai
+          test -x squashfs-root/resources/stenoai/stenoai
+          rm -rf squashfs-root
+
       - name: Show built artifacts
         if: always()
         run: ls -lh app/dist
@@ -129,3 +218,49 @@ jobs:
             app/dist/*.AppImage
           retention-days: 14
           if-no-files-found: warn
+
+      # Mirrors build-windows.yml's attach step. Linux publishes no
+      # latest-linux.yml: electron-builder emits one, but auto-update is not
+      # wired on Linux, so only the two user-facing installers go up.
+      - name: Attach Linux assets to the release (tags only)
+        # success() is explicit because supplying any `if:` drops the implicit
+        # one — without it this would run after a failed build or a failed
+        # install check and fail again on the missing .deb, burying the real
+        # error.
+        if: success() && startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          # Stable, versionless aliases for the README/website download links
+          # (mirrors the macOS DMG rename in build-release.yml and the Windows
+          # .exe rename in build-windows.yml). The versioned files ship too.
+          DEB=$(ls app/dist/*.deb | grep -v 'stenoAI-linux-amd64.deb' | head -1)
+          APPIMAGE=$(ls app/dist/*.AppImage | grep -v 'stenoAI-linux-x86_64.AppImage' | head -1)
+          cp "$DEB" "app/dist/stenoAI-linux-amd64.deb"
+          cp "$APPIMAGE" "app/dist/stenoAI-linux-x86_64.AppImage"
+          # Wait for build-release.yml to create the PUBLISHED release, then
+          # upload to it. Resolved via /releases/tags/:tag, which only ever
+          # returns the published (non-draft) release — the same draft-avoidance
+          # reasoning as build-windows.yml.
+          #
+          # 40 min, not the 30 build-windows.yml uses: v0.7.0's release
+          # published 29 min after the tag push, so 30 leaves almost no margin
+          # if notarization runs slow. Costs nothing when the release arrives on
+          # time — the loop exits on the first successful poll.
+          for i in $(seq 1 80); do
+            if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" >/dev/null 2>&1; then
+              echo "Published release $TAG exists — uploading Linux installers."
+              gh release upload "$TAG" \
+                app/dist/*.deb \
+                app/dist/*.AppImage \
+                --clobber
+              echo "Uploaded Linux assets to release $TAG."
+              exit 0
+            fi
+            echo "Published release $TAG not created yet (attempt $i/80) — waiting 30s…"
+            sleep 30
+          done
+          echo "Published release $TAG never appeared after ~40 min — failing so we notice."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -225,19 +225,18 @@ Known alpha limitations:
 
 Verified on Ubuntu 26.04 LTS (GNOME/Wayland, PipeWire), including system-audio loopback capture with `[You]`/`[Others]` diarisation.
 
-> Linux has **no tagged release yet** — the packages are built on every push to
-> main but not attached to a release. To try it, grab one from the
-> [Linux build workflow](https://github.com/stenolabs/stenoai/actions/workflows/build-linux.yml):
-> sign in to GitHub, open the latest green run, and download the
-> `stenoai-linux-<version>` artifact.
+**Install (`.deb`, recommended):** download [`stenoAI-linux-amd64.deb`](https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-linux-amd64.deb) from the [latest release](https://github.com/stenolabs/stenoai/releases/latest) and install it with `sudo apt install ./stenoAI-linux-amd64.deb` — apt pulls in the required system libraries automatically.
 
-**Install (`.deb`, recommended):** install it with `sudo apt install ./stenoAI-linux-<version>-amd64.deb` — apt pulls in the required system libraries automatically.
-
-**AppImage:** `chmod +x` `stenoAI-linux-<version>-x86_64.AppImage` and run it. An AppImage carries no package metadata, so **you must install PortAudio yourself** or the setup check fails with `OSError: PortAudio library not found`:
+**AppImage:** download [`stenoAI-linux-x86_64.AppImage`](https://github.com/stenolabs/stenoai/releases/latest/download/stenoAI-linux-x86_64.AppImage), `chmod +x` it, and run it. An AppImage carries no package metadata, so **you must install PortAudio yourself** or the setup check fails with `OSError: PortAudio library not found`:
 
 ```bash
 sudo apt install libportaudio2
 ```
+
+> Before the first tagged Linux release lands, grab the packages from the
+> [Linux build workflow](https://github.com/stenolabs/stenoai/actions/workflows/build-linux.yml):
+> sign in to GitHub, open the latest green run, and download the
+> `stenoai-linux-<version>` artifact.
 
 Known alpha limitations:
 


### PR DESCRIPTION
Follow-up to #526. Wires the Linux installers into tagged releases — and, first, proves the package actually installs.

Two halves, ordered on purpose: the smoke test runs **before** the attach step, so a package that cannot install can never be published.

## Install smoke test

A `.deb` that builds is not a `.deb` that installs, and the dependency list is the part most likely to be wrong. #526 landed a config where the plausible-looking fix would have declared `libportaudio2` and none of the nine Electron runtime libs, and nothing in CI would have noticed.

- **Asserts the declared `Depends` set explicitly.** Direct regression guard for #526's failure mode — fpm's `customDepends` replaces electron-builder's defaults rather than extending them. Installing on a runner that already has GTK would not notice.
- **Removes `libportaudio2` before installing.** An earlier step installs it so the bundled CLI can run pre-packaging, which would let a package with a wrong dependency list install cleanly and prove nothing. Now apt has to pull it back in via the package.
- **Runs the bundled backend from where an install actually puts it** (`/opt/Steno/resources/stenoai/stenoai`), exercising the PyInstaller bundle against the system's real shared libraries — the crash that motivated the dependency in the first place.
- **Extracts the AppImage** and checks the same payload (no FUSE on the runner, so extract rather than execute).

## Release attach

Mirrors `build-windows.yml`: on a tag push, wait for `build-release.yml` to publish the release, then upload the two installers under versionless aliases the README links. `build-release.yml` is untouched, so the signed macOS path is byte-for-byte unchanged.

40-minute poll rather than Windows' 30 — v0.7.0's release published 29 minutes after its tag, which leaves almost no margin if notarization runs slow. Costs nothing when the release is on time; the loop exits on the first successful poll.

No `latest-linux.yml` is published: electron-builder emits one, but auto-update is not wired on Linux and the README says so.

## Verified on CI, not just locally

Dispatched this workflow against the branch ([run 33777989956](https://github.com/stenolabs/stenoai/actions/runs/33777989956)) — `workflow_dispatch` uses the branch's own copy, so the new steps ran on a real x64 runner before merge. All green, attach correctly skipped (not a tag).

From that run's log:

```
Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0, libportaudio2
Removing libportaudio2:amd64 (19.6.0-1.2build3) ...
Setting up libportaudio2:amd64 (19.6.0-1.2build3) ...      <- pulled back in BY the .deb
dpkg status: install ok installed
{"allGood": false, "checks": [... {"name": "sounddevice", "ok": true, "status": "pass", "detail": "audio recording"} ...]}
```

That `sounddevice: pass` is the check that crashed with `OSError: PortAudio library not found` before #502 added the dependency — so the chain is validated end to end on the real x64 artifact, which nobody had run until now.

Also confirmed the produced names (`stenoAI-linux-0.7.0-amd64.deb`, `stenoAI-linux-0.7.0-x86_64.AppImage`) match what the alias derivation and the README links assume, and that the alias step is idempotent on a re-run (it picks the versioned file, not its own alias).

## What this does NOT prove

**The attach step itself never executed** — it only runs on `refs/tags/v*`, which `workflow_dispatch` cannot simulate. Its structure is copied from the Windows step that demonstrably works (v0.7.0 carries `stenoAI-windows-x64.exe`), and it is guarded by `success()`, so the worst case on the next tag is that Linux assets do not appear. The macOS release is unaffected either way.

The README keeps a transitional note pointing at the workflow artifacts until the first tagged Linux release lands, mirroring what the Windows section carried at the same stage — so the links are honest at every point in time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, Linux installers were only available as workflow artifacts, and CI did not verify that the `.deb` could install. This updates the workflow to test installation before publishing and attach stable Linux installer links to tagged releases, preventing dependency regressions such as #526 from reaching users.

**Install checks**

- Asserts the full `Depends` set, removes preinstalled `libportaudio2`, and confirms apt pulls it back in via the `.deb`.
- Requires dpkg to report a fully installed package, runs the installed backend, checks desktop integration, and extracts the AppImage to validate its bundled payload.
- Parses setup-check output with the app's own parser (`app/setup-check-parse.js`) instead of raw JSON, so log chatter can't false-fail the job, and requires the `sounddevice` check to pass.

**Release publishing**

- Uploads versioned installers plus versionless `.deb` and AppImage aliases after the published release appears, waiting up to 40 minutes.
- Keeps the macOS release flow unchanged, publishes no `latest-linux.yml`, and documents workflow artifacts as a fallback before the first tagged Linux release.

<sup>Written for commit c6fd25b6f0aba8e4471da4a13b56e04663ec7615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

