### PR TITLE
fix(ci): wait for PipeWire default sink readiness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -665,6 +665,9 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Test PipeWire readiness retries
+        run: node --test scripts/wait-pipewire-sink.test.js
+
       # pipewire-pulse + pulseaudio-utils give us pactl/paplay to create the
       # sink and play into it; wireplumber is the session manager that actually
       # assigns nodes (without it, pw-dump reports no default sink).
@@ -713,47 +716,10 @@ jobs:
             # get back.
             pactl load-module module-null-sink sink_name=steno_test \
               sink_properties=device.description=StenoTest
-            pactl set-default-sink steno_test
-
-            # getDefaultSinkName() reads the PipeWire "default" metadata
-            # object, not the pulse view of it, so require the exact sink value
-            # that the module under test will parse. An existing default for a
-            # different sink is not readiness. wireplumber normally updates it;
-            # set it directly if it has not converged, then allow the session
-            # manager a short second convergence window before failing.
-            DEFAULT_SINK_READY=false
-            for i in $(seq 1 15); do
-              DEFAULT_METADATA="$(pw-metadata -n default 2>/dev/null || true)"
-              if grep -Eq "default\.audio\.sink.*\"name\"[[:space:]]*:[[:space:]]*\"steno_test\"" \
-                <<< "$DEFAULT_METADATA"; then
-                DEFAULT_SINK_READY=true
-                break
-              fi
-              sleep 1
-            done
-
-            if [ "$DEFAULT_SINK_READY" != true ]; then
-              echo "wireplumber did not select steno_test — setting it directly"
-              for i in $(seq 1 5); do
-                if ! pw-metadata -n default 0 default.audio.sink "{\"name\":\"steno_test\"}"; then
-                  echo "pw-metadata set failed on attempt $i — retrying"
-                  sleep 1
-                  continue
-                fi
-                sleep 1
-                DEFAULT_METADATA="$(pw-metadata -n default 2>/dev/null || true)"
-                if grep -Eq "default\.audio\.sink.*\"name\"[[:space:]]*:[[:space:]]*\"steno_test\"" \
-                  <<< "$DEFAULT_METADATA"; then
-                  DEFAULT_SINK_READY=true
-                  break
-                fi
-              done
-            fi
-
-            if [ "$DEFAULT_SINK_READY" != true ]; then
-              echo "::error::PipeWire default sink did not converge to steno_test"
-              exit 1
-            fi
+            # Pulse can answer before WirePlumber accepts a default sink.
+            # Retry the setter and check the active metadata via the same
+            # getDefaultSinkName() reader used by the capture below.
+            bash scripts/wait-pipewire-sink.sh steno_test
             echo "--- pipewire default metadata ---"
             pw-metadata -n default || true
             echo "--- sinks ---"

--- a/scripts/wait-pipewire-sink.sh
+++ b/scripts/wait-pipewire-sink.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Wait for both PulseAudio's setter and the app's PipeWire reader to agree.
+set -euo pipefail
+
+sink="${1:?usage: wait-pipewire-sink.sh SINK}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# pactl info can succeed before WirePlumber creates its default metadata.
+# Retry the setter too: under set -e, a single early "Not supported" would
+# otherwise abort the job before it ever reaches the readiness check.
+for attempt in $(seq 1 30); do
+  if pactl set-default-sink "$sink"; then
+    if node - "$script_dir/../app/linux-loopback.js" "$sink" <<'NODE'
+const { getDefaultSinkName } = require(process.argv[2]);
+try {
+  const actual = getDefaultSinkName();
+  if (actual !== process.argv[3]) {
+    console.error(`Waiting for default sink ${process.argv[3]}; currently ${actual}`);
+    process.exitCode = 1;
+  }
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}
+NODE
+    then
+      echo "PipeWire default sink ready: $sink (attempt $attempt)"
+      exit 0
+    fi
+  fi
+  if [ "$attempt" -lt 30 ]; then sleep 1; fi
+done
+
+echo "::error::PipeWire default sink did not converge to $sink" >&2
+pactl list short sinks >&2 || true
+pw-dump >&2 || true
+exit 1

