### PR TITLE
ci(linux): cover real PipeWire capture, not just the bridge

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -649,7 +649,9 @@ jobs:
   # PipeWire runs headless here under dbus-run-session with a null sink, and a
   # known two-tone signal is played into it. That makes "captured only silence"
   # a failure rather than the normal state, which is what the developer-machine
-  # script could never guarantee.
+  # script could never guarantee. This check is intentionally advisory while
+  # its stability on hosted runners is established; promoting it to a required
+  # branch-protection context is a separate maintainer decision.
   linux-loopback-pipewire:
     name: Linux loopback (real PipeWire)
     runs-on: ubuntu-latest
@@ -672,6 +674,7 @@ jobs:
           sudo apt-get install -y pipewire pipewire-pulse wireplumber pulseaudio-utils dbus-x11
 
       - name: Capture real audio through the loopback module
+        timeout-minutes: 5
         run: |
           set -euo pipefail
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"
@@ -713,18 +716,28 @@ jobs:
             pactl set-default-sink steno_test
 
             # getDefaultSinkName() reads the PipeWire "default" metadata
-            # object, not the pulse view of it, so assert on THAT — it is what
-            # the module under test actually parses. wireplumber normally
-            # populates it; set it directly if it has not, so the capture below
-            # tests the module rather than session-manager timing.
+            # object, not the pulse view of it, so require the exact sink value
+            # that the module under test will parse. An existing default for a
+            # different sink is not readiness. wireplumber normally updates it;
+            # set it directly if it has not converged, then verify once more.
             for i in $(seq 1 15); do
-              if pw-metadata -n default 2>/dev/null | grep -q default.audio.sink; then break; fi
+              DEFAULT_METADATA="$(pw-metadata -n default 2>/dev/null || true)"
+              if grep -Eq "default\.audio\.sink.*\"name\"[[:space:]]*:[[:space:]]*\"steno_test\"" \
+                <<< "$DEFAULT_METADATA"; then
+                break
+              fi
               if [ "$i" = 15 ]; then
-                echo "wireplumber did not set a default sink — setting it directly"
+                echo "wireplumber did not select steno_test — setting it directly"
                 pw-metadata -n default 0 default.audio.sink "{\"name\":\"steno_test\"}"
               fi
               sleep 1
             done
+            DEFAULT_METADATA="$(pw-metadata -n default 2>/dev/null || true)"
+            if ! grep -Eq "default\.audio\.sink.*\"name\"[[:space:]]*:[[:space:]]*\"steno_test\"" \
+              <<< "$DEFAULT_METADATA"; then
+              echo "::error::PipeWire default sink did not converge to steno_test"
+              exit 1
+            fi
             echo "--- pipewire default metadata ---"
             pw-metadata -n default || true
             echo "--- sinks ---"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -735,7 +735,11 @@ jobs:
             if [ "$DEFAULT_SINK_READY" != true ]; then
               echo "wireplumber did not select steno_test — setting it directly"
               for i in $(seq 1 5); do
-                pw-metadata -n default 0 default.audio.sink "{\"name\":\"steno_test\"}"
+                if ! pw-metadata -n default 0 default.audio.sink "{\"name\":\"steno_test\"}"; then
+                  echo "pw-metadata set failed on attempt $i — retrying"
+                  sleep 1
+                  continue
+                fi
                 sleep 1
                 DEFAULT_METADATA="$(pw-metadata -n default 2>/dev/null || true)"
                 if grep -Eq "default\.audio\.sink.*\"name\"[[:space:]]*:[[:space:]]*\"steno_test\"" \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -636,6 +636,118 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # Real PipeWire capture, on a runner. Everything else about Linux system
