### PR TITLE
chore(release): prepare 0.7.1 with Linux alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,10 @@
 If you're looking for a hosted desktop recording API, consider checking out [Recall.ai](https://www.recall.ai/product/desktop-recording-sdk?utm_source=github&utm_medium=sponsorship&utm_campaign=ruzin-stenoai), an API that records Zoom, Google Meet, Microsoft Teams, in-person meetings, and more.
 
 ## 📢 What's New
-- **2026-08-31** 🗣️ Individual speaker labels — Steno now tells apart the voices sharing one side of a call, so a three-person meeting reads as `Speaker 2` / `Speaker 3` instead of one merged `[Others]`. macOS only.
-- **2026-08-31** 👤 Name a speaker once — confirm who someone is and Steno suggests them in later meetings. Off by default: turn on Speaker identification in Settings → AI, and manage or delete profiles in Settings → People.
-- **2026-08-31** 📄 Readable transcript export — exported transcripts open with a clean conversation view, with the original timestamped transcript kept below it.
-- **2026-08-31** 🇷🇺 Russian — pick Russian in Settings → Transcribe and summaries, titles and chat come back in Russian instead of English.
-
+- **2026-09-05** 🐧 Linux alpha: Debian/Ubuntu packages and an AppImage support microphone and PipeWire system-audio recording, with CPU-only bundled summaries.
+- **2026-09-05** 📁 Reliable recording and folders: failed recording starts no longer leave a stuck entry, and repeated clicks no longer create duplicate folders.
+- **2026-09-05** 📥 Clear download progress: Parakeet shows actual download progress and a separate model-preparation stage.
+- **2026-09-05** 📝 Transcript recovery: on Windows and Linux, the available live transcript replaces an ONNX batch transcript that read less than half the recording.
 
 ## Features
 
@@ -54,7 +53,7 @@ If you're looking for a hosted desktop recording API, consider checking out [Rec
 - **Live speaker labels** — Real-time on-screen text as you speak via Parakeet TDT v3 on Apple Silicon (MLX). Granola-style chat-bubble view with `[You]` vs `[Others]` attribution live during the recording.
 - **Individual speakers (macOS)** — Once the recording stops, Steno separates the voices sharing each channel, so the saved transcript reads `Speaker 2` / `Speaker 3` rather than one merged `[Others]`. Name a speaker once and Steno can suggest them in later meetings — that part is off by default, and the voice profiles never leave your Mac.
 - **Auto start/stop meetings** — Steno notices when a meeting starts and offers to take notes, then offers to summarise when it ends. Granola-style frictionless capture.
-- **System audio capture** — Record both sides of virtual meetings, headphones on, no extra setup or virtual cable. Native Core Audio Tap on macOS 14.4+, with selectable microphone input.
+- **System audio capture** — Record both sides of virtual meetings. Native Core Audio Tap on macOS 14.4+, Windows loopback capture, and PipeWire capture on Linux, with selectable microphone input.
 - **Recording that coexists** — A compact transcription pill docks beside the app instead of taking over; Stop lands you on the note instantly and you can resume recording into an existing note (it appends and re-generates on demand).
 - **Global record shortcut** — Start or stop recording from anywhere with `⌘⇧R` (`Ctrl+Shift+R` on Windows). Toggle it off in Settings if it clashes with another app. On macOS, power users can additionally bind any key of their own via the `stenoai://record/start` / `record/stop` deep links (Shortcuts app).
 - **In-app note-taking** — Jot notes while you record, or keep a dedicated **My notes** tab that stays editable alongside the AI summary; your notes are folded straight into the summary.
