### PR TITLE
refactor: refine built-in meeting report prompts

### DIFF
--- a/e2e/specs/templates-crud.t2.spec.ts
+++ b/e2e/specs/templates-crud.t2.spec.ts
@@ -73,3 +73,31 @@ test('templates: locked Standard rejects an edit', async ({ launchApp }) => {
   expect(res.success).toBe(false);
   expect((res.error ?? '').toLowerCase()).toContain('locked');
 });
+
+for (const id of ['product-demo', 'sales-call', 'one-on-one', 'standup']) {
+  test(`templates: ${id} keeps user edits until explicitly reset`, async ({ launchApp, userDataDir }) => {
+    const { page } = await launchApp();
+    const original = await page.evaluate(async (id) => {
+      const api = (window as unknown as StenoWindow).stenoai.templates;
+      const listed = await api.list();
+      return listed.templates.find(t => t.id === id) as Tmpl & { prompt: string; language: string };
+    }, id);
+    expect(original.prompt.length).toBeGreaterThan(0);
+    const saved = await page.evaluate(async ({ id, name }) =>
+      (window as unknown as StenoWindow).stenoai.templates.save({
+        id, name, prompt: 'My explicit custom instructions.', language: 'de',
+      }), { id, name: original.name });
+    expect(saved.success).toBe(true);
+    expect((readUserConfig(userDataDir).template_overrides as Record<string, { prompt: string }>)[id].prompt)
+      .toBe('My explicit custom instructions.');
+    const edited = await page.evaluate(async (id) =>
+      ((await (window as unknown as StenoWindow).stenoai.templates.list()).templates
+        .find(t => t.id === id) as Tmpl & { prompt: string }).prompt, id);
+    expect(edited).toBe('My explicit custom instructions.');
+    await page.evaluate(id => (window as unknown as StenoWindow).stenoai.templates.reset(id), id);
+    const restored = await page.evaluate(async (id) =>
+      (await (window as unknown as StenoWindow).stenoai.templates.list()).templates.find(t => t.id === id), id);
+    expect(restored).toMatchObject({ prompt: original.prompt, language: original.language, locked: false });
+    expect(readUserConfig(userDataDir).template_overrides).not.toHaveProperty(id);
+  });
+}