+  # audio is tested against a stub: linux-loopback.t1 drives synthetic PCM
+  # through the renderer bridge with mock IPC, and recording-lifecycle.t2
+  # SKIPS on Linux ("system-audio path unsupported on this host") because a
+  # bare runner has no PipeWire. So the part that actually talks to the OS —
+  # isLinuxLoopbackSupported, getDefaultSinkName's pw-dump parsing, and
+  # pw-record itself — had no automated coverage anywhere, only one
+  # contributor's desktop. #502's own final commit records that the
+  # frame-alignment fix was never confirmed against real audio.
+  #
+  # PipeWire runs headless here under dbus-run-session with a null sink, and a
+  # known two-tone signal is played into it. That makes "captured only silence"
+  # a failure rather than the normal state, which is what the developer-machine
+  # script could never guarantee.
+  linux-loopback-pipewire:
+    name: Linux loopback (real PipeWire)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # pipewire-pulse + pulseaudio-utils give us pactl/paplay to create the
+      # sink and play into it; wireplumber is the session manager that actually
+      # assigns nodes (without it, pw-dump reports no default sink).
+      - name: Install PipeWire
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pipewire pipewire-pulse wireplumber pulseaudio-utils dbus-x11
+
+      - name: Capture real audio through the loopback module
+        run: |
+          set -euo pipefail
+          export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+          sudo mkdir -p "$XDG_RUNTIME_DIR"
+          sudo chown "$(id -u):$(id -g)" "$XDG_RUNTIME_DIR"
+          chmod 700 "$XDG_RUNTIME_DIR"
+
+          node scripts/make-test-tone.js /tmp/tone.wav 20
+
+          # One dbus session for the whole thing: pipewire, the playback and the
+          # capture must share it or they see different graphs.
+          dbus-run-session -- bash -euo pipefail -c '
+            pipewire &
+            pipewire-pulse &
+            wireplumber &
+
+            # Readiness, not a fixed sleep: the graph is up when pactl can talk
+            # to it. Fail loudly rather than proceed into a confusing capture.
+            for i in $(seq 1 30); do
+              if pactl info > /dev/null 2>&1; then echo "PipeWire up after ${i}s"; break; fi
+              if [ "$i" = 30 ]; then echo "::error::PipeWire did not start"; exit 1; fi
+              sleep 1
+            done
+
+            # A null sink stands in for a real output device. Its monitor is
+            # what the app captures, so anything played to it is what we should
+            # get back.
+            pactl load-module module-null-sink sink_name=steno_test \
+              sink_properties=device.description=StenoTest
+            pactl set-default-sink steno_test
+            echo "default sink: $(pactl get-default-sink)"
+
+            # Loop so the tone outlasts the capture window regardless of timing.
+            ( while true; do paplay --device=steno_test /tmp/tone.wav || true; done ) &
+            PLAY_PID=$!
+            trap "kill $PLAY_PID 2>/dev/null || true" EXIT
+            sleep 2
+
+            # The real module: resolves the default sink by name via pw-dump,
+            # spawns pw-record against its monitor, and fails on a silent or
+            # empty capture.
+            node scripts/linux-loopback-poc-demo.js /tmp/captured.pcm
+          '
+
+      - name: Confirm the capture carries both channels
+        run: |
+          set -euo pipefail
+          # The demo script proves "not silence". This proves the STEREO frame
+          # layout survived: the tone is 440Hz left / 880Hz right, so a channel
+          # that is silent, or two channels that are identical, means the frame
+          # alignment or the channel mapping is wrong — the exact failure #502's
+          # createFrameAligner exists to prevent, and which no test has ever
+          # observed against real audio.
+          node -e "
+            const fs = require('fs');
+            const { measurePeakRms } = require('./scripts/measure-pcm');
+            const buf = fs.readFileSync('/tmp/captured.pcm');
+            if (buf.length < 48000 * 4) throw new Error('capture too short: ' + buf.length + ' bytes');
+            if (buf.length % 4 !== 0) throw new Error('capture is not a whole number of stereo frames: ' + buf.length);
+            const frames = buf.length / 4;
+            const left = Buffer.alloc(frames * 2);
+            const right = Buffer.alloc(frames * 2);
+            for (let i = 0; i < frames; i++) {
+              left.writeInt16LE(buf.readInt16LE(i * 4), i * 2);
+              right.writeInt16LE(buf.readInt16LE(i * 4 + 2), i * 2);
+            }
+            const L = measurePeakRms(left);
+            const R = measurePeakRms(right);
+            console.log('left  peak=' + L.peak + ' rms=' + L.rms.toFixed(1));
+            console.log('right peak=' + R.peak + ' rms=' + R.rms.toFixed(1));
+            if (L.peak === 0) throw new Error('left channel is silent');
+            if (R.peak === 0) throw new Error('right channel is silent');
+            if (left.equals(right)) throw new Error('channels are identical — stereo layout collapsed');
+            console.log('PASS: real PipeWire capture, both channels present and distinct.');
+          "
+
   build-backend-linux:
     name: Build backend bundle (Linux)
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -771,7 +771,32 @@ jobs:
             if (L.peak === 0) throw new Error('left channel is silent');
             if (R.peak === 0) throw new Error('right channel is silent');
             if (left.equals(right)) throw new Error('channels are identical — stereo layout collapsed');
