### PR TITLE
fix(release): stabilize privacy test and Linux ffmpeg download

### DIFF
--- a/e2e/specs/auto-summarize.t2.spec.ts
+++ b/e2e/specs/auto-summarize.t2.spec.ts
@@ -79,7 +79,11 @@ test('auto-summarize off writes a transcript-only note with no LLM call; the Gen
   const realDirBefore = fileSig(realUserDataDir());
 
   // Local provider (summariser talks to mock Ollama on 11434) + toggle OFF.
-  writeUserConfig(userDataDir, { ai_provider: 'local', auto_summarize_enabled: false });
+  // This test starts after onboarding. A partial existing config without this
+  // marker triggers the upgrade privacy notice and blocks the Generate button.
+  writeUserConfig(userDataDir, {
+    ai_provider: 'local', auto_summarize_enabled: false, privacy_notice_seen: true,
+  });
 
   // Silent STEREO wav -> both channels skip the RMS gate -> batch transcription
   // returns the silence sentinel with no model loaded; --live-transcript rescues
@@ -117,6 +121,7 @@ test('auto-summarize off writes a transcript-only note with no LLM call; the Gen
 
     // Phase 2 — real app: open the note, click "Generate notes", reprocess it.
     const { page } = await launchApp();
+    await expect(page.locator('html')).toHaveAttribute('data-privacy-gate', 'true');
     const meetingHash = `/meetings/${encodeURIComponent(summaryPath)}`;
 
     // Navigate straight to the note detail. Re-set the hash each poll so a

--- a/scripts/download-ollama.sh
+++ b/scripts/download-ollama.sh
@@ -83,9 +83,26 @@ case "$(uname -s)" in
         # Use static build for Linux
         FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
         mkdir -p "$BIN_DIR"
-        curl --fail --retry 3 --retry-delay 2 --retry-all-errors -L "$FFMPEG_URL" -o "$BIN_DIR/ffmpeg.tar.xz"
+        # Some upstream/proxy failures return HTTP 200 with an error page,
+        # which curl's HTTP retries cannot detect. Retry invalid archives too.
+        archive_ready=false
+        for attempt in 1 2 3; do
+            if curl --fail --retry 3 --retry-delay 2 --retry-all-errors -L "$FFMPEG_URL" -o "$BIN_DIR/ffmpeg.tar.xz" \
+                && tar -tJf "$BIN_DIR/ffmpeg.tar.xz" > "$BIN_DIR/ffmpeg-archive-contents.txt" 2>/dev/null \
+                && archive_member=$(grep -m 1 -E '^[^/]+/ffmpeg$' "$BIN_DIR/ffmpeg-archive-contents.txt"); then
+                archive_ready=true
+                break
+            fi
+            echo "Linux ffmpeg download attempt $attempt/3 failed or returned an invalid archive" >&2
+            if [ "$attempt" -lt 3 ]; then sleep 2; fi
+        done
+        rm -f "$BIN_DIR/ffmpeg-archive-contents.txt"
+        if [ "$archive_ready" != true ]; then
+            echo "Could not download a valid Linux ffmpeg archive after 3 attempts" >&2
+            exit 1
+        fi
         cd "$BIN_DIR"
-        tar -xf ffmpeg.tar.xz --strip-components=1 --wildcards '*/ffmpeg'
+        tar -xf ffmpeg.tar.xz --strip-components=1 "$archive_member"
         rm ffmpeg.tar.xz
         chmod +x ffmpeg
         assert_binary ffmpeg "$MIN_FFMPEG_BYTES"

--- a/tests/test_download_ffmpeg.py
+++ b/tests/test_download_ffmpeg.py
@@ -10,8 +10,8 @@ import unittest
 
 
 @unittest.skipUnless(
-    os.name == 'posix' and shutil.which('bash') and shutil.which('tar'),
-    'Linux download stage requires a POSIX shell and tar',
+    os.name == 'posix' and all(shutil.which(tool) for tool in ('bash', 'tar', 'xz')),
+    'Linux download stage requires a POSIX shell, tar and xz',
 )
 class LinuxFfmpegDownloadTests(unittest.TestCase):
     def run_download(self, mode):

--- a/tests/test_download_ffmpeg.py
+++ b/tests/test_download_ffmpeg.py
@@ -1,0 +1,90 @@
+"""Exercise the Linux ffmpeg download stage with deterministic HTTP payloads."""
+import io
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import unittest
+
+
+@unittest.skipUnless(
+    os.name == 'posix' and shutil.which('bash') and shutil.which('tar'),
+    'Linux download stage requires a POSIX shell and tar',
+)
+class LinuxFfmpegDownloadTests(unittest.TestCase):
+    def run_download(self, mode):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / 'scripts'
+            scripts.mkdir()
+            stubs = root / 'stubs'
+            stubs.mkdir()
+            # Execute the actual ffmpeg stage without downloading unrelated Ollama.
+            source = (Path(__file__).resolve().parents[1] / 'scripts/download-ollama.sh').read_text()
+            script = scripts / 'download.sh'
+            script.write_text(source.split('# --- Download Ollama ---')[0])
+            payload = b'fake ffmpeg\n' + b'\0' * 5_000_000
+            with tarfile.open(root / 'valid.tar.xz', 'w:xz') as archive:
+                entry = tarfile.TarInfo('ffmpeg-static/ffmpeg')
+                entry.size = len(payload)
+                archive.addfile(entry, io.BytesIO(payload))
+            with tarfile.open(root / 'missing.tar.xz', 'w:xz') as archive:
+                entry = tarfile.TarInfo('ffmpeg-static/README')
+                archive.addfile(entry, io.BytesIO(b''))
+            for name, body in {
+                'uname': 'echo Linux\n',
+                'sleep': 'exit 0\n',
+                'curl': '''count=0
+[ ! -f "$FIXTURE_ROOT/count" ] || count=$(cat "$FIXTURE_ROOT/count")
+count=$((count + 1))
+echo "$count" > "$FIXTURE_ROOT/count"
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = -o ]; then shift; output=$1; fi
+    shift
+done
+case "$FIXTURE_MODE" in
+    invalid) printf '<html>upstream unavailable</html>' > "$output" ;;
+    missing) cp "$FIXTURE_ROOT/missing.tar.xz" "$output" ;;
+    retry)
+        if [ "$count" -eq 1 ]; then
+            printf '<html>upstream unavailable</html>' > "$output"
+        else
+            cp "$FIXTURE_ROOT/valid.tar.xz" "$output"
+        fi ;;
+    valid) cp "$FIXTURE_ROOT/valid.tar.xz" "$output" ;;
+esac
+''',
+            }.items():
+                stub = stubs / name
+                stub.write_text('#!/bin/sh\n' + body)
+                stub.chmod(0o755)
+            result = subprocess.run(
+                ['bash', str(script)], capture_output=True, text=True,
+                env={**os.environ, 'PATH': str(stubs) + os.pathsep + os.environ['PATH'],
+                     'FIXTURE_ROOT': str(root), 'FIXTURE_MODE': mode},
+                timeout=30,
+            )
+            return result, int((root / 'count').read_text()), (root / 'bin/ffmpeg').exists()
+
+    def test_valid_archive_succeeds_without_retry(self):
+        result, calls, extracted = self.run_download('valid')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(calls, 1)
+        self.assertTrue(extracted)
+
+    def test_http_200_error_page_is_retried(self):
+        result, calls, extracted = self.run_download('retry')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(calls, 2)
+        self.assertTrue(extracted)
+
+    def test_invalid_payloads_fail_after_bounded_retries(self):
+        for mode in ('invalid', 'missing'):
+            with self.subTest(mode=mode):
+                result, calls, extracted = self.run_download(mode)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(calls, 3)
+                self.assertFalse(extracted)
+                self.assertIn('after 3 attempts', result.stderr)


### PR DESCRIPTION
Fixes two failures encountered while preparing the 0.7.1 release gate.

The Windows auto-summary test created an existing config without a privacy marker. The upgrade notice correctly appeared and blocked Generate notes. The test now seeds an acknowledged user and waits for the privacy query to resolve. Production dialog behavior is unchanged.

The Linux build received a 7 KB non-archive response from the ffmpeg download endpoint. HTTP retries do not catch a successful HTTP response with an invalid body. The download stage now validates the XZ archive and expected ffmpeg member, retries invalid responses up to three times, and fails clearly if none is valid. The source and macOS/Windows download paths are unchanged.

Validation: both auto-summary and all three privacy-consent T2 tests passed locally, with an isolated mock Ollama port. Windows CI subsequently passed the original failing T2 job. Three new download tests cover a valid archive, a transient HTTP-200 error page, persistent invalid responses and missing archive members. Bash syntax, diff whitespace and Ruff ratchet checks pass. A fresh real download from the existing source returned a valid 40 MB archive. The additional Linux-PC check could not run because SSH timed out; Linux CI must verify the new head.
