### PR TITLE
Rename Steno to StenoAI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="website/public/dragonfly-logo-512.png" alt="Steno Logo" width="120" height="120">
 
-  # Steno
+  # StenoAI
 
   *Your private stenographer*
 </div>
@@ -16,7 +16,7 @@
   <a href="#sponsors"><img src="https://img.shields.io/badge/Sponsors-%E2%9D%A4-EA4AAA?style=for-the-badge" alt="Sponsors"></a>
 </p>
 
-<p align="center">Steno is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, summarize, and query your meetings using local AI models. Perfect for government, defence and C-suite professionals with confidential data needs.</p>
+<p align="center">StenoAI is the privacy-first AI notepad for all your confidential conversations. No cloud, no usage limits and your private data never leaves your premises. Record, summarize, and query your meetings using local AI models. Perfect for government, defence and C-suite professionals with confidential data needs.</p>
 
 <p align="center"><sub>Trusted by teams at <b>AWS</b>, <b>Deliveroo</b>, <b>Tesco</b>, <b>Hashicorp</b>, <b>Rutgers</b> & <b>European Union</b>.</sub></p>
 


### PR DESCRIPTION
Updated the product name from 'Steno' to 'StenoAI' in the README.

## Description

Brief description of what this PR does and why it's needed.

## Type of Change

- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Tested locally with `npm start`
- [ ] Verified CLI functionality works
- [ ] Tested on macOS
- [ ] No breaking changes to existing functionality

## Additional Notes

Any additional context about this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the product from Steno to StenoAI in the README so documentation matches the current product name.

<sup>Written for commit 8cf05c259dfc2b0130c897ca7b5059b049401655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