@@ -233,15 +232,10 @@ Verified on Ubuntu 26.04 LTS (GNOME/Wayland, PipeWire), including system-audio l
 sudo apt install libportaudio2
 ```
 
-> Before the first tagged Linux release lands, grab the packages from the
-> [Linux build workflow](https://github.com/stenolabs/stenoai/actions/workflows/build-linux.yml):
-> sign in to GitHub, open the latest green run, and download the
-> `stenoai-linux-<version>` artifact.
-
 Known alpha limitations:
 
 - **Unsigned**, same as the Windows alpha.
-- **CPU-only summarisation** and `onnx-asr` transcription, same as Windows.
+- **CPU-only bundled summarisation** and `onnx-asr` transcription, same as Windows. To use GPU-accelerated summaries, run a separately installed Ollama with a supported GPU and driver, select **Settings → AI → Private Server**, enter `http://127.0.0.1:11434`, and choose a model installed on that server.
 - **System audio requires PipeWire** (Ubuntu's default since 22.10). The toggle reports unsupported on a PulseAudio-only or headless install, and recording falls back to mic-only.
 - **No speaker diarization sidecar** — per-channel `[You]`/`[Others]` labelling works, but the acoustic multi-speaker split is macOS-only.
 - **No auto-update.** `.deb` installs update by downloading a new package; AppImage self-update is a follow-up.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you're looking for a hosted desktop recording API, consider checking out [Rec
 
 ## Features
 
-- **Privacy-first** — 100% on-device; your recordings, transcripts, and summaries never leave your Mac.
+- **Privacy-first**: local AI processes your recordings, transcripts, and summaries on your device. External AI providers are optional.
 - **Live speaker labels** — Real-time on-screen text as you speak via Parakeet TDT v3 on Apple Silicon (MLX). Granola-style chat-bubble view with `[You]` vs `[Others]` attribution live during the recording.
 - **Individual speakers (macOS)** — Once the recording stops, Steno separates the voices sharing each channel, so the saved transcript reads `Speaker 2` / `Speaker 3` rather than one merged `[Others]`. Name a speaker once and Steno can suggest them in later meetings — that part is off by default, and the voice profiles never leave your Mac.
 - **Auto start/stop meetings** — Steno notices when a meeting starts and offers to take notes, then offers to summarise when it ends. Granola-style frictionless capture.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stenoai",
-  "version": "0.6.7",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stenoai",
-      "version": "0.6.7",
+      "version": "0.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stenoai",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AI powered intelligence layer for confidential workflows",
   "main": "main.js",
   "homepage": "https://github.com/stenolabs/stenoai",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,26 @@ title: "Changelog"
 description: "What's new in Steno -- recent releases and notable changes."
 ---
 
+<Update label="v0.7.1" description="September 5, 2026">
+**New**
+- **Linux alpha**: Debian/Ubuntu packages and an AppImage support microphone and PipeWire system-audio recording. Without PipeWire, recording uses the microphone only.
+
+**Improved**
+- Parakeet model downloads show actual progress and distinguish downloading from model preparation.
+- Weekday and month names match the English interface. Times keep the system's 12/24-hour clock preference.
+- The website and README use the StenoAI name, and the Government & Defence pages have been expanded.
+
+**Fixed**
+- Repeated folder-creation clicks no longer create duplicate sidebar folders, and failures are shown when a folder cannot be created.
+- A recording that fails to start no longer leaves a stuck "Recording" entry in the meetings list.
+- On Windows and Linux, the available live transcript replaces an ONNX batch transcript that successfully read less than half the recording.
+
+**Known Issues**
+- Linux packages are unsigned and require manual updates. AppImage users must install `libportaudio2` separately.
+- Bundled summaries are CPU-only on Linux, as in the Windows alpha. For GPU-accelerated summaries, run a separately installed Ollama with a supported GPU and driver, select **Settings → AI → Private Server**, enter `http://127.0.0.1:11434`, and choose a model installed on that server.
+- Acoustic multi-speaker identification remains macOS-only. Linux uses the existing `[You]` / `[Others]` channel labels.
+</Update>
+
 <Update label="v0.7.0" description="August 31, 2026">
 **New**
 - **Individual speaker labels (macOS)** — Steno now separates the voices that share one side of a call. A meeting with several remote participants reads as `Speaker 2`, `Speaker 3`, and so on, instead of collapsing everyone into a single `[Others]`. This runs on-device after the recording stops, and works whether the people are around one microphone or joining remotely.


### PR DESCRIPTION
Prepares StenoAI 0.7.1 with Linux alpha packages and the merged recording, folder, download-progress and transcript-recovery fixes.

Updates the app and lockfile versions, the README and the public changelog. Linux limitations and the separately installed Ollama option are documented. The template changes in #538 and bundled Linux GPU libraries in #533 are excluded.

Version metadata, the four-entry README section and diff whitespace checks pass. The code base at 50434235 passed main CI; this PR changes release metadata and documentation only. The release tag remains gated on the full pre-tag workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares StenoAI 0.7.1 with Linux alpha packages and the merged recording, folder, download-progress, and transcript-recovery fixes.

- Bumps `app` and lockfile versions to 0.7.1.
- Updates README and changelog with new features, fixes, and Linux alpha limitations.
- Documents the separately installed Ollama option for GPU-accelerated summaries.
- Clarifies privacy is device-local, with external AI providers optional.
- Excludes the template changes from #538 and bundled Linux GPU libraries from #533.
- The release tag remains gated on the full pre-tag workflow.

<sup>Written for commit 7e06db4ce34f35fbc6862beabd8f0fa55ad28a66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/stenolabs/stenoai/pull/539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

