### PR TITLE
fix(linux): preserve Ollama GPU backends

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -79,6 +79,12 @@ jobs:
           pyinstaller stenoai.spec --noconfirm
           ls -lh dist/stenoai
 
+      - name: Verify bundled Ollama GPU backends
+        run: |
+          output=$(python scripts/verify_ollama_gpu_bundle.py bin dist/stenoai)
+          echo "$output"
+          echo "$output" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Smoke-test bundled CLI
         run: |
           ./dist/stenoai/stenoai --help
@@ -184,6 +190,7 @@ jobs:
           # the crash that motivated adding it (#502) was exactly this.
           BACKEND=/opt/Steno/resources/stenoai/stenoai
           test -x "$BACKEND"
+          python scripts/verify_ollama_gpu_bundle.py bin /opt/Steno/resources/stenoai
           "$BACKEND" --help > /dev/null
           # setup-check exits non-zero with no model downloaded, which is
           # expected on a fresh runner; we only require that it runs to
@@ -228,11 +235,21 @@ jobs:
           "$APPIMAGE" --appimage-extract > /dev/null
           test -x squashfs-root/stenoai
           test -x squashfs-root/resources/stenoai/stenoai
+          python scripts/verify_ollama_gpu_bundle.py bin squashfs-root/resources/stenoai
           rm -rf squashfs-root
 
       - name: Show built artifacts
         if: always()