-            console.log('PASS: real PipeWire capture, both channels present and distinct.');
+
+            // Which channel is which. Two sines at equal amplitude have equal
+            // peak and near-equal RMS, so the checks above pass just as happily
+            // on a SWAPPED pair. Counting zero crossings identifies the
+            // frequency: the 880Hz channel must cross about twice as often as
+            // the 440Hz one. Cheap, and robust on a clean tone.
+            const crossings = (b) => {
+              let n = 0;
+              for (let i = 1; i < b.length / 2; i++) {
+                const prev = b.readInt16LE((i - 1) * 2);
+                const cur = b.readInt16LE(i * 2);
+                if ((prev < 0 && cur >= 0) || (prev >= 0 && cur < 0)) n++;
+              }
+              return n;
+            };
+            const cl = crossings(left);
+            const cr = crossings(right);
+            const ratio = cr / cl;
+            console.log('zero crossings: left=' + cl + ' right=' + cr + ' ratio=' + ratio.toFixed(2));
+            if (!(ratio > 1.6 && ratio < 2.4)) {
+              throw new Error(
+                'expected right (880Hz) to cross ~2x as often as left (440Hz), got ratio ' +
+                ratio.toFixed(2) + ' — channels are swapped or misaligned'
+              );
+            }
+            console.log('PASS: real PipeWire capture, both channels present, distinct, and correctly ordered.');
           "
 
   build-backend-linux:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -684,15 +684,24 @@ jobs:
           # One dbus session for the whole thing: pipewire, the playback and the
           # capture must share it or they see different graphs.
           dbus-run-session -- bash -euo pipefail -c '
+            # Start in dependency order and WAIT between each. Launching all
+            # three at once races: wireplumber connects before pipewire has its
+            # socket, dies with "disconnected from pipewire", and without a
+            # session manager there is no default-sink metadata — which then
+            # surfaces confusingly as `pactl set-default-sink` returning
+            # "Failure: Not supported".
             pipewire &
-            pipewire-pulse &
-            wireplumber &
-
-            # Readiness, not a fixed sleep: the graph is up when pactl can talk
-            # to it. Fail loudly rather than proceed into a confusing capture.
             for i in $(seq 1 30); do
-              if pactl info > /dev/null 2>&1; then echo "PipeWire up after ${i}s"; break; fi
-              if [ "$i" = 30 ]; then echo "::error::PipeWire did not start"; exit 1; fi
+              if pw-cli info 0 > /dev/null 2>&1; then echo "pipewire up after ${i}s"; break; fi
+              if [ "$i" = 30 ]; then echo "::error::pipewire did not start"; exit 1; fi
+              sleep 1
+            done
+
+            wireplumber &
+            pipewire-pulse &
+            for i in $(seq 1 30); do
+              if pactl info > /dev/null 2>&1; then echo "pulse layer up after ${i}s"; break; fi
+              if [ "$i" = 30 ]; then echo "::error::pipewire-pulse did not start"; exit 1; fi
               sleep 1
             done
 
@@ -702,7 +711,24 @@ jobs:
             pactl load-module module-null-sink sink_name=steno_test \
               sink_properties=device.description=StenoTest
             pactl set-default-sink steno_test
-            echo "default sink: $(pactl get-default-sink)"
+
+            # getDefaultSinkName() reads the PipeWire "default" metadata
+            # object, not the pulse view of it, so assert on THAT — it is what
+            # the module under test actually parses. wireplumber normally
+            # populates it; set it directly if it has not, so the capture below
+            # tests the module rather than session-manager timing.
+            for i in $(seq 1 15); do
+              if pw-metadata -n default 2>/dev/null | grep -q default.audio.sink; then break; fi
+              if [ "$i" = 15 ]; then
+                echo "wireplumber did not set a default sink — setting it directly"
+                pw-metadata -n default 0 default.audio.sink "{\"name\":\"steno_test\"}"
+              fi
+              sleep 1
+            done
+            echo "--- pipewire default metadata ---"
+            pw-metadata -n default || true
+            echo "--- sinks ---"
+            pactl list short sinks
 
             # Loop so the tone outlasts the capture window regardless of timing.
             ( while true; do paplay --device=steno_test /tmp/tone.wav || true; done ) &

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -719,22 +719,34 @@ jobs:
             # object, not the pulse view of it, so require the exact sink value
             # that the module under test will parse. An existing default for a
             # different sink is not readiness. wireplumber normally updates it;