--- a/scripts/wait-pipewire-sink.test.js
+++ b/scripts/wait-pipewire-sink.test.js
@@ -1,0 +1,81 @@
+// Exercise the real shell helper and the app's metadata reader with fake OS tools.
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function run(t, { setterFailures = 0, staleReads = 0, dumpFailures = 0 } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'steno-pipewire-readiness-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const tool = `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const name = path.basename(process.argv[1]);
+const counter = path.join(${JSON.stringify(dir)}, name + '.calls');
+const n = fs.existsSync(counter) ? Number(fs.readFileSync(counter, 'utf8')) + 1 : 1;
+fs.writeFileSync(counter, String(n));
+if (name === 'pactl') {
+  if (process.argv[2] === 'list') process.exit(0);
+  if (n <= ${setterFailures}) { console.error('Failure: Not supported'); process.exit(1); }
+} else if (name === 'pw-dump') {
+  if (n <= ${dumpFailures}) process.exit(1);
+  console.log(JSON.stringify([{
+    type: 'PipeWire:Interface:Metadata', props: { 'metadata.name': 'default' },
+    metadata: [
+      { key: 'default.configured.audio.sink', value: { name: 'steno_test' } },
+      { key: 'default.audio.sink', value: { name: n <= ${staleReads} ? 'other_sink' : 'steno_test' } },
+    ],
+  }]));
+}
+`;
+  for (const name of ['pactl', 'pw-dump', 'sleep']) {
+    fs.writeFileSync(path.join(dir, name), tool, { mode: 0o755 });
+  }
+  const result = spawnSync('bash', [path.join(__dirname, 'wait-pipewire-sink.sh'), 'steno_test'], {
+    env: { ...process.env, PATH: dir + path.delimiter + process.env.PATH },
+    encoding: 'utf8',
+    timeout: 20000,
+  });
+  assert.ifError(result.error);
+  return result;
+}
+
+test('accepts the selected sink when both interfaces are ready', (t) => {
+  const result = run(t);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /ready: steno_test \(attempt 1\)/);
+});
+
+test('survives Not supported until WirePlumber accepts the setter', (t) => {
+  const result = run(t, { setterFailures: 2 });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /Failure: Not supported/);
+  assert.match(result.stdout, /attempt 3/);
+});
+
+test('waits for the active sink even when the configured sink already matches', (t) => {
+  const result = run(t, { staleReads: 2 });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /attempt 3/);
+});
+
+test('retries a transient PipeWire read failure', (t) => {
+  const result = run(t, { dumpFailures: 1 });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /attempt 2/);
+});
+
+test('fails after bounded retries if the setter never becomes ready', (t) => {
+  const result = run(t, { setterFailures: 100 });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /::error::PipeWire default sink did not converge/);
+  assert.doesNotMatch(result.stdout, /ready:/);
+});
+
+test('fails when the active sink never matches', (t) => {
+  const result = run(t, { staleReads: 100 });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /::error::PipeWire default sink did not converge/);
+});


### PR DESCRIPTION
The Linux loopback check could abort with `Failure: Not supported` while WirePlumber was still starting. PulseAudio was responding, but `pactl set-default-sink` was not ready yet.

The check now retries the setter and waits until the app's `getDefaultSinkName()` reads the expected sink. Persistent failures still fail the job and print diagnostics.

Tests cover delayed startup, stale sink metadata, transient read errors and permanent failure. [CI passed](https://github.com/stenolabs/stenoai/actions/runs/33948691171), including the real PipeWire capture check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Linux loopback CI check so it no longer fails when PulseAudio responds before WirePlumber accepts the default sink.

**Bug Fixes**
- Replaces the inline default-sink convergence logic with a retrying helper that also validates through the app's own `getDefaultSinkName()` reader.
- Adds Node tests for setter retries, stale active metadata, transient read failures, and permanent failure.

<sup>Written for commit d78950b5c5c7a3acd30e971bfd5b74e2fefa233f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