-        run: ls -lh app/dist
+        run: |
+          ls -lh app/dist
+          for artifact in app/dist/*.deb app/dist/*.AppImage; do
+            [ -f "$artifact" ] || continue
+            bytes=$(stat --format=%s "$artifact")
+            human=$(du -h "$artifact" | cut -f1)
+            line="$(basename "$artifact"): ${bytes} bytes (${human})"
+            echo "$line"
+            echo "$line" >> "$GITHUB_STEP_SUMMARY"
+          done
 
       - name: Upload Linux artifacts
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -862,6 +862,9 @@ jobs:
       - name: Build backend with PyInstaller
         run: pyinstaller stenoai.spec --noconfirm
 
+      - name: Verify bundled Ollama GPU backends
+        run: python scripts/verify_ollama_gpu_bundle.py bin dist/stenoai
+
       - name: Upload backend bundle
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/verify_ollama_gpu_bundle.py
+++ b/scripts/verify_ollama_gpu_bundle.py
@@ -57,6 +57,21 @@ def _all_files(root: Path) -> list[Path]:
     return [path for path in root.rglob("*") if path.is_file()]
 
 
+def _payload_problem(path: Path, root: Path) -> Optional[str]:
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved_path = path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return "missing or broken"
+    if resolved_root not in resolved_path.parents:
+        return "resolves outside the Ollama tree"
+    if not resolved_path.is_file():
+        return "not a file"
+    if resolved_path.stat().st_size == 0:
+        return "empty"
+    return None
+
+
 def verify_ollama_gpu_bundle(
     source_root: Path,
     bundle_root: Path,
@@ -71,6 +86,17 @@ def verify_ollama_gpu_bundle(
         raise FileNotFoundError(f"Bundled Ollama tree not found: {target_root}")
 
     source_payloads = _payload_files(source_root)
+    invalid_source_payloads = [
+        f"{path.relative_to(source_root).as_posix()} ({problem})"
+        for path in source_payloads
+        if (problem := _payload_problem(path, source_root)) is not None
+    ]
+    if invalid_source_payloads:
+        raise FileNotFoundError(
+            "Downloaded Ollama GPU payload is invalid: "
+            + ", ".join(invalid_source_payloads)
+        )
+
     source_families = {
         family
         for path in source_payloads
@@ -89,27 +115,21 @@ def verify_ollama_gpu_bundle(
             + ", ".join(missing_families)
         )
 
-    missing_payloads: list[str] = []
-    empty_payloads: list[str] = []
+    invalid_target_payloads: list[str] = []
     target_payloads: list[Path] = []
     for source_path in source_payloads:
         relative_path = source_path.relative_to(source_root)
         target_path = target_root / relative_path
-        if not target_path.exists():
-            missing_payloads.append(relative_path.as_posix())
-            continue
-        if not target_path.is_file() or target_path.stat().st_size == 0:
-            empty_payloads.append(relative_path.as_posix())
+        if (problem := _payload_problem(target_path, target_root)) is not None:
+            invalid_target_payloads.append(f"{relative_path.as_posix()} ({problem})")
             continue
         target_payloads.append(target_path)
 
-    if missing_payloads or empty_payloads:
-        details = []
-        if missing_payloads:
-            details.append("missing or broken: " + ", ".join(missing_payloads))
-        if empty_payloads:
-            details.append("empty or not a file: " + ", ".join(empty_payloads))
-        raise FileNotFoundError("Bundled Ollama GPU payload is incomplete; " + "; ".join(details))
+    if invalid_target_payloads:
+        raise FileNotFoundError(
+            "Bundled Ollama GPU payload is incomplete: "
+            + ", ".join(invalid_target_payloads)
+        )
 
     return {
         "families": tuple(sorted(source_families)),

--- a/scripts/verify_ollama_gpu_bundle.py
+++ b/scripts/verify_ollama_gpu_bundle.py
@@ -1,0 +1,147 @@
+"""Verify that Linux bundles preserve Ollama's GPU backends."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Optional
+
+
+_GPU_FAMILIES = ("cuda", "rocm", "vulkan")
+_GPU_LIBRARY_PREFIXES = {
+    "cuda": "libggml-cuda.so",
+    "rocm": "libggml-hip.so",
+    "vulkan": "libggml-vulkan.so",
+}
+
+
+def ollama_gpu_family(relative_path: os.PathLike[str] | str) -> Optional[str]:
+    """Return the Ollama GPU family represented by a relative payload path."""
+    parts = PurePosixPath(str(relative_path).replace("\\", "/").lower()).parts
+    for index in range(len(parts) - 2):
+        if parts[index : index + 2] != ("lib", "ollama"):
+            continue
+        runner_dir = parts[index + 2]
+        for family in _GPU_FAMILIES:
+            if runner_dir == family or runner_dir.startswith(f"{family}_"):
+                return family
+    return None
+
+
+def should_prune_ollama_gpu_path(
+    relative_path: os.PathLike[str] | str,
+    *,
+    platform: str = sys.platform,
+) -> bool:
+    """Keep GPU backends on Linux/macOS and prune them on Windows only."""
+    return platform == "win32" and ollama_gpu_family(relative_path) is not None
+
+
+def _payload_files(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if (path.is_file() or path.is_symlink())
+        and ollama_gpu_family(path.relative_to(root)) is not None
+    )
+
+
+def _tree_bytes(paths: Iterable[Path]) -> int:
+    """Return logical bytes, following valid symlinks like the loader does."""
+    return sum(path.stat().st_size for path in paths)
+
+
+def _all_files(root: Path) -> list[Path]:
+    return [path for path in root.rglob("*") if path.is_file()]
+
+
+def verify_ollama_gpu_bundle(
+    source_root: Path,
+    bundle_root: Path,
+    *,
+    required_families: tuple[str, ...] = ("cuda",),
+) -> dict[str, object]:
+    """Require every source GPU payload in a PyInstaller bundle."""
+    target_root = bundle_root / "_internal" / "ollama"
+    if not source_root.is_dir():
+        raise FileNotFoundError(f"Ollama source tree not found: {source_root}")
+    if not target_root.is_dir():
+        raise FileNotFoundError(f"Bundled Ollama tree not found: {target_root}")
+
+    source_payloads = _payload_files(source_root)
+    source_families = {
+        family
+        for path in source_payloads
+        if (family := ollama_gpu_family(path.relative_to(source_root))) is not None
+    }
+    source_backend_families = {
+        family
+        for path in source_payloads
+        if (family := ollama_gpu_family(path.relative_to(source_root))) is not None
+        and path.name.startswith(_GPU_LIBRARY_PREFIXES[family])
+    }
+    missing_families = sorted(set(required_families) - source_backend_families)
+    if missing_families:
+        raise FileNotFoundError(
+            "Downloaded Ollama tree has no payload for required GPU families: "
+            + ", ".join(missing_families)
+        )
+
+    missing_payloads: list[str] = []
+    empty_payloads: list[str] = []
+    target_payloads: list[Path] = []
+    for source_path in source_payloads:
+        relative_path = source_path.relative_to(source_root)
+        target_path = target_root / relative_path
+        if not target_path.exists():
+            missing_payloads.append(relative_path.as_posix())
+            continue
+        if not target_path.is_file() or target_path.stat().st_size == 0:
+            empty_payloads.append(relative_path.as_posix())
+            continue
+        target_payloads.append(target_path)
+
+    if missing_payloads or empty_payloads:
+        details = []
+        if missing_payloads:
+            details.append("missing or broken: " + ", ".join(missing_payloads))
+        if empty_payloads:
+            details.append("empty or not a file: " + ", ".join(empty_payloads))
+        raise FileNotFoundError("Bundled Ollama GPU payload is incomplete; " + "; ".join(details))
+
+    return {
+        "families": tuple(sorted(source_families)),
+        "payload_count": len(target_payloads),
+        "gpu_logical_bytes": _tree_bytes(target_payloads),
+        "ollama_logical_bytes": _tree_bytes(_all_files(target_root)),
+        "bundle_logical_bytes": _tree_bytes(_all_files(bundle_root)),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source_root", type=Path, help="Downloaded Ollama tree, normally bin/")
+    parser.add_argument("bundle_root", type=Path, help="PyInstaller bundle root")
+    args = parser.parse_args()
+
+    try:
+        result = verify_ollama_gpu_bundle(args.source_root, args.bundle_root)
+    except (FileNotFoundError, OSError) as error:
+        print(f"verify_ollama_gpu_bundle: FAIL - {error}", file=sys.stderr)
+        return 1
+
+    families = ",".join(result["families"])
+    print(
+        "verify_ollama_gpu_bundle: PASS - "
+        f"families={families}; payloads={result['payload_count']}; "
+        f"gpu_logical_bytes={result['gpu_logical_bytes']}; "
+        f"ollama_logical_bytes={result['ollama_logical_bytes']}; "
+        f"bundle_logical_bytes={result['bundle_logical_bytes']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stenoai.spec
+++ b/stenoai.spec
@@ -37,6 +37,7 @@ if SPECPATH not in sys.path:
     sys.path.insert(0, SPECPATH)
 
 from scripts.diarize_bundle_guard import require_diarize_sidecar
+from scripts.verify_ollama_gpu_bundle import should_prune_ollama_gpu_path
 
 # Apple Silicon uses parakeet-mlx for ASR; Windows / Linux use onnx-asr via
 # ONNX Runtime. The two backends live in src/_parakeet_{mlx,onnx}.py and
@@ -213,22 +214,21 @@ for pkg in _DYLIB_PKGS:
     except Exception:
         pass
 
-# Bundle Ollama binary and libraries.
+# Bundle Ollama binary and libraries. Linux keeps GPU backends, Windows prunes
+# them for installer limits, and macOS uses its separate Metal runner layout.
 # Walk bin/ recursively — Ollama for Windows ships its runner libs under
 # lib/ollama/ that must be preserved relative to ollama.exe.
 # Ollama's Windows bundle ships GPU runner libs under lib/ollama/. As of
-# v0.30.8 that's lib/ollama/{cuda_v12,cuda_v13,vulkan} (rocm is no longer
-# shipped). They're NVIDIA-/discrete-GPU-only and add multiple GB
+# v0.31.1 that's lib/ollama/{cuda_v12,cuda_v13,vulkan} (rocm is a separate
+# archive). They're NVIDIA-/discrete-GPU-only and add multiple GB
 # (each cuda_v*/ggml-cuda.dll is ~1.6 GB) — dead weight on the CPU-only path:
 # transcription is ONNX-CPU, and the bundled Ollama summarises on the CPU
 # runner (ggml-cpu-*.dll / ggml-base.dll, which we keep). Skipping them keeps
 # the Windows bundle small enough for the NSIS installer to build (makensis
 # can't mmap a multi-GB app .7z). GPU acceleration for NVIDIA users is a