-            # set it directly if it has not converged, then verify once more.
+            # set it directly if it has not converged, then allow the session
+            # manager a short second convergence window before failing.
+            DEFAULT_SINK_READY=false
             for i in $(seq 1 15); do
               DEFAULT_METADATA="$(pw-metadata -n default 2>/dev/null || true)"
               if grep -Eq "default\.audio\.sink.*\"name\"[[:space:]]*:[[:space:]]*\"steno_test\"" \
                 <<< "$DEFAULT_METADATA"; then
+                DEFAULT_SINK_READY=true
                 break
-              fi
-              if [ "$i" = 15 ]; then
-                echo "wireplumber did not select steno_test — setting it directly"
-                pw-metadata -n default 0 default.audio.sink "{\"name\":\"steno_test\"}"
               fi
               sleep 1
             done
-            DEFAULT_METADATA="$(pw-metadata -n default 2>/dev/null || true)"
-            if ! grep -Eq "default\.audio\.sink.*\"name\"[[:space:]]*:[[:space:]]*\"steno_test\"" \
-              <<< "$DEFAULT_METADATA"; then
+
+            if [ "$DEFAULT_SINK_READY" != true ]; then
+              echo "wireplumber did not select steno_test — setting it directly"
+              for i in $(seq 1 5); do
+                pw-metadata -n default 0 default.audio.sink "{\"name\":\"steno_test\"}"
+                sleep 1
+                DEFAULT_METADATA="$(pw-metadata -n default 2>/dev/null || true)"
+                if grep -Eq "default\.audio\.sink.*\"name\"[[:space:]]*:[[:space:]]*\"steno_test\"" \
+                  <<< "$DEFAULT_METADATA"; then
+                  DEFAULT_SINK_READY=true
+                  break
+                fi
+              done
+            fi
+
+            if [ "$DEFAULT_SINK_READY" != true ]; then
               echo "::error::PipeWire default sink did not converge to steno_test"
               exit 1
             fi