--- a/src/templates.py
+++ b/src/templates.py
@@ -47,14 +47,17 @@ BUILTIN_TEMPLATES = {
         "name": "Product Demo",
         "icon": "presentation",
         "prompt": (
-            "Summarise this call for someone evaluating a product or service "
-            "being demonstrated to them. Cover: what was demoed and the "
-            "problem it's meant to solve; key features or capabilities shown; "
-            "pricing or commercial terms if mentioned; how well it fits the "
-            "stated needs; concerns or open questions raised; and next steps. "
-            "Structure the report with a short markdown heading per area, and "
-            "omit any area that wasn't discussed. Write in the language of the "
-            "meeting."
+            "Write a concise product-demo report in the same language as the speakers, "
+            "including the headings. Use each section once, with brief bullets: Stated "
+            "needs and buyer assessment; Capabilities and limitations; Commercial "
+            "terms; Open questions and next steps. Omit sections not discussed. For "
+            "each capability, state whether it was demonstrated, only promised, or "
+            "explicitly unavailable. Include stated needs and participants' own "
+            "assessment of fit; do not assess fit yourself. Preserve unsupported "
+            "requirements, conditions on pricing, and unresolved questions. Label "
+            "follow-up requests as requests until someone explicitly accepts them. "
+            "Never turn a proposed date into a deadline. Include action owners and "
+            "dates only when stated. Avoid repetition and bilingual headings."
         ),
         "language": "auto",
         "format": "markdown",
@@ -64,13 +67,17 @@ BUILTIN_TEMPLATES = {
         "name": "Sales Call",
         "icon": "handshake",
         "prompt": (
-            "Summarise this call for the person running the sales "
-            "conversation. Cover: the prospect's stated needs, pain points, "
-            "and priorities; objections or concerns raised; budget, timeline, "
-            "or decision-process details mentioned; competitors or "
-            "alternatives referenced; and agreed next steps. Structure the "
-            "report with a short markdown heading per area, and omit any area "
-            "that wasn't discussed. Write in the language of the meeting."
+            "Write a concise sales-call report in the same language as the speakers, "
+            "including the headings. Use each section once, with brief bullets: Needs "
+            "and constraints; Budget and decision process; Alternatives; Next steps. "
+            "Omit sections not discussed. Record stated buying interest and any "
+            "explicit lack of purchase commitment. Keep buyer statements separate from "
+            "seller proposals. Preserve objections, conditions, and uncertainty. "
+            "Interest is not a purchase commitment; an estimated budget is not "
+            "approved; a proposed date is not agreed. Do not infer buying authority or "
+            "deal probability. Separate unaccepted requests from agreed actions. "
+            "Include action owners and dates only when explicitly stated. State each "
+            "fact once and avoid bilingual headings."
         ),
         "language": "auto",
         "format": "markdown",
@@ -80,12 +87,16 @@ BUILTIN_TEMPLATES = {
         "name": "1:1",
         "icon": "user-check",
         "prompt": (
-            "Summarise this 1:1 conversation. Cover: topics discussed and any "
-            "updates shared, feedback given in either direction, concerns or "
-            "blockers raised, decisions made, and follow-up actions with who "
-            "owns them. Structure the report with a short markdown heading per "
-            "area, and omit any area that wasn't discussed. Write in the "
-            "language of the meeting."
+            "Write a concise 1:1 report in the same language as the speakers, including "
+            "the headings. Use each section once, with brief bullets: Updates; Feedback "
+            "and concerns; Decisions and next steps. Omit sections not discussed. "
+            "Record each person's position when they disagree, with the speaker's name "
+            "when clear. Keep both positions without judging who is right. Distinguish "
+            "suggestions and requests from agreed decisions and actions. Keep "
+            "unresolved requests explicit. Do not infer motives, feelings, or "
+            "performance ratings. Include action owners and deadlines only when "
+            "explicitly stated, preserving tentative dates and dependencies. State each "
+            "point once and avoid bilingual headings."
         ),
         "language": "auto",
         "format": "markdown",
@@ -95,11 +106,16 @@ BUILTIN_TEMPLATES = {
         "name": "Standup",
         "icon": "list-checks",
         "prompt": (
-            "Summarise this standup/status meeting concisely. For each "
-            "update, capture what was done, what's planned next, and any "
-            "blockers raised. List updates as brief bullet points, grouped by "
-            "person or topic. Keep it brief - this is a quick status sync, "
-            "not a detailed report. Write in the language of the meeting."
+            "Write concise standup notes in the language of the speakers. Use one short "
+            "bullet list per identified person, and a separate topic list for "
+            "unattributed work. Each bullet should preserve the actual status: "
+            "completed, still in progress, tentative, blocked, or resolved. Keep the "
+            "specific work item attached to its status and any dependency; for example, "
+            "a plan to test an export is not a plan to test a completed login fix. "
+            "Capture explicit requests for help and accepted actions with stated owners "
+            "and times. Leave unassigned work unassigned. Include only information "
+            "discussed. Avoid empty status categories, repeated updates, and a separate "
+            "summary."
         ),
         "language": "auto",
         "format": "markdown",

--- a/tests/fixtures/template-quality.json
+++ b/tests/fixtures/template-quality.json
@@ -1,0 +1,90 @@
+[
+  {
+    "template": "product-demo",
+    "language": "en",
+    "transcript": "Maya (buyer): We need SSO and offline access. Leo (vendor): Here is the CSV export working in the demo. SSO is planned for December, not available today. Offline access is not supported. Maya: Then we cannot yet confirm it fits. Leo: List price is 20 euros per seat; a discount needs approval. Maya: Could you send security details next week? Leo: I need to check who can do that; no date agreed.",
+    "expectations": [
+      "CSV export demonstrated; SSO is a future plan",
+      "Offline unsupported and fit unconfirmed",
+      "20 euros is list price; discount not approved",
+      "Security follow-up requested but no accepted owner/deadline"
+    ]
+  },
+  {
+    "template": "product-demo",
+    "language": "de",
+    "transcript": "Mara (Kundin): Wir benötigen SSO und Offline-Zugriff. Leon (Anbieter): Hier sehen Sie den CSV-Export in der Demo. SSO ist für Dezember geplant, heute aber nicht verfügbar. Offline-Zugriff wird nicht unterstützt. Mara: Dann ist die Eignung noch offen. Leon: Der Listenpreis ist 20 Euro je Nutzer, Rabatt muss genehmigt werden. Mara: Könnten Sie nächste Woche Sicherheitsunterlagen schicken? Leon: Ich muss erst klären, wer das übernehmen kann. Einen Termin haben wir nicht vereinbart.",
+    "expectations": [
+      "CSV gezeigt; SSO nur geplant",
+      "Offline nicht unterstützt; Eignung offen",
+      "Listenpreis20Euro; Rabatt ungeklärt",
+      "Unterlagen nur angefragt, kein vereinbarter Verantwortlicher/Termin"
+    ]
+  },
+  {
+    "template": "sales-call",
+    "language": "en",
+    "transcript": "Ava (prospect): The manual export is our main problem. We are interested, but this is not a purchase commitment. I estimate a budget of 8000 euros; finance has not approved it. Ben (seller): Could we sign on Friday? Ava: No, legal must review first. I am not the final decision maker. We also use Atlas. Ben: I will email the security questionnaire tomorrow. Ava: Thanks, agreed. We have not agreed a signing date.",
+    "expectations": [
+      "Interest is not commitment",
+      "8000 estimated, not approved",
+      "Legal dependency, no signing deadline or inferred authority",
+      "Seller commits questionnaire tomorrow; competitor Atlas mentioned"
+    ]
+  },
+  {
+    "template": "sales-call",
+    "language": "de",
+    "transcript": "Eva (Interessentin): Unser Hauptproblem ist der manuelle Export. Wir sind interessiert, sagen aber keinen Kauf zu. Ich schätze das Budget auf 8000 Euro, die Finanzabteilung hat es nicht genehmigt. Tom (Vertrieb): Können wir Freitag unterschreiben? Eva: Nein, zuerst muss die Rechtsabteilung prüfen. Ich entscheide nicht abschließend. Wir nutzen auch Atlas. Tom: Ich schicke morgen den Sicherheitsfragebogen. Eva: Danke, einverstanden. Einen Termin für die Unterschrift haben wir nicht vereinbart.",
+    "expectations": [
+      "Interesse keine Kaufzusage",
+      "8000Euro geschätzt und nicht genehmigt",
+      "Rechtsprüfung offen; Freitag nicht vereinbart",
+      "Tom schickt morgen Fragebogen; Atlas erwähnt"
+    ]
+  },
+  {
+    "template": "one-on-one",
+    "language": "en",
+    "transcript": "Nora: The handover documentation is finished. I feel overloaded this week. Kai: I think priorities were clear. Nora: I disagree. Kai: Maybe we could reduce meetings next month. Nora: Let's discuss that later; no decision today. Kai: I will review the workload with you on Tuesday. Nora: Agreed. I would like mentoring, but we have not assigned a mentor or date.",
+    "expectations": [
+      "Documentation finished; overload attributed to Nora",
+      "Priority disagreement preserved, no performance judgment",
+      "Fewer meetings suggestion not decision",
+      "Kai workload review Tuesday agreed; mentoring request unassigned"
+    ]
+  },
+  {
+    "template": "one-on-one",
+    "language": "de",
+    "transcript": "Nora: Die Übergabedokumentation ist fertig. Ich fühle mich diese Woche überlastet. Kai: Ich finde, die Prioritäten waren klar. Nora: Da widerspreche ich. Kai: Vielleicht könnten wir nächsten Monat weniger Meetings machen. Nora: Das besprechen wir später, heute entscheiden wir das nicht. Kai: Ich schaue mir mit dir am Dienstag die Arbeitslast an. Nora: Einverstanden. Ich wünsche mir Mentoring, aber wir haben weder eine Person noch einen Termin festgelegt.",
+    "expectations": [
+      "Dokumentation fertig; Überlastung als Noras Aussage",
+      "Uneinigkeit erhalten, kein Leistungsurteil",
+      "Weniger Meetings nur Vorschlag",
+      "Kai Dienstag Arbeitslast vereinbart; Mentoring ohne Zuordnung"
+    ]
+  },
+  {
+    "template": "standup",
+    "language": "en",
+    "transcript": "Lee: The login fix is finished. The export is still in progress. I might test it tomorrow if the test server is ready. Sam: I was blocked by access yesterday, but that is resolved now. Today I plan to review the tests. Unidentified speaker: The migration still needs an owner. Lee: Can someone help with the export? Sam: I will pair with Lee after lunch.",
+    "expectations": [
+      "Login done, export ongoing",
+      "Testing tomorrow conditional",
+      "Sam access blocker resolved",
+      "Migration unassigned; Sam pairing after lunch agreed"
+    ]
+  },
+  {
+    "template": "standup",
+    "language": "de",
+    "transcript": "Lea: Der Login-Fix ist fertig. Am Export arbeite ich noch. Vielleicht teste ich ihn morgen, falls der Testserver bereit ist. Sam: Gestern fehlte mir der Zugriff, das ist inzwischen gelöst. Heute plane ich, die Tests zu prüfen. Unbekannte Person: Für die Migration fehlt noch ein Verantwortlicher. Lea: Kann mir jemand beim Export helfen? Sam: Ich unterstütze Lea nach dem Mittagessen.",
+    "expectations": [
+      "Login fertig, Export laufend",
+      "Test morgen bedingt",
+      "Sams Zugriffsproblem gelöst",
+      "Migration ohne Verantwortlichen; Sam hilft nach Mittag"
+    ]
+  }
+]

--- a/tests/fixtures/template-quality.md
+++ b/tests/fixtures/template-quality.md
@@ -1,0 +1,37 @@
+# Built-in template quality cases
+
+`template-quality.json` contains eight synthetic conversations: one English and
+one German case for each editable built-in. No recordings or personal meeting
+content are used. `expectations` are a human review rubric, not substring tests.
+
+Compare current and proposed prompts using the production
+`OllamaSummarizer._create_template_report_prompt` helper with each case's resolved
+`language`, then the same local model and decoding options for both versions.
+Use the chat API with one user message and `think=false`, matching template
+reports. Keep the model, options and before/after outputs with the evaluation.
+A mocked completion or a matching heading is not a quality assertion.
+
+Review factual support, retained qualifications and disagreements, correct
+speakers and action owners, requested versus accepted actions, output language,
+and repetition. Read the transcript as well as the listed expectations. A shorter
+report alone is not a pass. An omitted material disagreement, invented commitment,
+or reassigned action should block release of the prompt change.
+
+## Initial local comparison, 2026-09-05
+
+Gemma `gemma4:e2b-it-qat`, temperature 0, seed 42, context 8192, output limit 1100.
+All 16 before/after calls completed without truncation. Reports are generally
+more compact, and the final demo cases distinguish demonstrated CSV export from
+promised SSO and unavailable offline access. The comparison does not establish
+release quality:
+
+- Both demo outputs assign the security-document request to the vendor despite
+  the transcript leaving its owner unconfirmed.
+- The German 1:1 omits Nora's disagreement, which the baseline retained.
+- The English standup omits Sam's accepted pairing action, which the baseline
+  retained; the German standup repeats the unassigned migration topic.
+- The English sales report omits the explicit absence of a purchase commitment.
+
+These are open quality cases, not passing model assertions. The prompt changes
+remain a draft and should not be included in a release solely on green unit or
+CRUD tests. Existing user overrides and the locked Standard template are unchanged.


### PR DESCRIPTION
Product Demo reports can currently blur what was shown with what is only planned. Sales Call reports can lose purchase conditions, while 1:1 and Standup reports can drop disagreements or treat requests as accepted work. This change makes those boundaries explicit. Template IDs, the locked Standard template and existing user overrides stay unchanged.

The PR adds T2 cases that check upgrade preservation, edit persistence, per-template reset and the exact shipped, edited and reset prompt sent during report generation. The quality fixtures now contain 16 synthetic English and German conversations split into development and held-out cases. “Acme” is a fictional placeholder.

This remains a draft until the current prompts pass the repeated production-equivalent evaluation documented in `tests/fixtures/template-quality.md`.

Validation: repository privacy guard, 41 focused Python tests, Ruff, JSON validation, Prettier, git diff check and Playwright test discovery passed locally. CI passed all 16 checks, including the macOS, Windows and Linux backend builds plus T1, model-free T2 and pipeline runs on all three platforms.