-# tracked follow-up (separate build/pack). The substring markers match any
-# cuda_vNN dir; rocm is kept as a defensive marker in case a future Ollama
-# re-adds it. No-op on macOS — these dirs don't exist there (Metal is built
-# into the darwin binary + its mlx_metal_v3/ runner, which we keep).
-_OLLAMA_GPU_MARKERS = ('lib/ollama/cuda', 'lib/ollama/rocm', 'lib/ollama/vulkan')
+# tracked follow-up (separate build/pack). Linux must retain these libraries:
+# its standard Ollama archive uses them for GPU inference. macOS remains a
+# no-op because Metal is built into its binary + mlx_metal_v3/ runner.
 
 # On darwin, Ollama's runner tree is routed into a COLLECT-stage DATA TOC
 # (`ollama_datas`) instead of `Analysis.binaries`. This is load-bearing, not a
@@ -262,8 +262,8 @@ if os.path.exists(ollama_bin_dir):
             filepath = os.path.join(root, filename)
             rel = os.path.relpath(filepath, ollama_bin_dir)
             rel_fs = rel.replace(os.sep, '/').lower()
-            if any(marker in rel_fs for marker in _OLLAMA_GPU_MARKERS):
-                continue  # skip GPU runner libs (CUDA/ROCm/Vulkan)
+            if should_prune_ollama_gpu_path(rel_fs, platform=sys.platform):
+                continue  # Windows only: skip GPU runner libs
             rel_dir = os.path.dirname(rel)
             base = os.path.basename(filename).lower()
             if base in ('ffmpeg', 'ffmpeg.exe'):