--- a/app/renderer/src/components/MainToolbar.tsx
+++ b/app/renderer/src/components/MainToolbar.tsx
@@ -184,10 +184,10 @@ function RecordingOptionsPopover({
   const systemAudioSupport = useSystemAudioSupport();
   // macOS default is on (system_audio_enabled defaults true on darwin).
   const enabled = systemAudio.data ?? true;
-  // macOS only: the toggle chooses mic-only vs mic+system. On Windows the
-  // product decision is always mic+system, so the toggle is hidden (the
-  // renderer forces loopback on there). Also hidden while support is loading
-  // or on a Mac without loopback support (pre-14.4).
+  // macOS only: the toggle chooses mic-only vs mic+system. On Windows and
+  // Linux the product decision is always mic+system, so the toggle is hidden
+  // (the renderer forces loopback on there). Also hidden while support is
+  // loading or on a Mac without loopback support (pre-14.4).
   const showSystemAudio = isMac && systemAudioSupport.data?.supported === true;
   // Controlled so the import action can close the popover when it fires — the
   // import's progress then shows as a processing row in the meeting list,

--- a/app/renderer/src/hooks/useSystemAudioCapture.ts
+++ b/app/renderer/src/hooks/useSystemAudioCapture.ts
@@ -65,8 +65,10 @@ export function useSystemAudioCapture() {
   // runs while status === 'recording' (the mic is captured regardless). The
   // "Record system audio" setting no longer gates whether we record — it only
   // decides whether system LOOPBACK is mixed in:
-  //  - Windows: always on when the OS supports it (the toggle is hidden; the
-  //    product decision is always mic+system).
+  //  - Windows and Linux: always on when the OS supports it (the toggle is
+  //    hidden on both; the product decision is always mic+system). Whether
+  //    that should stay true now it covers a third platform is an open
+  //    question, raised on #502 and not settled.
   //  - macOS: follows the user's setting (default on; off = mic-only).
   // When the support query is still loading we assume supported so a fast user
   // who records before the IPC resolves still gets loopback.
@@ -330,7 +332,10 @@ export function useSystemAudioCapture() {
             // user to a setting that isn't the cause. macOS raises a
             // NotAllowedError from getDisplayMedia when Screen & System Audio
             // Recording is denied. main gates the notification on
-            // notifications_enabled; it's macOS-only (Windows never fired it).
+            // notifications_enabled. This ACQUISITION-failure path stays
+            // mac-gated: Windows has no equivalent permission error. Linux does
+            // send the same notification, but from the onEnded path below (a
+            // live capture dying mid-recording), not from here.
             const accessDenied =
               loopbackErr instanceof DOMException && loopbackErr.name === 'NotAllowedError';
             if (accessDenied && isMac) {

--- a/app/renderer/src/routes/settings/GeneralTab.tsx
+++ b/app/renderer/src/routes/settings/GeneralTab.tsx
@@ -440,8 +440,9 @@ export function GeneralTab() {
         </Select>
       </SettingRow>
 
-      {/* macOS only: chooses mic-only vs mic+system. Windows always records
-          mic+system (toggle hidden), so this control isn't shown there. */}
+      {/* macOS only: chooses mic-only vs mic+system. Windows and Linux always
+          record mic+system (toggle hidden), so this control isn't shown
+          there. */}
       {isMac && (
         <SettingRow label="Record system audio" description={systemAudioDescription}>
           <Switch

--- a/scripts/linux-loopback-poc-demo.js
+++ b/scripts/linux-loopback-poc-demo.js
@@ -5,10 +5,10 @@
 //
 // Two callers. On a Linux desktop, run it directly
 // (`node scripts/linux-loopback-poc-demo.js`) with audio playing, to prove the
-// capture mechanism by hand. In CI it is the linux-loopback-pipewire job in
-// .github/workflows/e2e.yml, which stands up headless PipeWire with a null
-// sink and plays a known tone into it — so "captured only silence" is a
-// failure there rather than the ordinary state of a quiet machine.
+// capture mechanism by hand. In CI the advisory linux-loopback-pipewire job
+// in .github/workflows/e2e.yml stands up headless PipeWire with a null sink
+// and plays a known tone into it — so "captured only silence" is a failure
+// there rather than the ordinary state of a quiet machine.
 //
 // Everything else covering this feature uses a stub: linux-loopback.t1 drives
 // synthetic PCM through the renderer bridge, and recording-lifecycle.t2 skips

--- a/scripts/linux-loopback-poc-demo.js
+++ b/scripts/linux-loopback-poc-demo.js
@@ -1,7 +1,18 @@
 #!/usr/bin/env node
-// Manual runner for the app/linux-loopback.js feasibility spike. Not wired
-// into any build/test target — run directly with `node scripts/linux-loopback-poc-demo.js`
-// on a Linux desktop session to prove the capture mechanism end-to-end.
+// End-to-end check of app/linux-loopback.js against a REAL PipeWire session:
+// resolves the default sink, captures its monitor, and fails on an empty or
+// silent result.
+//
+// Two callers. On a Linux desktop, run it directly
+// (`node scripts/linux-loopback-poc-demo.js`) with audio playing, to prove the
+// capture mechanism by hand. In CI it is the linux-loopback-pipewire job in
+// .github/workflows/e2e.yml, which stands up headless PipeWire with a null
+// sink and plays a known tone into it — so "captured only silence" is a
+// failure there rather than the ordinary state of a quiet machine.
+//
+// Everything else covering this feature uses a stub: linux-loopback.t1 drives
+// synthetic PCM through the renderer bridge, and recording-lifecycle.t2 skips
+// on Linux. This is the only place pw-record itself runs under test.
 
 const fs = require('fs');
 const path = require('path');

--- a/scripts/make-test-tone.js
+++ b/scripts/make-test-tone.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Writes a stereo 16-bit WAV of a steady sine tone, for the PipeWire loopback
+// CI check (.github/workflows/e2e.yml, linux-loopback-pipewire). Dependency-free
+// on purpose: the job needs a known non-silent signal to play into the test
+// sink, and pulling ffmpeg in just to synthesise one would be a heavier
+// dependency than the twelve lines it takes to write the samples.
+//
+// Left and right carry DIFFERENT frequencies so a channel swap or a
+// frame-alignment slip is detectable in the captured PCM, not just presence of
+// sound. See scripts/measure-pcm.js for the analysis side.
+const fs = require('fs');
+
+const RATE = 48000;
+const SECONDS = Number(process.argv[3] || 10);
+const LEFT_HZ = 440;
+const RIGHT_HZ = 880;
+const AMPLITUDE = 0.35 * 32767; // well clear of silence, well clear of clipping
+
+const frames = RATE * SECONDS;
+const data = Buffer.alloc(frames * 4); // 2 channels * 2 bytes
+for (let i = 0; i < frames; i++) {
+  const t = i / RATE;
+  data.writeInt16LE(Math.round(AMPLITUDE * Math.sin(2 * Math.PI * LEFT_HZ * t)), i * 4);
+  data.writeInt16LE(Math.round(AMPLITUDE * Math.sin(2 * Math.PI * RIGHT_HZ * t)), i * 4 + 2);
+}
+
+const header = Buffer.alloc(44);
+header.write('RIFF', 0);
+header.writeUInt32LE(36 + data.length, 4);
+header.write('WAVE', 8);
+header.write('fmt ', 12);
+header.writeUInt32LE(16, 16);        // PCM chunk size
+header.writeUInt16LE(1, 20);         // PCM
+header.writeUInt16LE(2, 22);         // stereo
+header.writeUInt32LE(RATE, 24);
+header.writeUInt32LE(RATE * 4, 28);  // byte rate
+header.writeUInt16LE(4, 32);         // block align
+header.writeUInt16LE(16, 34);        // bits per sample
+header.write('data', 36);
+header.writeUInt32LE(data.length, 40);
+
+const out = process.argv[2] || 'tone.wav';
+fs.writeFileSync(out, Buffer.concat([header, data]));
+console.log(`wrote ${out}: ${SECONDS}s stereo ${LEFT_HZ}Hz/${RIGHT_HZ}Hz @ ${RATE}Hz`);


### PR DESCRIPTION
Closes the gap found while checking what our Linux CI actually proves.

**The gap.** `t2-linux` is green, but the Linux-specific feature is not tested. From #527's run:

```
[t2] SKIPPED recording lifecycle: system-audio (renderer-driven) path unsupported on this host.
```

`recording-lifecycle.t2` skips on Linux because a bare runner has no PipeWire. The three `linux-loopback.t1` specs pass, but they are mock-IPC — they feed synthetic PCM over the channel and test the renderer half; `pw-record` never runs. Their own header says so: *"Real system audio needs PipeWire and a live sink, which a CI runner has neither of."*

So `isLinuxLoopbackSupported`, `getDefaultSinkName`'s pw-dump parsing, and `pw-record` itself had coverage nowhere. And #502's final commit records that even the contributor's manual check couldn't confirm the frame-alignment fix: *"NOT re-verified with real captured audio — this machine's PipeWire monitor is currently returning silence for raw `pw-record` too."*

**What this does.** Runs PipeWire headless under `dbus-run-session` with a null sink, plays a known tone into it, and captures it back through the real `app/linux-loopback.js`. Because the signal is known, *captured only silence* is a failure rather than the ordinary state of a quiet machine.

The tone is **440Hz left / 880Hz right**, so the assertion goes past "there was sound": the captured PCM is split and both channels must be non-silent **and distinct**. A collapsed or swapped stereo layout is precisely what a frame-alignment slip produces — this is the first test anywhere that could observe that on real audio.

**Notes**

- Promotes `scripts/linux-loopback-poc-demo.js` from a manual spike runner to the CI gate. Header updated; it still works standalone on a desktop.
- `make-test-tone.js` is dependency-free rather than pulling ffmpeg in to synthesise a sine wave.
- Readiness is polled via `pactl info`, not a fixed sleep.

**Risk.** Headless PipeWire on a GitHub runner is the unproven part — this PR's own CI run is the experiment. If it turns out flaky rather than merely working, it should be quarantined rather than left to erode trust in the suite; I'd rather find that out here than after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Linux CI job that captures real audio through PipeWire, closing the gap where the OS-facing loopback code (sink resolution via `pw-dump`, `pw-record` itself) had no automated coverage. Also corrects four renderer comments that described system-audio as mac-vs-Windows now that Linux follows the Windows branch; comments only, no behavior change.

- Runs PipeWire headless under `dbus-run-session` with a null sink, plays a 440Hz/880Hz stereo tone, and captures it back through the real `app/linux-loopback.js`.
- Because the signal is known, a silent capture fails rather than being the normal quiet-machine state; zero-crossing counts also confirm left is 440Hz and right is 880Hz, catching swapped or collapsed stereo.
- Promotes `scripts/linux-loopback-poc-demo.js` from a manual spike to the CI gate and adds `scripts/make-test-tone.js` as a dependency-free tone generator.
- The first CI run failed on a service startup race; the job now starts PipeWire in dependency order, waits for each layer, and asserts on the PipeWire `default` metadata that `getDefaultSinkName()` parses, retrying transient metadata writes until convergence and setting the sink directly if needed.
- Headless PipeWire on a runner is still unproven; if the job turns out flaky it should be quarantined rather than left to erode trust in the suite.

<sup>Written for commit 2517c525e5b93c2fc06547f2bb096ac0bad7852e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