--- a/tests/test_verify_ollama_gpu_bundle.py
+++ b/tests/test_verify_ollama_gpu_bundle.py
@@ -1,0 +1,119 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.verify_ollama_gpu_bundle import (
+    ollama_gpu_family,
+    should_prune_ollama_gpu_path,
+    verify_ollama_gpu_bundle,
+)
+
+
+class OllamaGpuPathTests(unittest.TestCase):
+    def test_recognizes_supported_gpu_directories(self):
+        self.assertEqual(ollama_gpu_family("lib/ollama/cuda_v12/libggml-cuda.so"), "cuda")
+        self.assertEqual(ollama_gpu_family("lib/ollama/rocm/libggml-hip.so"), "rocm")
+        self.assertEqual(ollama_gpu_family("lib/ollama/vulkan/libggml-vulkan.so"), "vulkan")
+
+    def test_does_not_treat_cpu_or_similar_names_as_gpu_payloads(self):
+        self.assertIsNone(ollama_gpu_family("lib/ollama/libggml-cpu.so"))
+        self.assertIsNone(ollama_gpu_family("lib/ollama/vulkanish/library.so"))
+
+    def test_windows_prunes_gpu_payloads_only(self):
+        self.assertTrue(
+            should_prune_ollama_gpu_path(
+                "lib\\ollama\\cuda_v13\\ggml-cuda.dll",
+                platform="win32",
+            )
+        )
+        self.assertFalse(
+            should_prune_ollama_gpu_path("lib/ollama/ggml-cpu.dll", platform="win32")
+        )
+
+    def test_linux_and_macos_preserve_gpu_payloads(self):
+        path = "lib/ollama/cuda_v12/libggml-cuda.so"
+        self.assertFalse(should_prune_ollama_gpu_path(path, platform="linux"))
+        self.assertFalse(should_prune_ollama_gpu_path(path, platform="darwin"))
+
+
+class OllamaGpuBundleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        root = Path(self.temp_dir.name)
+        self.source = root / "source"
+        self.bundle = root / "bundle"
+        self.target = self.bundle / "_internal" / "ollama"
+
+        for relative_path in (
+            "lib/ollama/cuda_v12/libggml-cuda.so",
+            "lib/ollama/vulkan/libggml-vulkan.so",
+        ):
+            source_path = self.source / relative_path
+            target_path = self.target / relative_path
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            source_path.write_bytes(b"source payload")
+            target_path.write_bytes(b"bundled payload")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_accepts_every_gpu_payload_offered_by_source(self):
+        result = verify_ollama_gpu_bundle(self.source, self.bundle)
+
+        self.assertEqual(result["families"], ("cuda", "vulkan"))
+        self.assertEqual(result["payload_count"], 2)
+        self.assertGreater(result["gpu_logical_bytes"], 0)
+
+    def test_accepts_valid_relative_gpu_symlink(self):
+        cuda_dir = self.source / "lib/ollama/cuda_v12"
+        source_versioned = cuda_dir / "libggml-cuda.so.0"
+        source_versioned.write_bytes(b"source versioned payload")
+        (cuda_dir / "libggml-cuda.so.link").symlink_to(source_versioned.name)
+
+        target_cuda_dir = self.target / "lib/ollama/cuda_v12"
+        target_versioned = target_cuda_dir / "libggml-cuda.so.0"
+        target_versioned.write_bytes(b"bundled versioned payload")
+        (target_cuda_dir / "libggml-cuda.so.link").symlink_to(target_versioned.name)
+
+        result = verify_ollama_gpu_bundle(self.source, self.bundle)
+
+        self.assertEqual(result["payload_count"], 4)
+
+    def test_rejects_missing_gpu_payload(self):
+        (self.target / "lib/ollama/vulkan/libggml-vulkan.so").unlink()
+
+        with self.assertRaisesRegex(FileNotFoundError, "vulkan/libggml-vulkan.so"):
+            verify_ollama_gpu_bundle(self.source, self.bundle)
+
+    def test_rejects_empty_gpu_payload(self):
+        (self.target / "lib/ollama/cuda_v12/libggml-cuda.so").write_bytes(b"")
+
+        with self.assertRaisesRegex(FileNotFoundError, "empty"):
+            verify_ollama_gpu_bundle(self.source, self.bundle)
+
+    def test_rejects_broken_gpu_symlink(self):
+        target = self.target / "lib/ollama/cuda_v12/libggml-cuda.so"
+        target.unlink()
+        target.symlink_to("missing.so")
+
+        with self.assertRaisesRegex(FileNotFoundError, "missing or broken"):
+            verify_ollama_gpu_bundle(self.source, self.bundle)
+
+    def test_rejects_source_without_required_cuda_payload(self):
+        cuda_source = self.source / "lib/ollama/cuda_v12/libggml-cuda.so"
+        cuda_source.unlink()
+
+        with self.assertRaisesRegex(FileNotFoundError, "required GPU families: cuda"):
+            verify_ollama_gpu_bundle(self.source, self.bundle)
+
+    def test_rejects_cuda_directory_without_cuda_backend_library(self):
+        cuda_source = self.source / "lib/ollama/cuda_v12/libggml-cuda.so"
+        cuda_source.rename(cuda_source.with_name("README"))
+
+        with self.assertRaisesRegex(FileNotFoundError, "required GPU families: cuda"):
+            verify_ollama_gpu_bundle(self.source, self.bundle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_ollama_gpu_bundle.py
+++ b/tests/test_verify_ollama_gpu_bundle.py
@@ -63,7 +63,9 @@ class OllamaGpuBundleTests(unittest.TestCase):
 
         self.assertEqual(result["families"], ("cuda", "vulkan"))
         self.assertEqual(result["payload_count"], 2)
-        self.assertGreater(result["gpu_logical_bytes"], 0)
+        self.assertEqual(result["gpu_logical_bytes"], 30)
+        self.assertEqual(result["ollama_logical_bytes"], 30)
+        self.assertEqual(result["bundle_logical_bytes"], 30)
 
     def test_accepts_valid_relative_gpu_symlink(self):
         cuda_dir = self.source / "lib/ollama/cuda_v12"
@@ -98,6 +100,23 @@ class OllamaGpuBundleTests(unittest.TestCase):
         target.symlink_to("missing.so")
 
         with self.assertRaisesRegex(FileNotFoundError, "missing or broken"):
+            verify_ollama_gpu_bundle(self.source, self.bundle)
+
+    def test_rejects_gpu_symlink_that_escapes_ollama_tree(self):
+        outside = self.bundle.parent / "outside.so"
+        outside.write_bytes(b"outside payload")
+        target = self.target / "lib/ollama/cuda_v12/libggml-cuda.so"
+        target.unlink()
+        target.symlink_to(outside)
+
+        with self.assertRaisesRegex(FileNotFoundError, "outside the Ollama tree"):
+            verify_ollama_gpu_bundle(self.source, self.bundle)
+
+    def test_rejects_invalid_source_payload(self):
+        source = self.source / "lib/ollama/cuda_v12/libggml-cuda.so"
+        source.write_bytes(b"")
+
+        with self.assertRaisesRegex(FileNotFoundError, "Downloaded.*invalid.*empty"):
             verify_ollama_gpu_bundle(self.source, self.bundle)
 
     def test_rejects_source_without_required_cuda_payload(self):


### PR DESCRIPTION
Linux packages were dropping Ollama's GPU libraries through a pruning rule intended for Windows installer limits. This keeps those libraries on Linux and checks that downloaded GPU payloads survive PyInstaller, deb installation and AppImage extraction. Windows pruning and macOS Metal packaging remain unchanged.

The installer verification follows the current StenoAI installation path through the backend path. Tests reject missing, empty, broken and escaping payloads.

The earlier [installer build](https://github.com/stenolabs/stenoai/actions/runs/33920520077) preserved 15 CUDA/Vulkan payloads. Its packages were about 2.5 GB for deb and 1.9 GB for AppImage. This PR retains bundled Ollama GPU support; a separately installed runtime remains separate work.

After integrating current main, all 13 focused Python tests, the privacy guard and Ruff ratchet passed. Independent integration review found no blockers. Updated CI is pending. These checks establish package completeness, not GPU compatibility or actual inference on every Linux machine; no fresh Linux GPU runtime test was performed on the local Mac.

Closes #532.
